### PR TITLE
make separate shared tsne

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -130,6 +130,7 @@ LoadingBoard <- function(id,
     ## Modules
     ## ================================================================================
     loading_tsne_server("tsne", pgx.dir = getPGXDIR, watermark = FALSE)
+    loading_tsne_server("tsne_shared", pgx.dir = reactive(pgx_shared_dir), watermark = FALSE)
 
     pgxtable <- loading_table_datasets_server("pgxtable", rl = rl)
 

--- a/components/board.loading/R/loading_tsneplot.R
+++ b/components/board.loading/R/loading_tsneplot.R
@@ -48,7 +48,8 @@ loading_tsne_server <- function(id, pgx.dirRT,
 
       ## if no t-SNE file exists, we need to calculate it
       if (is.null(pos)) {
-        F <- data.table::fread(file.path(PGX.DIR, "datasets-allFC.csv"))
+        dbg("[loading_tsneplot.R] recalculating tSNE positions...")
+        F <- data.table::fread(file.path(pgx.dir, "datasets-allFC.csv"))
         F <- as.matrix(F[, -1], rownames = F[[1]])
         dim(F)
         ## F[is.na(F)] <- 0
@@ -93,9 +94,10 @@ loading_tsne_server <- function(id, pgx.dirRT,
     plot.RENDER <- function() {
       df <- plot_data()
       shiny::req(df)
-
+      
       dataset.pos <- df[[2]]
-
+      marker_size <- ifelse( nrow(df[[1]]) > 50, 5, 10)
+      
       fig <- plotly::plot_ly(
         data = df[[1]],
         x = ~x,
@@ -104,7 +106,7 @@ loading_tsne_server <- function(id, pgx.dirRT,
         color = ~dataset,
         ## colors = omics_pal_c(palette = "brand_blue")(100),
         marker = list(
-          size = 10,
+          size = marker_size,
           line = list(
             color = omics_colors("super_dark_grey"),
             width = 1.2
@@ -137,6 +139,9 @@ loading_tsne_server <- function(id, pgx.dirRT,
     }
 
     modal_plot.RENDER <- function() {
+      df <- plot_data()
+      shiny::req(df)
+      marker_size <- ifelse( nrow(df[[1]]) > 50, 6, 12)
       p <- plot.RENDER() %>%
         plotly::layout(
           showlegend = TRUE,
@@ -144,7 +149,7 @@ loading_tsne_server <- function(id, pgx.dirRT,
             size = 16
           )
         )
-      p <- plotly::style(p, marker.size = 11)
+      p <- plotly::style(p, marker.size = marker_size)
       p
     }
 

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -27,14 +27,14 @@ LoadingUI <- function(id) {
   div(
     class = "p-1",
     uiOutput(ns("navheader")),
-    div(
-      class = "row",
-      div(
-        class = "col-md-7",
-        shiny::tabsetPanel(
-          id = ns('tabs'),
-          shiny::tabPanel(
-            'User',
+    shiny::tabsetPanel(
+      id = ns('tabs'),
+      shiny::tabPanel(
+        'User',
+        div(
+          class = "row",
+          div(
+            class = "col-md-7",
             loading_table_datasets_ui(
               ns("pgxtable"),
               height = c("65vh", 700),
@@ -64,8 +64,25 @@ LoadingUI <- function(id) {
               )
             )
           ),
-          shiny::tabPanel(
-            'Shared',
+          div(
+            class = "col-md-5",
+            loading_tsne_ui(ns("tsne"),
+              height = c("65vh", "70vh"),
+              width = c("auto",  "100%")
+            ) %>%
+              tagAppendAttributes(
+                ##style = 'padding-top: 61.5px;'
+              )
+          )
+        )
+      ),
+         
+      shiny::tabPanel(
+        'Shared',
+        div(
+          class = "row",
+          div(
+            class = "col-md-7",
             loading_table_datasets_shared_ui(
               ns("pgxtable_shared"),
               height = c("65vh", 700),
@@ -79,18 +96,18 @@ LoadingUI <- function(id) {
                 class = "btn btn-outline-primary"
               )
             )
-          )
+          ),
+          div(
+            class = "col-md-5",
+            loading_tsne_ui(ns("tsne_shared"),
+              height = c("65vh", "70vh"),
+              width = c("auto",  "100%")
+            ) %>%
+              tagAppendAttributes(
+                ## style = 'padding-top: 61.5px;'
+              )
+          )          
         )
-      ),
-      div(
-        class = "col-md-5",
-        loading_tsne_ui(ns("tsne"),
-        height = c("65vh", "70vh"),
-        width = c("auto",  "100%")
-        ) %>%
-          tagAppendAttributes(
-            style = 'padding-top: 61.5px;'
-          )
       )
     )
   )


### PR DESCRIPTION
make separate public tsne. We still need to think of a good way to show both without too much recalculating the tSNE (this can be slow for >1000 comparisons)  if shared folder becomes really big. 