### PR TITLE
#249/gene table not reacting

### DIFF
--- a/components/board.featuremap/R/featuremap_plot_table_gene_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_gene_map.R
@@ -29,12 +29,6 @@ featuremap_plot_gene_map_ui <- function(id, label = "", height = c(600, 800)) {
       ns("gene_map"),
       title = "Gene UMAP",
       label = "a",
-      # outputFunc = function(x, width, height) {
-      #   plotOutput(x,
-      #     brush = ns("geneUMAP_brush"), width = width,
-      #     height = height
-      #   )
-      # },
       plotlib = "plotly",
       plotlib2 = "plotly",
       info.text = info_text,
@@ -46,7 +40,7 @@ featuremap_plot_gene_map_ui <- function(id, label = "", height = c(600, 800)) {
     TableModuleUI(
       ns("datasets"),
       info.text = info_text_table,
-      height = c(280, TABLE_HEIGHT_MODAL),
+      height = c("30vh", TABLE_HEIGHT_MODAL),
       width = c("auto", "90%"),
       title = "Gene table",
       label = "c"
@@ -62,6 +56,9 @@ featuremap_plot_gene_map_server <- function(id,
                                             filter_genes,
                                             watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     selGenes <- shiny::reactive({
       shiny::req(pgx)
       sel <- filter_genes()
@@ -131,8 +128,9 @@ featuremap_plot_gene_map_server <- function(id,
 
       p <- plotUMAP(pos, fc, hilight,
         nlabel = nlabel, title = colorby,
-        cex = 1.2, source = "", plotlib = "plotly"
-      )
+        cex = 1.2, plotlib = "plotly",
+        source = ns("gene_filter")
+      ) %>% plotly::layout(dragmode = "select")
       p
     })
 
@@ -159,13 +157,10 @@ featuremap_plot_gene_map_server <- function(id,
 
       ## detect brush
       sel.genes <- NULL
-      ## b <- input$ftmap-geneUMAP_brush  ## ugly??
-      b <- NULL
-      b <- input[["geneUMAP_brush"]] ## ugly??
+      b <- plotly::event_data("plotly_selected", source = ns("gene_filter"))
       if (!is.null(b) & length(b) > 0) {
-        sel <- which(pos[, 1] > b$xmin & pos[, 1] < b$xmax &
-          pos[, 2] > b$ymin & pos[, 2] < b$ymax)
-        sel.genes <- rownames(pos)[sel]
+        sel <- b$key
+        sel.genes <- rownames(pos)[rownames(pos) %in% sel]
       }
 
       pheno <- "tissue"
@@ -207,8 +202,8 @@ featuremap_plot_gene_map_server <- function(id,
         fillContainer = TRUE,
         options = list(
           dom = "lfrtip",
-          scrollX = TRUE, ## scrollY = TRUE,
-          scrollY = "70vh",
+          scrollX = TRUE,
+          scrollY = "20vh",
           scroller = TRUE,
           deferRender = TRUE
         ) ## end of options.list

--- a/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
@@ -28,12 +28,6 @@ featuremap_plot_table_geneset_map_ui <- function(id, label = "", height = c(600,
       ns("gset_map"),
       title = "Geneset UMAP",
       label = "a",
-      # outputFunc = function(x, width, height) {
-      #   plotOutput(x,
-      #     brush = ns("gsetUMAP_brush"), width = width,
-      #     height = height
-      #   )
-      # },
       plotlib = "plotly",
       plotlib2 = "plotly",
       info.text = info_text,
@@ -61,6 +55,9 @@ featuremap_plot_table_geneset_map_server <- function(id,
                                                      sigvar,
                                                      watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     selGsets <- shiny::reactive({
       shiny::req(pgx)
       db <- filter_gsets()
@@ -126,8 +123,8 @@ featuremap_plot_table_geneset_map_server <- function(id,
       par(mfrow = c(1, 1))
       p <- plotUMAP(pos, fc, hilight,
         nlabel = nlabel, title = colorby,
-        cex = 1.2, source = "", plotlib = "plotly"
-      )
+        cex = 1.2, source =  ns("geneset_filter"), plotlib = "plotly"
+      ) %>% plotly::layout(dragmode = "select")
       p
     })
 
@@ -153,12 +150,11 @@ featuremap_plot_table_geneset_map_server <- function(id,
 
       ## detect brush
       sel.gsets <- NULL
-      b <- input[["gsetUMAP_brush"]] ## ugly??
+      b <- plotly::event_data("plotly_selected", source = ns("geneset_filter"))
 
       if (!is.null(b) & length(b)) {
-        sel <- which(pos[, 1] > b$xmin & pos[, 1] < b$xmax &
-          pos[, 2] > b$ymin & pos[, 2] < b$ymax)
-        sel.gsets <- rownames(pos)[sel]
+        sel <- b$key
+        sel.gsets <- rownames(pos)[rownames(pos) %in% sel]
       }
 
       pheno <- "tissue"
@@ -197,7 +193,7 @@ featuremap_plot_table_geneset_map_server <- function(id,
         options = list(
           dom = "lfrtip",
           scrollX = TRUE, ## scrollY = TRUE,
-          scrollY = "70vh",
+          scrollY = "20vh",
           scroller = TRUE,
           deferRender = TRUE
         ) ## end of options.list

--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -95,9 +95,9 @@ FeatureMapBoard <- function(id, pgx) {
         hilight.lwd = 0.8,
         hilight = hilight,
         hilight2 = hilight2,
-        title = title
+        title = title,
         ## legend.pos = 'bottomright',
-        ## source = source,
+        source = source,
         ## key = rownames(pos)
       )
 


### PR DESCRIPTION
Fixes issue #249 

## Description
To solve this issue:

- Enabled the `source` argument on the `pgx.scatterPlotXY` function call ([Code](https://github.com/bigomics/omicsplayground/blob/d81ce83e5a3285ff1df14c16a4d44fef72bfe5a4/components/board.featuremap/R/featuremap_server.R#L82)) which is used to render the Plot that we want to use to perform the selection. This argument will be used to be able to retrieve the plot selection and subset the table correctly.
- Added selection ability (and namespaced `source`) to the plots ([Code](https://github.com/bigomics/omicsplayground/commit/524956373f68437b0a76b923d6ffe1cef7bb7e66#diff-39aae2c13cc1ec9685c2612dc0b8beebf51d51d58c05cbfb181fe5a8bed23f84R132-R133))
- Get selection ([Code](https://github.com/bigomics/omicsplayground/commit/524956373f68437b0a76b923d6ffe1cef7bb7e66#diff-39aae2c13cc1ec9685c2612dc0b8beebf51d51d58c05cbfb181fe5a8bed23f84R160))
- Subset table with the information that `plotly` selection gives ([Code](https://github.com/bigomics/omicsplayground/commit/524956373f68437b0a76b923d6ffe1cef7bb7e66#diff-39aae2c13cc1ec9685c2612dc0b8beebf51d51d58c05cbfb181fe5a8bed23f84R162-R163))

## Additional changes

- Correct `scrollY` value for the tables ([Code](https://github.com/bigomics/omicsplayground/commit/524956373f68437b0a76b923d6ffe1cef7bb7e66#diff-39aae2c13cc1ec9685c2612dc0b8beebf51d51d58c05cbfb181fe5a8bed23f84R206))
- Fixed this issue also for the Geneset tab.