### PR TITLE
Fixes before release - xavier

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -26,6 +26,9 @@ Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = "true")
 
 options(shiny.maxRequestSize = 999*1024^2)  ## max 999Mb upload
 options(shiny.fullstacktrace = TRUE)
+# The following DT global options ensure
+    # 1. The header scrolls with the X scroll bar
+options(DT.options = list(autoWidth = FALSE, scrollX = TRUE))
 reticulate::use_miniconda('r-reticulate')
 
 get_opg_root <- function() {

--- a/components/app/R/utils/boardHeader.R
+++ b/components/app/R/utils/boardHeader.R
@@ -5,8 +5,8 @@ boardHeader <- function(title, info_link) {
         ##h2(input$nav),
         shiny::div(
             id = "navheader-current-section",
-            HTML(paste0(title," &nbsp;")), 
-            withTooltip( 
+            HTML(paste0(title," &nbsp;")),
+            withTooltip(
                 shiny::actionLink(
                     inputId = info_link,
                     label="",
@@ -15,9 +15,6 @@ boardHeader <- function(title, info_link) {
                 ),
                 "Show information and tutorial about this board"
             )
-        ),        
-        shiny::br(),
-        ##shiny::div(shiny::textOutput("current_dataset"), class='current-dataset')
-        shiny::div("Data set name selected", id='navheader-current-dataset')        
+        )
     )
 }

--- a/components/base/R/PlotModule.R
+++ b/components/base/R/PlotModule.R
@@ -150,8 +150,8 @@ PlotModuleUI <- function(id,
 
     if(no.download || length(download.fmt)==0 ) dload.button <- ""
 
-    if(!is.null(label) && label!="") label <- paste0("(",label,")")
-    label1 = shiny::HTML(paste0("<span class='module-label'>",label,"</span>"))
+    if(!is.null(label) && label!="") label <- paste0("&nbsp;(",label,")")
+    label <- shiny::div(class = "plotmodule-title", shiny::HTML(label))
 
     zoom.button <- NULL
     if(1 && show.maximize) {
@@ -164,10 +164,8 @@ PlotModuleUI <- function(id,
 
     header <- shiny::fillRow(
         flex = c(NA,1,NA,NA,NA,NA),
-        ##flex=c(NA,NA,1),
-        label1,
-##      shiny::HTML(paste("<center>",title,"</center>")),
         shiny::div(class='plotmodule-title', title=title, title),
+        label,
         DropdowMenu(
             shiny::tags$p(shiny::HTML(info.text), style = "font-size: smaller;"),
             shiny::br(),

--- a/components/base/R/TableModule.R
+++ b/components/base/R/TableModule.R
@@ -125,6 +125,7 @@ tableModule <- function(input, output, session,
         if(!is.null(selector)){
           dt$x$selection$mode = selector
         }
+        dt$x$container <- stringr::str_remove(dt$x$container, "stripe")
         dt
     },
     fillContainer = T)
@@ -141,7 +142,7 @@ tableModule <- function(input, output, session,
         if(!is.null(selector)){
           dt$x$selection$mode = selector
         }
-
+        dt$x$container <- stringr::str_remove(dt$x$container, "stripe")
         dt
     },
     fillContainer = T)

--- a/components/base/R/TableModule.R
+++ b/components/base/R/TableModule.R
@@ -9,7 +9,8 @@ tableModule <- function(input, output, session,
                         caption=NULL, caption2=caption,
                         csvFunc=NULL, filename="data.csv", ##inputs=NULL,
                         width=c("100%","100%"), height=c("auto","auto"),
-                        options = NULL, info.width="300px"
+                        options = NULL, info.width="300px",
+                        selector = c("none","single", "multi","key")[1]
                         )
 {
     ##require(bsutils)
@@ -108,10 +109,11 @@ tableModule <- function(input, output, session,
     height.2 <- ifnotchar.int(height[2])
 
     output$datatable <- DT::renderDT({
-        # If the options `scrollX` or `autoWidth` are set,
+        # If the options `scrollX` or `autoWidth` or `selector` are set,
         # the global defaults of the global.R
         # will be overwritten. This ensures those options
-        # are kept so that the header scrolls properly.
+        # are kept so that the header scrolls properly, and clickable
+        # properties for tables.
         dt <- func()
         active_options <- names(dt$x$options)
         if("scrollX" %in% active_options){
@@ -120,9 +122,13 @@ tableModule <- function(input, output, session,
         if("autoWidth" %in% active_options){
             dt$x$options$autoWidth <- FALSE
         }
+        if(!is.null(selector)){
+          dt$x$selection$mode = selector
+        }
         dt
     },
     fillContainer = T)
+
     output$datatable2 <- DT::renderDT({
         dt <- func2()
         active_options <- names(dt$x$options)
@@ -132,6 +138,10 @@ tableModule <- function(input, output, session,
         if("autoWidth" %in% active_options){
             dt$x$options$autoWidth <- FALSE
         }
+        if(!is.null(selector)){
+          dt$x$selection$mode = selector
+        }
+
         dt
     },
     fillContainer = T)

--- a/components/base/R/TableModule.R
+++ b/components/base/R/TableModule.R
@@ -108,12 +108,33 @@ tableModule <- function(input, output, session,
     height.2 <- ifnotchar.int(height[2])
 
     output$datatable <- DT::renderDT({
-         func()
+        # If the options `scrollX` or `autoWidth` are set,
+        # the global defaults of the global.R
+        # will be overwritten. This ensures those options
+        # are kept so that the header scrolls properly.
+        dt <- func()
+        active_options <- names(dt$x$options)
+        if("scrollX" %in% active_options){
+            dt$x$options$scrollX <- TRUE
+        }
+        if("autoWidth" %in% active_options){
+            dt$x$options$autoWidth <- FALSE
+        }
+        dt
     },
     fillContainer = T)
     output$datatable2 <- DT::renderDT({
-         func2()
-    })
+        dt <- func2()
+        active_options <- names(dt$x$options)
+        if("scrollX" %in% active_options){
+            dt$x$options$scrollX <- TRUE
+        }
+        if("autoWidth" %in% active_options){
+            dt$x$options$autoWidth <- FALSE
+        }
+        dt
+    },
+    fillContainer = T)
 
     output$popuptable <- shiny::renderUI({
         if(any(class(caption2)=="reactive")) {

--- a/components/base/R/TableModule.R
+++ b/components/base/R/TableModule.R
@@ -1,0 +1,181 @@
+tableWidget <- function(id) {
+    ns <- shiny::NS(id)
+    shiny::uiOutput(ns("widget"))
+}
+
+tableModule <- function(input, output, session,
+                        func, func2=NULL, info.text="Info text",
+                        title=NULL, label="", server=TRUE,
+                        caption=NULL, caption2=caption,
+                        csvFunc=NULL, filename="data.csv", ##inputs=NULL,
+                        width=c("100%","100%"), height=c("auto","auto"),
+                        options = NULL, info.width="300px"
+                        )
+{
+    ##require(bsutils)
+    ns <- session$ns
+
+    if(any(class(caption)=="reactive")) {
+        caption <- caption()
+    }
+    if(class(caption)=="character") {
+        caption <- shiny::HTML(caption)
+    }
+
+    options.button <- ""
+    if(!is.null(options) && length(options)>0) {
+        options.button <- shinyWidgets::dropdownButton(
+            options,
+            ##shiny::br(),
+            ##dload,
+            circle = TRUE, size = "xs", ## status = "danger",
+            ## icon = shiny::icon("gear"),
+            icon = shiny::icon("bars"),
+            width = "250px",
+            inputId = ns("options"),
+            tooltip = shinyWidgets::tooltipOptions(title = "Settings", placement = "right")
+        )
+    }
+
+    ##if(!is.null(label) && label!="") label <- paste0("(",label,")")
+    label1 = shiny::HTML(paste0("<span class='module-label'>",label,"</span>"))
+    title1 = title
+    if(label!="") {
+        title1 = shiny::HTML(paste0(title," (",label,")"))
+    }
+
+    zoom.button <- modalTrigger(
+        ns("zoombutton"),
+        ns("tablePopup"),
+        icon("window-maximize"),
+        class="btn-circle-xs"
+    )
+
+    header <- shiny::fillRow(
+        ##flex=c(NA,NA,NA,NA,1),
+        flex=c(NA,1,NA,NA,NA,NA),
+        label1,
+        shiny::div(class='plotmodule-title', title=title, title1),
+        shinyWidgets::dropdownButton(
+            shiny::tags$p(shiny::HTML(info.text)),
+            shiny::br(),
+            circle = TRUE, size = "xs", ## status = "danger",
+            icon = shiny::icon("info"), width = info.width,
+            inputId = ns("info"), right=FALSE,
+            tooltip = shinyWidgets::tooltipOptions(title = "Info", placement = "right")
+        ),
+        options.button,
+        shiny::div(class='download-button',
+            shinyWidgets::dropdownButton(
+                shiny::downloadButton(ns("csv"), "CSV"),
+                circle = TRUE, size = "xs", ## status = "danger",
+                icon = shiny::icon("download"), width = "80px", right=FALSE,
+                tooltip = shinyWidgets::tooltipOptions(title = "Download",
+                    placement = "right")
+            )),
+        ##withTooltip(zoom.button,"maximize table")
+        zoom.button
+    )
+
+    CSVFILE = paste0(gsub("file","data",tempfile()),".csv")
+    CSVFILE
+
+    ## render2 <- shiny::renderPlot({plot_array[[3]]()}, res=res)
+    download.csv <- shiny::downloadHandler(
+        filename = filename,
+        content = function(file) {
+          if(!is.null(csvFunc)) {
+            dt <- csvFunc()
+          } else {
+            dt <- func()$x$data
+          }
+          ##write.csv(dt, file=CSVFILE, row.names=FALSE)
+          ##file.copy(CSVFILE, file, overwrite=TRUE)
+          write.csv(dt, file=file, row.names=FALSE)
+        }
+    )
+    output$csv <- download.csv
+
+    if(is.null(func2)) func2 <- func
+    if(length(height)==1) height <- c(height,height)
+    if(length(width)==1)  width  <- c(width,width)
+    ##ifnotchar.int <- function(s) ifelse(grepl("[%]$|auto|vmin|vh|vw|vmax",s),s,as.integer(s))
+    ifnotchar.int <- function(s) suppressWarnings(
+      ifelse(!is.na(as.integer(s)), paste0(as.integer(s),"px"), s))
+    width.1  <- ifnotchar.int(width[1])
+    width.2  <- ifnotchar.int(width[2])
+    height.1 <- ifnotchar.int(height[1])
+    height.2 <- ifnotchar.int(height[2])
+
+    output$datatable <- DT::renderDT({
+         func()
+    },
+    fillContainer = T)
+    output$datatable2 <- DT::renderDT({
+         func2()
+    })
+
+    output$popuptable <- shiny::renderUI({
+        if(any(class(caption2)=="reactive")) {
+            caption2 <- caption2()
+        }
+        if(any(class(caption2)=="character")) {
+            caption2 <- shiny::HTML(caption2)
+        }
+        shiny::tagList(
+            shiny::div( caption2, class="caption2"),
+            DT::DTOutput(ns("datatable2"), width=width.2, height=height.2)
+        )
+    })
+
+    output$widget <- shiny::renderUI({
+
+        modaldialog.style <- paste0("#",ns("tablePopup")," .modal-dialog {width:",width.2,";}")
+        modalbody.style   <- paste0("#",ns("tablePopup")," .modal-body {min-height:",height.2,";}")
+        modalfooter.none  <- paste0("#",ns("tablePopup")," .modal-footer{display:none;}")
+        div.caption <- NULL
+        if(!is.null(caption)) div.caption <- shiny::div(caption, class="table-caption")
+
+        div(class="tablewidget",
+            shiny::fillCol(
+              flex = c(NA,NA,1,NA),
+              shiny::tags$head(shiny::tags$style(modaldialog.style)),
+              shiny::tags$head(shiny::tags$style(modalbody.style)),
+              shiny::tags$head(shiny::tags$style(modalfooter.none)),
+              div(header, class="plotmodule-header"),
+              div.caption,
+              DT::DTOutput(ns("datatable"), width=width.1, height=height.1),
+              shiny::div(class="popup-table",
+                         modalUI(
+                           id = ns("tablePopup"),
+                           title = title,
+                           size = "fullscreen",
+                           shiny::uiOutput(ns("popuptable"))
+                         ))
+            ))
+        })
+
+    module <- list(
+        ##data = func,
+        data = shiny::reactive(func()$x$data),
+        rows_current = shiny::reactive(input$datatable_rows_current),
+        rows_selected = shiny::reactive(input$datatable_rows_selected),
+        rows_all = shiny::reactive(input$datatable_rows_all),
+        rownames_current = shiny::reactive({
+            rns <- rownames(func()$x$data)
+            if(is.null(rns)) rns <- 1:nrow(func()$x$data)
+            rns[input$datatable_rows_current]
+        }),
+        rownames_selected = shiny::reactive({
+            rns <- rownames(func()$x$data)
+            if(is.null(rns)) rns <- 1:nrow(func()$x$data)
+            rns[input$datatable_rows_selected]
+        }),
+        rownames_all = shiny::reactive({
+            rns <- rownames(func()$x$data)
+            if(is.null(rns)) rns <- 1:nrow(func()$x$data)
+            rns[input$datatable_rows_all]
+        })
+    )
+    return(module)
+}

--- a/components/base/R/pgx-modules.R
+++ b/components/base/R/pgx-modules.R
@@ -906,184 +906,185 @@ plotModule <- function(input, output, session,
 ##================================================================================
 
 
-tableWidget <- function(id) {
-    ns <- shiny::NS(id)
-    shiny::uiOutput(ns("widget"))
-}
-
-tableModule <- function(input, output, session,
-                        func, func2=NULL, info.text="Info text",
-                        title=NULL, label="", server=TRUE,
-                        caption=NULL, caption2=caption,
-                        csvFunc=NULL, filename="data.csv", ##inputs=NULL,
-                        ##no.download = FALSE, just.info=FALSE,
-                        width=c("100%","100%"), height=c("auto","auto"),
-                        options = NULL, info.width="300px"
-                        )
-{
-    ##require(bsutils)
-    ns <- session$ns
-
-    if(any(class(caption)=="reactive")) {
-        caption <- caption()
-    }
-    if(class(caption)=="character") {
-        caption <- shiny::HTML(caption)
-    }
-
-    options.button <- ""
-    if(!is.null(options) && length(options)>0) {
-        options.button <- shinyWidgets::dropdownButton(
-            options,
-            ##shiny::br(),
-            ##dload,
-            circle = TRUE, size = "xs", ## status = "danger",
-            ## icon = shiny::icon("gear"),
-            icon = shiny::icon("bars"),
-            width = "250px",
-            inputId = ns("options"),
-            tooltip = shinyWidgets::tooltipOptions(title = "Settings", placement = "right")
-        )
-    }
-
-    ##if(!is.null(label) && label!="") label <- paste0("(",label,")")
-    label1 = shiny::HTML(paste0("<span class='module-label'>",label,"</span>"))
-    title1 = title
-    if(label!="") {
-        title1 = shiny::HTML(paste0(title," (",label,")"))
-    }
-
-    zoom.button <- modalTrigger(
-        ns("zoombutton"),
-        ns("tablePopup"),
-        icon("window-maximize"),
-        class="btn-circle-xs"
-    )
-
-    header <- shiny::fillRow(
-        ##flex=c(NA,NA,NA,NA,1),
-        flex=c(NA,1,NA,NA,NA,NA),
-        label1,
-        shiny::div(class='plotmodule-title', title=title, title1),
-        shinyWidgets::dropdownButton(
-            shiny::tags$p(shiny::HTML(info.text)),
-            shiny::br(),
-            circle = TRUE, size = "xs", ## status = "danger",
-            icon = shiny::icon("info"), width = info.width,
-            inputId = ns("info"), right=FALSE,
-            tooltip = shinyWidgets::tooltipOptions(title = "Info", placement = "right")
-        ),
-        options.button,
-        shiny::div(class='download-button',
-            shinyWidgets::dropdownButton(
-                shiny::downloadButton(ns("csv"), "CSV"),
-                circle = TRUE, size = "xs", ## status = "danger",
-                icon = shiny::icon("download"), width = "80px", right=FALSE,
-                tooltip = shinyWidgets::tooltipOptions(title = "Download",
-                    placement = "right")
-            )),
-        ##withTooltip(zoom.button,"maximize table")
-        zoom.button
-    )
-
-    CSVFILE = paste0(gsub("file","data",tempfile()),".csv")
-    CSVFILE
-
-    ## render2 <- shiny::renderPlot({plot_array[[3]]()}, res=res)
-    download.csv <- shiny::downloadHandler(
-        filename = filename,
-        content = function(file) {
-          if(!is.null(csvFunc)) {
-            dt <- csvFunc()
-          } else {
-            dt <- func()$x$data
-          }
-          ##write.csv(dt, file=CSVFILE, row.names=FALSE)
-          ##file.copy(CSVFILE, file, overwrite=TRUE)
-          write.csv(dt, file=file, row.names=FALSE)
-        }
-    )
-    output$csv <- download.csv
-
-    if(is.null(func2)) func2 <- func
-    if(length(height)==1) height <- c(height,height)
-    if(length(width)==1)  width  <- c(width,width)
-    ##ifnotchar.int <- function(s) ifelse(grepl("[%]$|auto|vmin|vh|vw|vmax",s),s,as.integer(s))
-    ifnotchar.int <- function(s) suppressWarnings(
-      ifelse(!is.na(as.integer(s)), paste0(as.integer(s),"px"), s))
-    width.1  <- ifnotchar.int(width[1])
-    width.2  <- ifnotchar.int(width[2])
-    height.1 <- ifnotchar.int(height[1])
-    height.2 <- ifnotchar.int(height[2])
-
-    output$datatable <- DT::renderDT({
-         func()
-    })
-    output$datatable2 <- DT::renderDT({
-         func2()
-    })
-
-    output$popuptable <- shiny::renderUI({
-        if(any(class(caption2)=="reactive")) {
-            caption2 <- caption2()
-        }
-        if(any(class(caption2)=="character")) {
-            caption2 <- shiny::HTML(caption2)
-        }
-        shiny::tagList(
-            shiny::div( caption2, class="caption2"),
-            DT::DTOutput(ns("datatable2"), width=width.2, height=height.2)
-        )
-    })
-
-    output$widget <- shiny::renderUI({
-
-        modaldialog.style <- paste0("#",ns("tablePopup")," .modal-dialog {width:",width.2,";}")
-        modalbody.style   <- paste0("#",ns("tablePopup")," .modal-body {min-height:",height.2,";}")
-        modalfooter.none  <- paste0("#",ns("tablePopup")," .modal-footer{display:none;}")
-        div.caption <- NULL
-        if(!is.null(caption)) div.caption <- shiny::div(caption, class="table-caption")
-
-        div(class="tablewidget",
-            shiny::fillCol(
-              flex = c(NA,NA,1,NA),
-              shiny::tags$head(shiny::tags$style(modaldialog.style)),
-              shiny::tags$head(shiny::tags$style(modalbody.style)),
-              shiny::tags$head(shiny::tags$style(modalfooter.none)),
-              div(header, class="plotmodule-header"),
-              div.caption,
-              DT::DTOutput(ns("datatable"), width=width.1, height=height.1),
-              shiny::div(class="popup-table",
-                         modalUI(
-                           id = ns("tablePopup"),
-                           title = title,
-                           size = "fullscreen",
-                           shiny::uiOutput(ns("popuptable"))
-                         ))
-            ))
-        })
-
-    module <- list(
-        ##data = func,
-        data = shiny::reactive(func()$x$data),
-        rows_current = shiny::reactive(input$datatable_rows_current),
-        rows_selected = shiny::reactive(input$datatable_rows_selected),
-        rows_all = shiny::reactive(input$datatable_rows_all),
-        rownames_current = shiny::reactive({
-            rns <- rownames(func()$x$data)
-            if(is.null(rns)) rns <- 1:nrow(func()$x$data)
-            rns[input$datatable_rows_current]
-        }),
-        rownames_selected = shiny::reactive({
-            rns <- rownames(func()$x$data)
-            if(is.null(rns)) rns <- 1:nrow(func()$x$data)
-            rns[input$datatable_rows_selected]
-        }),
-        rownames_all = shiny::reactive({
-            rns <- rownames(func()$x$data)
-            if(is.null(rns)) rns <- 1:nrow(func()$x$data)
-            rns[input$datatable_rows_all]
-        })
-    )
-    return(module)
-}
+# tableWidget <- function(id) {
+#     ns <- shiny::NS(id)
+#     shiny::uiOutput(ns("widget"))
+# }
+# 
+# tableModule <- function(input, output, session,
+#                         func, func2=NULL, info.text="Info text",
+#                         title=NULL, label="", server=TRUE,
+#                         caption=NULL, caption2=caption,
+#                         csvFunc=NULL, filename="data.csv", ##inputs=NULL,
+#                         ##no.download = FALSE, just.info=FALSE,
+#                         width=c("100%","100%"), height=c("auto","auto"),
+#                         options = NULL, info.width="300px"
+#                         )
+# {
+#     ##require(bsutils)
+#     ns <- session$ns
+# 
+#     if(any(class(caption)=="reactive")) {
+#         caption <- caption()
+#     }
+#     if(class(caption)=="character") {
+#         caption <- shiny::HTML(caption)
+#     }
+# 
+#     options.button <- ""
+#     if(!is.null(options) && length(options)>0) {
+#         options.button <- shinyWidgets::dropdownButton(
+#             options,
+#             ##shiny::br(),
+#             ##dload,
+#             circle = TRUE, size = "xs", ## status = "danger",
+#             ## icon = shiny::icon("gear"),
+#             icon = shiny::icon("bars"),
+#             width = "250px",
+#             inputId = ns("options"),
+#             tooltip = shinyWidgets::tooltipOptions(title = "Settings", placement = "right")
+#         )
+#     }
+# 
+#     ##if(!is.null(label) && label!="") label <- paste0("(",label,")")
+#     label1 = shiny::HTML(paste0("<span class='module-label'>",label,"</span>"))
+#     title1 = title
+#     if(label!="") {
+#         title1 = shiny::HTML(paste0(title," (",label,")"))
+#     }
+# 
+#     zoom.button <- modalTrigger(
+#         ns("zoombutton"),
+#         ns("tablePopup"),
+#         icon("window-maximize"),
+#         class="btn-circle-xs"
+#     )
+# 
+#     header <- shiny::fillRow(
+#         ##flex=c(NA,NA,NA,NA,1),
+#         flex=c(NA,1,NA,NA,NA,NA),
+#         label1,
+#         shiny::div(class='plotmodule-title', title=title, title1),
+#         shinyWidgets::dropdownButton(
+#             shiny::tags$p(shiny::HTML(info.text)),
+#             shiny::br(),
+#             circle = TRUE, size = "xs", ## status = "danger",
+#             icon = shiny::icon("info"), width = info.width,
+#             inputId = ns("info"), right=FALSE,
+#             tooltip = shinyWidgets::tooltipOptions(title = "Info", placement = "right")
+#         ),
+#         options.button,
+#         shiny::div(class='download-button',
+#             shinyWidgets::dropdownButton(
+#                 shiny::downloadButton(ns("csv"), "CSV"),
+#                 circle = TRUE, size = "xs", ## status = "danger",
+#                 icon = shiny::icon("download"), width = "80px", right=FALSE,
+#                 tooltip = shinyWidgets::tooltipOptions(title = "Download",
+#                     placement = "right")
+#             )),
+#         ##withTooltip(zoom.button,"maximize table")
+#         zoom.button
+#     )
+# 
+#     CSVFILE = paste0(gsub("file","data",tempfile()),".csv")
+#     CSVFILE
+# 
+#     ## render2 <- shiny::renderPlot({plot_array[[3]]()}, res=res)
+#     download.csv <- shiny::downloadHandler(
+#         filename = filename,
+#         content = function(file) {
+#           if(!is.null(csvFunc)) {
+#             dt <- csvFunc()
+#           } else {
+#             dt <- func()$x$data
+#           }
+#           ##write.csv(dt, file=CSVFILE, row.names=FALSE)
+#           ##file.copy(CSVFILE, file, overwrite=TRUE)
+#           write.csv(dt, file=file, row.names=FALSE)
+#         }
+#     )
+#     output$csv <- download.csv
+# 
+#     if(is.null(func2)) func2 <- func
+#     if(length(height)==1) height <- c(height,height)
+#     if(length(width)==1)  width  <- c(width,width)
+#     ##ifnotchar.int <- function(s) ifelse(grepl("[%]$|auto|vmin|vh|vw|vmax",s),s,as.integer(s))
+#     ifnotchar.int <- function(s) suppressWarnings(
+#       ifelse(!is.na(as.integer(s)), paste0(as.integer(s),"px"), s))
+#     width.1  <- ifnotchar.int(width[1])
+#     width.2  <- ifnotchar.int(width[2])
+#     height.1 <- ifnotchar.int(height[1])
+#     height.2 <- ifnotchar.int(height[2])
+# 
+#     output$datatable <- DT::renderDT({
+#          func()
+#     })
+#     output$datatable2 <- DT::renderDT({
+#          func2()
+#     })
+# 
+#     output$popuptable <- shiny::renderUI({
+#         if(any(class(caption2)=="reactive")) {
+#             caption2 <- caption2()
+#         }
+#         if(any(class(caption2)=="character")) {
+#             caption2 <- shiny::HTML(caption2)
+#         }
+#         shiny::tagList(
+#             shiny::div( caption2, class="caption2"),
+#             DT::DTOutput(ns("datatable2"), width=width.2, height=height.2)
+#         )
+#     })
+# 
+#     output$widget <- shiny::renderUI({
+# 
+#         modaldialog.style <- paste0("#",ns("tablePopup")," .modal-dialog {width:",width.2,";}")
+#         modalbody.style   <- paste0("#",ns("tablePopup")," .modal-body {min-height:",height.2,";}")
+#         modalfooter.none  <- paste0("#",ns("tablePopup")," .modal-footer{display:none;}")
+#         div.caption <- NULL
+#         if(!is.null(caption)) div.caption <- shiny::div(caption, class="table-caption")
+# 
+#         div(class="tablewidget",
+#             shiny::fillCol(
+#               flex = c(NA,NA,1,NA),
+#               shiny::tags$head(shiny::tags$style(modaldialog.style)),
+#               shiny::tags$head(shiny::tags$style(modalbody.style)),
+#               shiny::tags$head(shiny::tags$style(modalfooter.none)),
+#               div(header, class="plotmodule-header"),
+#               div.caption,
+#               DT::DTOutput(ns("datatable"), width=width.1, height=height.1),
+#               shiny::div(class="popup-table",
+#                          modalUI(
+#                            id = ns("tablePopup"),
+#                            title = title,
+#                            size = "fullscreen",
+#                            shiny::uiOutput(ns("popuptable"))
+#                          ))
+#             ))
+#         })
+# 
+#     module <- list(
+#         ##data = func,
+#         data = shiny::reactive(func()$x$data),
+#         rows_current = shiny::reactive(input$datatable_rows_current),
+#         rows_selected = shiny::reactive(input$datatable_rows_selected),
+#         rows_all = shiny::reactive(input$datatable_rows_all),
+#         rownames_current = shiny::reactive({
+#             rns <- rownames(func()$x$data)
+#             if(is.null(rns)) rns <- 1:nrow(func()$x$data)
+#             rns[input$datatable_rows_current]
+#         }),
+#         rownames_selected = shiny::reactive({
+#             rns <- rownames(func()$x$data)
+#             if(is.null(rns)) rns <- 1:nrow(func()$x$data)
+#             rns[input$datatable_rows_selected]
+#         }),
+#         rownames_all = shiny::reactive({
+#             rns <- rownames(func()$x$data)
+#             if(is.null(rns)) rns <- 1:nrow(func()$x$data)
+#             rns[input$datatable_rows_all]
+#         })
+#     )
+#     return(module)
+# }
+# 

--- a/components/board.drugconnectivity/R/drugconnectivity_table_dsea.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_table_dsea.R
@@ -72,10 +72,10 @@ drugconnectivity_table_dsea_server <- function(id,
     dsea_table <- shiny::callModule(
       tableModule,
       id = "dsea_table",
-      label = "",
       func = table.RENDER,
       options = table.opts,
       info.text = info_text,
+      selector = "single",
       title = "Enrichment table",
       height = c(360, 700)
     )

--- a/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
+++ b/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
@@ -97,7 +97,8 @@ enrichment_table_enrichment_analysis_server <- function(id,
         HTML('<span class="module-label">(I)</span>Enrichment analysis')
       ),
       info.width = "500px",
-      height = c(285, 700)
+      height = c(285, 700),
+      selector = "single"
     )
 
     return(gseatable)

--- a/components/board.enrichment/R/enrichment_table_genes_in_geneset_ui.R
+++ b/components/board.enrichment/R/enrichment_table_genes_in_geneset_ui.R
@@ -71,6 +71,7 @@ enrichment_table_genes_in_geneset_server <- function(id,
       id = "genetable",
       func = genetable.RENDER,
       info.text = genetable_text,
+      selector = "single",
       title = tags$div(
         HTML('<span class="module-label">(II)</span>Genes in gene set')
       ),

--- a/components/board.expression/R/expression_table_genetable.R
+++ b/components/board.expression/R/expression_table_genetable.R
@@ -119,6 +119,7 @@ expression_table_genetable_server <- function(id,
       info.text = genetable_text,
       info.width = "500px",
       options = genetable_opts,
+      selector = "single",
       title = tags$div(
         HTML('<span class="module-label">(I)</span>Differential expression analysis')
       )

--- a/components/board.expression/R/expression_table_gsettable.R
+++ b/components/board.expression/R/expression_table_gsettable.R
@@ -76,6 +76,7 @@ expression_table_gsettable_server <- function(id,
       id = "gsettable",
       func = gsettable.RENDER,
       info.text = gsettable_text,
+      selector = "single",
       title = tags$div(
         HTML('<span class="module-label">(II)</span>Gene sets with gene')
       ),

--- a/components/board.loading/R/loading_tsneplot.R
+++ b/components/board.loading/R/loading_tsneplot.R
@@ -5,10 +5,7 @@
 
 loading_tsne_ui <- function(id, label='', height=c(350,600)) {
     ns <- shiny::NS(id)
-    ## options (hamburger menu)
-    options <- tagList(
-        actionButton(ns("button1"),"some action")
-    )
+
     info_text = paste0('<b>Similarity clustering</b> of fold-change signatures colored by data sets using t-SNE. Each dot corresponds to a specific comparison. Signatures/datasets that are clustered closer together, are more similar.')
     
     PlotModuleUI(
@@ -16,8 +13,7 @@ loading_tsne_ui <- function(id, label='', height=c(350,600)) {
         outputFunc = plotly::plotlyOutput,
         outputFunc2 = plotly::plotlyOutput,        
         info.text = info_text,
-        options = options,
-        download.fmt=c("png","pdf","csv"),         
+        download.fmt = c("png","pdf","csv"),         
         width = c("auto","100%"),
         height = height,
         label = label,

--- a/components/board.wordcloud/R/wordcloud_server.R
+++ b/components/board.wordcloud/R/wordcloud_server.R
@@ -104,7 +104,7 @@ WordCloudBoard <- function(id, pgx) {
 
     # Leading-edge table
 
-    wordcloud_leadingEdgeTable <- wordcloud_table_leading_edge_server(
+    wordcloud_table_leading_edge_server(
       "wordcloud_leadingEdgeTable",
       pgx = pgx,
       wc_contrast = shiny::reactive(input$wc_contrast),

--- a/components/board.wordcloud/R/wordcloud_table_enrichment.R
+++ b/components/board.wordcloud/R/wordcloud_table_enrichment.R
@@ -50,6 +50,7 @@ wordcloud_table_enrichment_server <- function(id,
       id = "wordcloud_enrichmentTable",
       func = wordcloud_enrichmentTable.RENDER,
       info.text = wordcloud_enrichmentTable_info,
+      selector = "single",
       title = tags$div(
         HTML('<span class="module-label">(e)</span>Enrichment table')
       ),


### PR DESCRIPTION
- Figure labels are now after the plot title
- Tables have uniform row color (no grey stripes)
- Removed “Data name selected” label at top right of every board
- Removed action button on UMAP figure on load dataset screen
- Moved tableModule to a separate file in order to separate things and work on that
- Fixed scrollX for tables, now the header also moves with the scroller
- Now tableModule has the argument `selector`, placed it accordingly on the tables that have to be selectable