### PR TITLE
create Shiny wrappers around bigdash JS triggers... end of JS PITA..

### DIFF
--- a/components/00SourceAll.R
+++ b/components/00SourceAll.R
@@ -67,6 +67,7 @@ if(!file.exists('00SourceAll.R')) {
   source('base/R/pgx-ui.R',encoding='UTF-8')
   source('base/R/pgx-vizpanels.R',encoding='UTF-8')
   source('base/R/pgx-wordcloud.R',encoding='UTF-8')
+  source('base/R/ui-bigdashplus.R',encoding='UTF-8')
   source('base/R/ui-boardHeader.R',encoding='UTF-8')
   source('base/R/ui-code.R',encoding='UTF-8')
   source('base/R/ui-modalUI.R',encoding='UTF-8')

--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -188,7 +188,7 @@ BOARDS <- c("welcome","load","upload","dataview","clustersamples","clusterfeatur
   "wgcna", "tcga","comp","user")
 if(is.null(opt$BOARDS_ENABLED))  opt$BOARDS_ENABLED = BOARDS
 ENABLED <- array(rep(TRUE,length(BOARDS)),dimnames=list(BOARDS))
-ENABLED  <- array(BOARDS %in% opt$BOARDS_ENABLED, dimnames=list(BOARDS))
+ENABLED <- array(BOARDS %in% opt$BOARDS_ENABLED, dimnames=list(BOARDS))
 
 ## disable connectivity map if we have no signature database folder
 has.sigdb <- length(dir(SIGDB.DIR,pattern="sigdb.*h5"))>0
@@ -197,7 +197,6 @@ if(has.sigdb==FALSE) ENABLED["cmap"] <- FALSE
 ## Main tab titles
 MAINTABS = c("DataView","Clustering","Expression","Enrichment",
              "Signature","CellProfiling","DEV")
-
 
 ## --------------------------------------------------------------------
 ## --------------------- HANDLER MANAGER ------------------------------

--- a/components/app/R/modules/WelcomeBoard.R
+++ b/components/app/R/modules/WelcomeBoard.R
@@ -31,6 +31,17 @@ WelcomeBoard <- function(id, auth, r_global) {
     observeEvent(input$init_example_data, {
       r_global$load_example_trigger <- TRUE
     })
+
+    observeEvent(input$init_upload_data, {
+      bigdash.openSidebar()
+      bigdash.selectTab( session, "upload-tab" )
+    })
+
+    observeEvent(input$init_load_data, {
+      bigdash.openSidebar()
+      bigdash.selectTab( session, "load-tab" )
+    })
+
   })
 }
 
