### PR TITLE
enable google tags; put ID in Renviron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,12 @@ Thumbs.db
 
 data/*.pgx
 data/*.csv
+logs/*.rds
 
+# Sensitive files #
+####################
 firebase.rds
 test-firestore.R
 .httr-oauth
 bigomics-extra.js
-google-analytics.html
+Renviron.site

--- a/shiny/app.R
+++ b/shiny/app.R
@@ -31,6 +31,11 @@ message("***********************************************")
 message("***** RUNTIME ENVIRONMENT VARIABLES ***********")
 message("***********************************************")
 
+if(file.exists("Renviron.site")) {
+    message("Loading local Renviron.site")    
+    readRenviron("Renviron.site")
+}
+
 envcat <- function(var) message(var," = ",Sys.getenv(var))
 envcat("SHINYPROXY_USERNAME")
 envcat("SHINYPROXY_USERGROUPS")
@@ -40,6 +45,7 @@ envcat("PLAYGROUND_EXPIRY")
 envcat("PLAYGROUND_QUOTA")
 envcat("PLAYGROUND_LEVEL")
 envcat("PLAYGROUND_HELLO")
+envcat("OMICS_GOOGLE_TAG")
 
 ## --------------------------------------------------------------------
 ## -------------------------- INIT ------------------------------------
@@ -887,9 +893,13 @@ createUI <- function(tabs)
     windowTitle = TITLE
     theme = shinythemes::shinytheme("cerulean")
     id = "maintabs"
+
+    ## Add Google Tag manager header code    
     gtag <- NULL
-    if(0 && file.exists("www/google-tags.html")) {
-        gtag <- shiny::tags$head(includeHTML("www/google-tags.html"))
+    if(Sys.getenv("OMICS_GOOGLE_TAG")!="") {
+        gtag.html <- htmltools::includeHTML("www/google-tags.html")
+        gtag.html <- sub("GTM-0000000",Sys.getenv("OMICS_GOOGLE_TAG"),gtag.html)
+        gtag <- shiny::tags$head(gtag.html)
     }
         
     header = shiny::tagList(
@@ -976,8 +986,19 @@ tabs = list(
     "DEV" = c("corsa","system","multi")
 )
 
-ui = createUI(tabs)
-##ui = navbarPage("Hello World!")
+
+## Add Google Tag manager body code
+gtag2 <- NULL
+if(Sys.getenv("OMICS_GOOGLE_TAG")!="") {
+    gtag2 <- htmltools::includeHTML("www/google-tags-noscript.html")
+    gtag2 <- sub("GTM-0000000",Sys.getenv("OMICS_GOOGLE_TAG"),gtag2)
+}
+
+ui = tagList(
+    gtag2,
+    createUI(tabs)
+)
+
 
 ## --------------------------------------------------------------------
 ## ------------------------------ RUN ---------------------------------

--- a/shiny/www/google-tags-noscript.html
+++ b/shiny/www/google-tags-noscript.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-0000000"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/shiny/www/google-tags.html
+++ b/shiny/www/google-tags.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-0000000');</script>
+<!-- End Google Tag Manager -->


### PR DESCRIPTION
Enable Google Tag Manager to allow Google Analytics. GTM is bit more general than just enabling GA. So we use this for adding future tags.