### PR TITLE
venn diagram to module

### DIFF
--- a/components/00SourceAll.R
+++ b/components/00SourceAll.R
@@ -116,6 +116,7 @@ if(!file.exists('00SourceAll.R')) {
   source('board.featuremap/R/featuremap_ui.R',encoding='UTF-8')
   source('board.functional/R/functional_server.R',encoding='UTF-8')
   source('board.functional/R/functional_ui.R',encoding='UTF-8')
+  source('board.intersection/R/intersection_plot_venn_diagram.R',encoding='UTF-8')
   source('board.intersection/R/intersection_server.R',encoding='UTF-8')
   source('board.intersection/R/intersection_ui.R',encoding='UTF-8')
   source('board.loading/R/loading_server.R',encoding='UTF-8')

--- a/components/board.intersection/R/intersection_plot_venn_diagram.R
+++ b/components/board.intersection/R/intersection_plot_venn_diagram.R
@@ -1,0 +1,154 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2022 BigOmics Analytics Sagl. All rights reserved.
+##
+
+intersection_plot_venn_diagram_ui <- function(id, label='', height=c(600,800)) {
+  
+  ns <- shiny::NS(id)
+  
+  info_text = "The Venn diagram visualizes the number of intersecting genes between the profiles. The list of intersecting genes with further details is also reported in an interactive table below, where users can select and remove a particular contrasts from the intersection analysis."
+  
+  venndiagram.opts = shiny::tagList(
+    shiny::radioButtons(ns('include'),'Counting:', choices=c("both","up/down"), inline=TRUE)
+  )
+  
+  PlotModuleUI(
+    ns("vennplot"),
+    title = "Venn Diagram",
+    label = "b",
+    info.text = info_text,
+    options = venndiagram.opts,
+    download.fmt = c("png","pdf","csv"),
+    height = height
+  )
+  
+}
+
+
+intersection_plot_venn_diagram_server <- function(id, 
+                                                  getSignificantTable,
+                                                  watermark=FALSE){
+  moduleServer( id, function(input, output, session) {
+    
+    dbg("[intersection_plot_venn_diagram_server] created!")
+    
+    venndiagram.RENDER <- shiny::reactive({
+      dt <- getSignificantTable()
+      shiny::req(dt)
+      
+      if(is.null(dt) || nrow(dt)==0) return(NULL)
+      
+      dt1 = dt[,2:ncol(dt),drop=FALSE]
+      label = LETTERS[1:ncol(dt1)]
+      colnames(dt1) = label
+      include = "both"
+      if(input$include=="up/down") {
+        include = c("up/down")
+      }
+      
+      par(mfrow=c(1,1), mar=c(1,1,3,1)*0, bty="n")
+      par(oma=c(0.0,0,0,0))
+      if(ncol(dt1)==1) {
+        frame()
+        text(0.5, 0.5, "Error: Venn diagram needs at least two groups")
+        return(NULL)            
+      } 
+      if(ncol(dt1)>7) {
+        frame()
+        text(0.5, 0.5, "Error: too many groups for Venn diagram")
+        return(NULL)
+      } 
+      
+      p <- NULL
+      if(0) {
+        ## dt1 = dt1[,1:min(5,ncol(dt1))]
+        limma::vennDiagram(
+          dt1,  main=NULL, cex.main=0.2, cex=1.2, mar=c(0,0,2,0),
+          include=include, bty="n", fg=grey(0.7),
+          circle.col=c("turquoise", "salmon","lightgreen","orange") )
+        tt = paste(label,"=",colnames(dt)[-1])
+        legend("topleft", legend=tt, bty='n', cex=0.9, y.intersp=0.95,
+               inset=c(0.04,-0.01), xpd=TRUE)       
+        
+      } else {
+        
+        ##colnames(dt1) <- colnames(dt)[-1]
+        
+        x <- apply(dt1, 2, function(x) rownames(dt1)[which(x!=0)])
+        
+        xlen <- sapply(x,length) 
+        dbg("[venndiagram.RENDER] list.len = ",xlen)
+        
+        if(length(x)==0 || all(xlen==0)) {
+          frame()
+          text(0.5, 0.5, "Error: no valid genes. Please adjust thresholds.",
+               col='red')
+          return(NULL)
+        }
+        
+        if(include=="up/down"){
+          x_up <- apply(dt1, 2, function(x) paste(rownames(dt1)[which(x>0)], x[which(x>0)]))
+          x_down <- apply(dt1, 2, function(x) paste(rownames(dt1)[which(x<0)], x[which(x<0)]))
+          
+          count_up <- ggVennDiagram::process_region_data(ggVennDiagram::Venn(x_up))$count
+          count_down <- ggVennDiagram::process_region_data(ggVennDiagram::Venn(x_down))$count
+          count_both <- paste0(count_up, "\n", count_down)
+          
+          p <- ggVennDiagram::ggVennDiagram(
+            x,
+            label = "both",
+            edge_size = 0.4
+          ) +
+            ggplot2::scale_fill_gradient(low="grey90",high = "red") +
+            ggplot2::theme( legend.position = "none",
+                            plot.margin = ggplot2::unit(c(1,1,1,1)*0.3, "cm"))
+          
+          p$layers[[4]]$data$both <- count_both
+        } else{
+          p <- ggVennDiagram::ggVennDiagram(
+            x,
+            label = "count",
+            edge_size = 0.4
+          ) +
+            ggplot2::scale_fill_gradient(low="grey90",high = "red") +
+            ggplot2::theme( legend.position = "none", 
+                            plot.margin = ggplot2::unit(c(1,1,1,1)*0.3, "cm"))
+        }
+        
+        ## legend
+        tt = paste(label,"=",colnames(dt)[-1])
+        n1  <- ceiling(length(tt)/2)
+        tt1 <- tt[1:n1]
+        tt2 <- tt[(n1+1):length(tt)]
+        if(length(tt2) < length(tt1)) tt2 <- c(tt2,"   ")
+        tt1 <- paste(tt1, collapse='\n')
+        tt2 <- paste(tt2, collapse='\n')            
+        
+        xlim <- ggplot2::ggplot_build(p)$layout$panel_scales_x[[1]]$range$range
+        ylim <- ggplot2::ggplot_build(p)$layout$panel_scales_y[[1]]$range$range
+        x1 = xlim[1] - 0.1*diff(xlim)
+        x2 = xlim[1] + 0.6*diff(xlim)
+        y1 = ylim[2] + 0.12*diff(xlim)
+        
+        p <- p +
+          ggplot2::annotate("text", x = x1, y = y1, hjust="left",
+                            label = tt1, size=4, lineheight=0.83) +
+          ggplot2::annotate("text", x = x2, y = y1, hjust="left",
+                            label = tt2, size=4, lineheight=0.83) +
+          ggplot2::coord_sf(clip="off")
+      }        
+      p
+    })
+    
+    PlotModuleServer(
+      "vennplot",
+      func = venndiagram.RENDER,
+      res = c(60,120),                ## resolution of plots
+      pdf.width = 8, pdf.height = 5,
+      add.watermark = watermark
+    )
+    
+  }
+  )
+}

--- a/components/board.intersection/R/intersection_ui.R
+++ b/components/board.intersection/R/intersection_ui.R
@@ -28,15 +28,27 @@ IntersectionInputs <- function(id) {
                 withTooltip( shiny::textAreaInput(ns("customlist"), NULL, value = NULL,
                                         rows=5, placeholder="Paste your custom gene list"),
                         "Paste a custom list of genes to highlight.", placement="bottom")
-            )
+            ),
+            shiny::h6("Thresholds for (b) Venn Diagram and (c) Intersection"),
+            withTooltip( shiny::selectInput(ns("fdr"),"FDR", choices=c(1e-9,1e-6,1e-3,0.01,0.05,0.1,0.2,0.5,1), 
+                                            selected=0.20),
+                         "Threshold for false discovery rate",
+                         placement="right", options = list(container = "body")),
+            withTooltip( shiny::selectInput(ns("lfc"),"logFC threshold",
+                                            choices = c(0,0.1,0.2,0.5,1,2,5),
+                                            selected = 0.2),
+                         "Threshold for fold-change (log2 scale)",
+                         placement="right", options = list(container = "body"))
         )
     )
 }
 
 IntersectionUI <- function(id) {
     ns <- shiny::NS(id)  ## namespace
-
-    shiny::tabsetPanel(
+    
+    imgH <- c("35vh","70vh")   ## heights for small and fullscreen image  
+    
+        shiny::tabsetPanel(
         id = ns("tabs1"),
         shiny::tabPanel(
             "Pairwise scatter",
@@ -55,7 +67,7 @@ IntersectionUI <- function(id) {
                 ),
                 div(
                     class = "col-md-6",
-                    plotWidget(ns("venndiagram")),
+                    intersection_plot_venn_diagram_ui(ns("venndiagram"),height=imgH),
                     tableWidget(ns("venntable"))
                 )
             )


### PR DESCRIPTION
Fixed bug #160  +
- Converted venn diagram to the new module structure (PlotModule)
- Separated the venn plot from the intersection_server/ui into its own file (intersection_plot_venn_diagram) following the structure of DataView
- Moved the FDR and LFC threshold filters from the Options of the Venn diagram plot to the Options of the whole component. The reason being this filters were not just affecting the venn diagram, but the venn diagram and the table underneath, therefore, it made no sense to have this option on the venn diagram selector alone