### PR TITLE
Pgx as reactiveValue

### DIFF
--- a/components/app/R/OPTIONS
+++ b/components/app/R/OPTIONS
@@ -17,6 +17,5 @@ TIMEOUT         = 0
 HONCHO_URL      = http://localhost:8000
 
 #BOARDS_ENABLED = load,view,clust,expr,enrich,isect,func,word,drug,sig,scell,cor,bio,cmap,tcga
-#BOARDS_DISABLED = view,expr,enrich,isect,func,word,drug,sig,scell,cor,bio,cmap,corsa,multi,system,wgcna,tcga,clust,ftmap,comp
-#BOARDS_DISABLED = expr,enrich,isect,func,word,drug,sig,scell,cor,bio,cmap,corsa,multi,system,wgcna,tcga,clust,ftmap,comp
-#BOARDS_DISABLED = corsa,multi,system,tcga
+#BOARDS_ENABLED = load,view,clust
+#BOARDS_DISABLED = expr,enrich,isect,func,word,drug,sig,scell,cor,bio,cmap,wgcna,tcga,clust,ftmap,comp

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -85,8 +85,8 @@ app_server <- function(input, output, session) {
     pgx <- reactiveValues()
            
     ## Modules needed from the start        
-    env[["load"]] <- shiny::callModule(
-        LoadingBoard, "load",
+    env$load <- LoadingBoard(
+        id = "load",
         pgx_dir = pgx_dir,
         limits = limits,
         enable_userdir = opt$ENABLE_USERDIR,                                
@@ -108,8 +108,7 @@ app_server <- function(input, output, session) {
         }
     })
     
-    env[["user"]] <- shiny::callModule(UserBoard, "user", user = env[["load"]][["auth"]])
-    ##shinyjs::runjs("logout()")    
+    env$user <- UserBoard("user", user = env$load$auth)
 
     ## Modules needed after dataset is loaded (deferred)
     modules_loaded <- FALSE

--- a/components/board.dataview/R/dataview_module_geneinfo.R
+++ b/components/board.dataview/R/dataview_module_geneinfo.R
@@ -33,7 +33,7 @@ dataview_module_geneinfo_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_module_geneinfo_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_module_geneinfo_server <- function(id, parent.input, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 

--- a/components/board.dataview/R/dataview_plot_abundance.R
+++ b/components/board.dataview/R/dataview_plot_abundance.R
@@ -27,7 +27,7 @@ dataview_plot_abundance_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_abundance_server <- function(id, pgxdata, parent.input,
+dataview_plot_abundance_server <- function(id, parent.input,
                                            getCountsTable, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {

--- a/components/board.dataview/R/dataview_plot_averagecounts.R
+++ b/components/board.dataview/R/dataview_plot_averagecounts.R
@@ -28,7 +28,7 @@ dataview_plot_averagecounts_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_averagecounts_server <- function(id, pgxdata, parent.input,
+dataview_plot_averagecounts_server <- function(id, parent.input,
                                                  getCountsTable, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {

--- a/components/board.dataview/R/dataview_plot_averagerank.R
+++ b/components/board.dataview/R/dataview_plot_averagerank.R
@@ -25,7 +25,7 @@ dataview_plot_averagerank_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_averagerank_server <- function(id, pgxData, parent.input, watermark=FALSE)
+dataview_plot_averagerank_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
         
@@ -33,7 +33,7 @@ dataview_plot_averagerank_server <- function(id, pgxData, parent.input, watermar
 
             dbg("[dataview_averagerankplot_server:plot_data] reacted! ")
 
-            pgx <- pgxData()
+            ##pgx <- pgxData()
             shiny::req(pgx)
             shiny::req(parent.input)
             shiny::req(parent.input$search_gene)                         

--- a/components/board.dataview/R/dataview_plot_boxplot.R
+++ b/components/board.dataview/R/dataview_plot_boxplot.R
@@ -20,7 +20,7 @@ dataview_plot_boxplot_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_boxplot_server <- function(id, pgxdata, parent.input, getCountsTable, watermark=FALSE)
+dataview_plot_boxplot_server <- function(id, parent.input, getCountsTable, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 

--- a/components/board.dataview/R/dataview_plot_correlation.R
+++ b/components/board.dataview/R/dataview_plot_correlation.R
@@ -25,7 +25,7 @@ dataview_plot_correlation_ui <- function(id, label='', height=c(600,800)) {
   
 }
 
-dataview_plot_correlation_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_plot_correlation_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
   moduleServer( id, function(input, output, session) {
     
@@ -73,7 +73,7 @@ dataview_plot_correlation_server <- function(id, pgxdata, parent.input, watermar
 
     plot_data <- shiny::reactive({
 
-      pgx <- pgxdata()
+      ## pgx <- pgxdata()
       shiny::req(pgx)
       shiny::req(parent.input)             
       if(class(parent.input)[1]=="reactiveExpr") {

--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -31,7 +31,7 @@ dataview_plot_expression_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_expression_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_plot_expression_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 
@@ -39,9 +39,8 @@ dataview_plot_expression_server <- function(id, pgxdata, parent.input, watermark
         
         plot_data <- shiny::reactive({
            
-             dbg("[dataview_expressionplot_server:plot_data] reacted! ")
+            dbg("[dataview_expressionplot_server:plot_data] reacted! ")
 
-            pgx <- pgxdata()
             shiny::req(pgx)
             shiny::req(parent.input$data_groupby,
                        parent.input$search_gene,

--- a/components/board.dataview/R/dataview_plot_histogram.R
+++ b/components/board.dataview/R/dataview_plot_histogram.R
@@ -26,7 +26,7 @@ dataview_plot_histogram_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_histogram_server <- function(id, pgxdata, parent.input,
+dataview_plot_histogram_server <- function(id, parent.input,
                                             getCountsTable, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {

--- a/components/board.dataview/R/dataview_plot_phenoassociation.R
+++ b/components/board.dataview/R/dataview_plot_phenoassociation.R
@@ -30,12 +30,11 @@ dataview_plot_phenoassociation_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_phenoassociation_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_plot_phenoassociation_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 
         plot_data  <- shiny::reactive({
-            pgx = pgxdata()
             shiny::req(pgx)
             annot <- pgx$samples
             samples <- selectSamplesFromSelectedLevels(pgx$Y, parent.input$data_samplefilter)

--- a/components/board.dataview/R/dataview_plot_phenoheatmap.R
+++ b/components/board.dataview/R/dataview_plot_phenoheatmap.R
@@ -29,14 +29,14 @@ dataview_plot_phenoheatmap_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_phenoheatmap_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_plot_phenoheatmap_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 
         ## extract data from pgx object
         plot_data  <- shiny::reactive({
 
-            pgx = pgxdata()
+            ##pgx = pgxdata()
             shiny::req(pgx)
             dbg("[data_phenoHeatmap.RENDER] reacted")
 

--- a/components/board.dataview/R/dataview_plot_tissue.R
+++ b/components/board.dataview/R/dataview_plot_tissue.R
@@ -26,7 +26,7 @@ dataview_plot_tissue_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_tissue_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_plot_tissue_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 
@@ -34,7 +34,6 @@ dataview_plot_tissue_server <- function(id, pgxdata, parent.input, watermark=FAL
 
             dbg("[dataview_tissueplot_server:plot_data] reacted!")
             
-            pgx <- pgxdata()
             shiny::req(pgx)
             if(is.null(parent.input$data_type)) return(NULL)
             

--- a/components/board.dataview/R/dataview_plot_totalcounts.R
+++ b/components/board.dataview/R/dataview_plot_totalcounts.R
@@ -27,7 +27,7 @@ dataview_plot_totalcounts_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_totalcounts_server <- function(id, pgxdata, parent.input, getCountsTable, watermark=FALSE)
+dataview_plot_totalcounts_server <- function(id, parent.input, getCountsTable, watermark=FALSE)
 {
     moduleServer( id, function(input, output, session) {
 

--- a/components/board.dataview/R/dataview_plot_tsneplot.R
+++ b/components/board.dataview/R/dataview_plot_tsneplot.R
@@ -32,19 +32,19 @@ dataview_plot_tsne_ui <- function(id, label='', height=c(600,800)) {
     
 }
 
-dataview_plot_tsne_server <- function(id, pgxdata, parent.input, watermark=FALSE)
+dataview_plot_tsne_server <- function(id, pgx, parent.input, watermark=FALSE)
 {
-    moduleServer( id, function(input, output, session) {
+    moduleServer(id, function(input, output, session) {
         
         plot_dl <- reactiveValues()
         
         plot_data <- shiny::reactive({
             
-            shiny::req(pgxdata)
+            shiny::req(pgx)
             shiny::req(parent.input)
             shiny::req(parent.input$search_gene)
                         
-            pgx <- pgxdata()            
+            ## pgx <- pgxdata()            
             gene <- parent.input$search_gene
             samples <- colnames(pgx$X)
             sfilt <- parent.input$data_samplefilter

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -7,16 +7,15 @@
 #'
 #' @description A shiny Module (server code).
 #'
-#' @param input 
-#' @param output 
-#' @param session 
-#' @param pgxdata 
 #' @param id,input,output,session Internal parameters for {shiny}.
 #' @param pgxdata Reactive expression that provides the input pgx data object 
 #'
 #' @export 
-DataViewBoard <- function(input, output, session, pgxdata)
+##DataViewBoard <- function(input, output, session, id, pgx)
+DataViewBoard <- function(id, pgx)
 {
+  moduleServer(id, function(input, output, session) {
+
     ns <- session$ns ## NAMESPACE
     rowH = 355  ## row height of panels
     imgH = 315  ## height of images
@@ -59,7 +58,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
     
     ## update filter choices upon change of data set
     shiny::observe({
-        pgx <- pgxdata()
+        ##pgx <- pgxdata()
         shiny::req(pgx)
 
         ## levels for sample filter
@@ -77,7 +76,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
 
 
     shiny::observeEvent( input$data_type, {
-        pgx = pgxdata()
+        ##pgx = pgxdata()
         if(input$data_type %in% c("counts","CPM")) {
             pp <- rownames(pgx$counts)
         } else {
@@ -105,7 +104,6 @@ DataViewBoard <- function(input, output, session, pgxdata)
     
     input_search_gene <- reactive({
         if( input$search_gene %in% c("(type SYMBOL for more genes...)","")) {
-            pgx <- pgxdata()
             gene1 <- last_search_gene() 
             return(gene1)
         }
@@ -119,32 +117,32 @@ DataViewBoard <- function(input, output, session, pgxdata)
     ##================================================================================
 
     ## dbg("[***dataview_server] names.input = ",names(input))    
-    dataview_module_geneinfo_server("geneinfo", pgxdata, input)
+    dataview_module_geneinfo_server("geneinfo", input)
 
     ## first tab
-    dataview_plot_averagerank_server("averagerankplot", pgxdata, input)            
-    dataview_plot_tsne_server("tsneplot", pgxdata, input)        
-    dataview_plot_correlation_server("correlationplot", pgxdata, input)
-    dataview_plot_tissue_server("tissueplot", pgxdata, input)            
-    dataview_plot_expression_server("expressionplot", pgxdata, input)
+    dataview_plot_averagerank_server("averagerankplot", pgx, input)            
+    dataview_plot_tsne_server("tsneplot", pgx, input)        
+    dataview_plot_correlation_server("correlationplot", pgx, input)
+    dataview_plot_tissue_server("tissueplot", pgx, input)            
+    dataview_plot_expression_server("expressionplot", pgx, input)
 
     ## second tab
-    dataview_plot_totalcounts_server("counts_total", pgxdata, input, getCountsTable)
-    dataview_plot_boxplot_server("counts_boxplot", pgxdata, input, getCountsTable)
-    dataview_plot_histogram_server("counts_histplot", pgxdata, input, getCountsTable)
-    dataview_plot_abundance_server("counts_abundance", pgxdata, input, getCountsTable)
-    dataview_plot_averagecounts_server("counts_averagecounts", pgxdata, input, getCountsTable)
+    dataview_plot_totalcounts_server("counts_total", input, getCountsTable)
+    dataview_plot_boxplot_server("counts_boxplot", input, getCountsTable)
+    dataview_plot_histogram_server("counts_histplot", input, getCountsTable)
+    dataview_plot_abundance_server("counts_abundance", input, getCountsTable)
+    dataview_plot_averagecounts_server("counts_averagecounts", input, getCountsTable)
     
     ## fourth tab
-    dataview_plot_phenoheatmap_server("phenoheatmap", pgxdata, input)
-    dataview_plot_phenoassociation_server("phenoassociation", pgxdata, input)    
+    dataview_plot_phenoheatmap_server("phenoheatmap", pgx, input)
+    dataview_plot_phenoassociation_server("phenoassociation", pgx, input)    
     
     ##================================================================================
     ##========================= FUNCTIONS ============================================
     ##================================================================================
     
     getCountsTable <- shiny::reactive({
-        pgx = pgxdata()
+        ## pgx = pgxdata()
         shiny::req(pgx)
 
         shiny::validate(shiny::need("counts" %in% names(pgx), "no 'counts' in object."))
@@ -291,7 +289,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
 
     data_rawdataTable.RENDER <- shiny::reactive({
         ## get current view of raw_counts
-        pgx = pgxdata()
+        ## pgx = pgxdata()   ## NOT NEEDED ANYMORE!!!
         shiny::req(pgx)
         shiny::req(input$data_groupby)
 
@@ -471,7 +469,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
     
     data_sampleTable.RENDER <- shiny::reactive({
         ## get current view of raw_counts
-        pgx = pgxdata()
+        ## pgx = pgxdata()
         shiny::req(pgx)
         
         dt <- NULL
@@ -509,7 +507,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
 
     data_contrastTable.RENDER <- shiny::reactive({
         ## get current view of raw_counts
-        pgx = pgxdata()
+        ## pgx = pgxdata()
         shiny::req(pgx)
 
         dbg("[data_contrastTable.RENDER] reacted")
@@ -574,7 +572,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
     ##================================================================================
 
     datatable_timings.RENDER <- shiny::reactive({
-        pgx <- pgxdata()
+        ## pgx <- pgxdata()
         shiny::req(pgx)
 
         dbg("[datatable_timings.RENDER] reacted")
@@ -604,7 +602,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
     )
 
     datatable_objectdims.RENDER <- shiny::reactive({
-        pgx <- pgxdata()
+        ## pgx <- pgxdata()
         shiny::req(pgx)
 
         dims1 <- lapply( pgx, dim)
@@ -630,7 +628,7 @@ DataViewBoard <- function(input, output, session, pgxdata)
     )
 
     datatable_objectsize.RENDER <- shiny::reactive({
-        pgx <- pgxdata()
+        ## pgx <- pgxdata()
         shiny::req(pgx)
         objsize <- sapply(pgx,object.size)
         objsize <- round( objsize/1e6, digits=2)
@@ -649,5 +647,6 @@ DataViewBoard <- function(input, output, session, pgxdata)
         options = NULL, title='Object sizes',
         info.text = datatable_objectsize_text
     )
-
+      
+  }) ## end of moduleServer
 }

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -3,7 +3,8 @@
 ## Copyright (c) 2018-2022 BigOmics Analytics Sagl. All rights reserved.
 ##
 
-LoadingBoard <- function(input, output, session, pgx_dir, 
+LoadingBoard <- function(id,
+                         pgx_dir, 
                          limits = c("samples"=1000,"comparisons"=20,
                                     "genes"=20000, "genesets"=10000,
                                     "datasets"=10),
@@ -13,6 +14,8 @@ LoadingBoard <- function(input, output, session, pgx_dir,
                          enable_userdir = TRUE,
                          authentication="none")
 {
+  moduleServer(id, function(input, output, session) {
+
     ns <- session$ns ## NAMESPACE
     dbg("[LoadingBoard] >>> initializing LoadingBoard...")
 
@@ -787,4 +790,5 @@ LoadingBoard <- function(input, output, session, pgx_dir,
         ##usermode = shiny::reactive({ USERMODE() })
     )
     return(res)
+  })  ## end of moduleServer      
 }

--- a/components/board.user/R/user_server.R
+++ b/components/board.user/R/user_server.R
@@ -4,8 +4,10 @@
 ##
 
 
-UserBoard <- function(input, output, session, user)
+UserBoard <- function(id, user)
 {
+  moduleServer(id, function(input, output, session)
+  {    
     ns <- session$ns ## NAMESPACE
     dbg("[UserBoard] >>> initializing UserBoard...")
 
@@ -181,4 +183,5 @@ UserBoard <- function(input, output, session, user)
         enable_beta = reactive({ as.logical(input$enable_beta) })
     )
     return(res)
+  })    
 }


### PR DESCRIPTION
To pass the active pgx object around, currently a handle to a reactive function that is actually created inside the loaiding module, is passed using an "envitonment" list, passed into the modules and env[['load']][['inputData']]. This handle is used inside the modules often referred (and dereferenced) as  ngs <- inputData() or pgx <- inputData, and after that ngs/pgx are used to access the object. I now created a reactiveValues object in the main server part, which is a "list to reactiveValues" from the active pgx objects. Instead of the construct above, the modules can directly access the reactiveValues object referring it as pgx, so without having to do pgx <- inputData(). The major advantage is that the pgx object is also writable, so we can make modifications in the object even in the modules (have to be careful though!). Please have a look in the server.R right after the loading module, and the code changes in board.dataview. The 'env' list object and 'pgx' reactiveValues will remain both existing in the transition, later we can get rid of the 'env' object I think. 