@@ -44,9 +55,9 @@ WelcomeBoardUI <- function(id, enable_upload=TRUE) {
   ## if upload enabled show button, otherwise empty
   upload_button <- "  "
   if(enable_upload) {
-    upload_button <- tags$a(
-      id = "init-upload-data",
-      "Upload new data",
+    upload_button <- shiny::actionButton(
+      ns("init_upload_data"),
+      label = "Upload new data",
       class = "btn btn-outline-info welcome-btn"
     )
   }
@@ -76,9 +87,9 @@ WelcomeBoardUI <- function(id, enable_upload=TRUE) {
         class = "col-md-7",
         h3("I'm an existing user..."),
         upload_button,
-        tags$button(
-          id = "init-load-data",
-          "Use my saved data",
+        shiny::actionButton(
+          ns("init_load_data"),
+          label = "Use my saved data",
           class = "btn btn-outline-primary welcome-btn"
         )
       )

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -27,7 +27,7 @@ app_server <- function(input, output, session) {
     honcho.responding
     honcho.token <- Sys.getenv("HONCHO_TOKEN", "")
     has.honcho <- (honcho.token!="" && honcho.responding)
-  if(1 && has.honcho) {
+    if(1 && has.honcho) {
         info("[server.R] Honcho is alive! ")
         sever::sever(sever_screen2(session$token), bg_color = "#004c7d")
     } else {
@@ -284,8 +284,8 @@ app_server <- function(input, output, session) {
         shiny::removeModal()
 
         #show hidden tabs
-        bigdash.showTabs()  # see ui-bigdashplus.R
-        ##session$sendCustomMessage("show-tabs", list())
+        bigdash.showTabsGoToDataView(session)  # see ui-bigdashplus.R
+        ##bigdash.hideTab(session, "upload-tab")
 
     })
 
@@ -317,6 +317,9 @@ app_server <- function(input, output, session) {
     ##--------------------------------------------------------------------------
     ## Dynamically hide/show certain sections depending on USERMODE/object
     ##--------------------------------------------------------------------------
+
+    ## toggleTab("load-tabs","Upload data", opt$ENABLE_UPLOAD)
+    ##bigdash.toggleTab(session, "upload-tab", opt$ENABLE_UPLOAD)
 
     shiny::observeEvent({
         auth$logged()
@@ -365,7 +368,6 @@ app_server <- function(input, output, session) {
 
         ## Dynamically show upon availability in pgx object
         info("[server.R] disabling extra features")
-        toggleTab("load-tabs","Upload data", opt$ENABLE_UPLOAD)
         tabRequire(PGX, "connectivity", "maintabs", "Similar experiments")
         tabRequire(PGX, "drugs", "maintabs", "Drug connectivity")
         tabRequire(PGX, "wordcloud", "maintabs", "Word cloud")

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -108,8 +108,8 @@ app_ui <- function() {
         )
 
         ## filter disabled modules
-        ENABLED['welcome'] <- TRUE
-        ENABLED['load'] <- TRUE
+        ENABLED['welcome'] <<- TRUE
+        ENABLED['load'] <<- TRUE
         #ENABLED['upload'] <- TRUE
         dbg("[ui.R] sum.enabled = ",sum(ENABLED))
         dbg("[ui.R] names.enabled = ",names(ENABLED))

--- a/components/app/R/utils/utils.R
+++ b/components/app/R/utils/utils.R
@@ -144,10 +144,10 @@ toggleTab <- function(inputId, target, do.show, req.file=NULL ) {
         do.show <- do.show && has.file
     }
     if(do.show) {
-        shiny::showTab(inputId, target)
+      shiny::showTab(inputId, target)
     }
     if(!do.show) {
-        shiny::hideTab(inputId, target)
+      shiny::hideTab(inputId, target)
     }
 }
 

--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -37,7 +37,8 @@ const sidebarOpen = () => {
 }
 
 $(function(){
-	
+
+        // init sequence: close sidebar, goto Welcome page and hide it's tab item
 	setTimeout(() => {
 		$('.sidebar-label').trigger('click');
 		$('.sidebar-menu')
@@ -48,9 +49,11 @@ $(function(){
 			.first()
 			.css('display', 'none');
 		// on mouseover this does not work anymore, substitute by lock button option
-		// $('.settings-label').click()
+	        //$('.settings-label').click()
 	}, 250);
 
+/*
+// now handled by WelcomeBoard using traditional Shiny
 
 	$('#init-load-data').on('click', (e) => {
 	 	$(".tab-sidebar:eq(1)").trigger('click');
@@ -61,7 +64,8 @@ $(function(){
 	 	$(".tab-sidebar:eq(2)").trigger('click');
 		$('.sidebar-label').trigger('click');
 	 });
-
+*/
+    
 	const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
 	const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
 })
@@ -209,7 +213,7 @@ const logout = () => {
 
 const logoutInApp = () => {
 	unloadSidebar();
-	$(".tab-sidebar:eq(1)").trigger('click');
+	$(".tab-sidebar:eq(1)").trigger('click');  // show welcome page
 	sidebarClose();
 	Shiny.setInputValue('auth-userLogout', 1, {priority: 'event'});
 	Shiny.setInputValue('userLogout', 1, {priority: 'event'});
@@ -356,8 +360,22 @@ Shiny.addCustomMessageHandler('show-tabs', (msg) => {
 	}, 1000);
 });
 
-
-Shiny.addCustomMessageHandler('select-bigtab', (msg) => {
-    ##console.log('msg.value' + msg.value)
+Shiny.addCustomMessageHandler('bigdash-select-tab', (msg) => {
     $(`.tab-trigger[data-target=${msg.value}]`).trigger('click');
+});
+
+Shiny.addCustomMessageHandler('bigdash-hide-menuitem', (msg) => {
+    $(`.tab-trigger[data-target=${msg.value}]`).hide();
+});
+
+Shiny.addCustomMessageHandler('bigdash-show-menuitem', (msg) => {
+    $(`.tab-trigger[data-target=${msg.value}]`).show();    
+});
+
+Shiny.addCustomMessageHandler('bigdash-hide-tab', (msg) => {
+    $(`.big-tab[data-name=${msg.value}]`).hide();
+});
+
+Shiny.addCustomMessageHandler('bigdash-show-tab', (msg) => {
+    $(`.big-tab[data-name=${msg.value}]`).show();
 });

--- a/components/base/R/ui-bigdashplus.R
+++ b/components/base/R/ui-bigdashplus.R
@@ -2,20 +2,74 @@
 ## 
 ##
 
-
 ## This calls the select-bigtab JS in app/R/www/temp.js
 bigdash.selectTab <- function(session, selected) {
   shiny:::validate_session_object(session)
-  message <- shiny:::dropNulls(list(value = selected))
+  msg <- shiny:::dropNulls(list(value = selected))
   ##session$sendInputMessage(inputId, message)
-  session$sendCustomMessage("select-tab", message)
+  session$sendCustomMessage("bigdash-select-tab", msg)
 }
 
-bigdash.showTabs <- function() {
-  session$sendCustomMessage("show-tabs", list())
+bigdash.showTabsGoToDataView <- function(session) {
+  session$sendCustomMessage("show-tabs", list())  ## in app/R/www/temp.js
+}
+
+## ------------------- sideBar ---------------------------
+bigdash.openSidebar <- function() {
+  shinyjs::runjs("sidebarOpen()")  ## in app/R/www/temp.js
+}
+
+bigdash.closeSidebar <- function() {
+  shinyjs::runjs("sidebarClose()")  ## in app/R/www/temp.js
+}
+
+bigdash.toggleSidebar <- function(state) {
+  if(state) bigdash.openSidebar()
+  if(!state) bigdash.closeSidebar()
+}
+
+## --------------------menuItem --------------------------
+bigdash.showMenuItem <- function(session, item) {
+  shiny:::validate_session_object(session)
+  msg <- shiny:::dropNulls(list(value = item))
+  session$sendCustomMessage("bigdash-show-menuitem", msg)  ## in app/R/www/temp.js
+}
+
+bigdash.hideMenuItem <- function(session, item) {
+  shiny:::validate_session_object(session)
+  msg <- shiny:::dropNulls(list(value = item))
+  session$sendCustomMessage("bigdash-hide-menuitem", msg)  ## in app/R/www/temp.js
+}
+
+bigdash.toggleMenuItem <- function(session, item, state) {
+  if(state) bigdash.showMenuItem(session, item)
+  if(!state) bigdash.hideMenuItem(session, item)  
+}
+
+## --------------------BigTab --------------------------
+bigdash.showTab <- function(session, tab) {
+  shiny:::validate_session_object(session)
+  msg <- shiny:::dropNulls(list(value = tab))
+  session$sendCustomMessage("bigdash-show-tab", msg)  ## in app/R/www/temp.js
+  bigdash.showMenuItem(session, tab)
+}
+
+bigdash.hideTab <- function(session, tab) {
+  shiny:::validate_session_object(session)
+  msg <- shiny:::dropNulls(list(value = tab))
+  session$sendCustomMessage("bigdash-hide-tab", msg)  ## in app/R/www/temp.js
+  bigdash.hideMenuItem(session, tab)
+}
+
+bigdash.toggleTab <- function(session, tab, state) {
+  message("[bigdash.toggleTab] tab = ",tab)
+  message("[bigdash.toggleTab] state = ",state)
+  if(state) bigdash.showTab(session, tab)
+  if(!state) bigdash.hideTab(session, tab)  
 }
 
 
+#--------------------------------------------------------------------------------
 # This JS code is responsible for activating and desactivating the class `active`,
 # defined on `scss/components/_dropdownmenu.scss` when clicking a dropdown button.
 # It also has logic implemented so that when clicking a different dropdown item,

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -465,7 +465,7 @@ LoadingBoard <- function(id,
       }
 
       on.exit({
-        bigdash.showTabs()  ## in ui-bigdashplus.R
+        bigdash.showTabsGoToDataView(session)  ## in ui-bigdashplus.R
       })
 
       pgxfile <- NULL


### PR DESCRIPTION
I started creating sensible Shiny wrappers around the JS triggers. Now you can show/hide tabs and menu items using their name instead of their fragile menu index. The functions are in base/R/ui-bigdashplus.R and their JS counterpart in www/temp.js. But these functions should probably best be incorporated in bigDash. I have converted the buttons on the Welcome page as classic actionButtons with observeEvent, rather than button+JS.