### PR TITLE
fix: diffexpr plots blink and initialize to all genes selected

### DIFF
--- a/components/board.expression/R/expression_plot_barplot.R
+++ b/components/board.expression/R/expression_plot_barplot.R
@@ -78,6 +78,7 @@ expression_plot_barplot_server <- function(id,
       showothers <- input$barplot_showothers
       sel <- sel()
       res <- res()
+      shiny::req(sel())
 
       psel <- rownames(res)[sel]
       gene <- pgx$genes[1, "gene_name"]

--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -75,7 +75,7 @@ expression_plot_maplot_server <- function(id,
       if (length(comp1) == 0) {
         return(NULL)
       }
-      shiny::req(pgx)
+      shiny::req(pgx, sel1())
 
       fdr <- as.numeric(gx_fdr())
       lfc <- as.numeric(gx_lfc())

--- a/components/board.expression/R/expression_plot_topfoldchange.R
+++ b/components/board.expression/R/expression_plot_topfoldchange.R
@@ -58,6 +58,7 @@ expression_plot_topfoldchange_server <- function(id,
       comp <- comp() # input$gx_contrast
       sel <- sel()
       res <- res()
+      shiny::req(sel())
 
       psel <- rownames(res)[sel]
       gene <- pgx$genes[psel, "gene_name"]

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -71,7 +71,6 @@ expression_plot_volcano_server <- function(id,
     plot_data <- shiny::reactive({
       # calculate required inputs for plotting
 
-
       comp1 <- comp1()
       fdr <- as.numeric(fdr())
       lfc <- as.numeric(lfc())
@@ -81,6 +80,8 @@ expression_plot_volcano_server <- function(id,
       df1 <- df1()
       sel2 <- sel2()
       df2 <- df2()
+
+      req(sel1())
 
       fam.genes <- res$gene_name
 
@@ -159,7 +160,7 @@ expression_plot_volcano_server <- function(id,
     })
 
 
-    plotly.RENDER <- function() {
+    plotly.RENDER <- reactive({
       pd <- plot_data()
       shiny::req(pd)
 
@@ -181,9 +182,9 @@ expression_plot_volcano_server <- function(id,
         showlegend = FALSE
       ) %>% plotly::layout(margin = list(b = 65))
       plt
-    }
+    })
 
-    modal_plotly.RENDER <- function() {
+    modal_plotly.RENDER <- reactive({
       fig <- plotly.RENDER() %>%
         plotly::layout(
           font = list(size = 18),
@@ -193,7 +194,7 @@ expression_plot_volcano_server <- function(id,
         )
       fig <- plotly::style(fig, marker.size = 20)
       fig
-    }
+    })
 
     PlotModuleServer(
       "pltmod",

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -80,9 +80,9 @@ ExpressionBoard <- function(id, pgx) {
     genetable_rows_selected <- reactiveVal()
 
     observe({
+      req(genetable$rows_selected())
       genetable_rows_selected(genetable$rows_selected())
     })
-
 
     # reactives ########
 
@@ -94,9 +94,6 @@ ExpressionBoard <- function(id, pgx) {
       test <- intersect(test, gx.methods0)
       test
     })
-
-
-
 
 
     # functions #########
@@ -194,18 +191,17 @@ ExpressionBoard <- function(id, pgx) {
     }
 
     fullDiffExprTable <- shiny::reactive({
+      print('REACTIVE1 RUNNING')
       ## return the full DE table
       if (is.null(pgx)) {
         return(NULL)
       }
-      comp <- 1
-      tests <- "trend.limma"
-      fdr <- 1
-      lfc <- 0
       comp <- input$gx_contrast
       tests <- input$gx_statmethod
       fdr <- as.numeric(input$gx_fdr)
       lfc <- as.numeric(input$gx_lfc)
+
+      req(input$gx_contrast, input$gx_statmethod, input$gx_fdr, input$gx_lfc)
 
       if (is.null(comp)) {
         return(NULL)


### PR DESCRIPTION
this fixes the issue where the top four plots on the differential expression board blink and initialize to all the genes selected. now they only initialize to show the first gene in the table below as selected.