### PR TITLE
files with no copyright fix

### DIFF
--- a/build/sysdata.R
+++ b/build/sysdata.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ## code to prepare internal `1sysdata.rda` dataset goes here
 
 source("../R/setdirs.R")

--- a/components/00SourceAll.R
+++ b/components/00SourceAll.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ## Generated automatically: do not edit by hand
 
 message('source all called from wd = ',getwd())

--- a/components/app/R/modules/InfoModals.R
+++ b/components/app/R/modules/InfoModals.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 
 
 show_upgrade_modal <- function(timeout.min=40) {

--- a/components/app/R/modules/TimerModule.R
+++ b/components/app/R/modules/TimerModule.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ##library(shiny)
 ##library(shinyjs)
 ##library(shinyalert)

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 app_ui <- function() {
     #-------------------------------------------------------
     ## Build USERMENU

--- a/components/base/R/auth.R
+++ b/components/base/R/auth.R
@@ -16,14 +16,14 @@ google_base_url <- function(){
 google_user_get <- function(key, uid){
 	if(missing(key))
 		stop("Missing key")
-	
+
 	if(missing(uid))
 		stop("Missing uid")
 
 	url <- sprintf(
-		"%s/%s?key=%s", 
-		google_base_url(), 
-		URLencode(uid), 
+		"%s/%s?key=%s",
+		google_base_url(),
+		URLencode(uid),
 		key
 	)
 
@@ -34,10 +34,10 @@ google_user_get <- function(key, uid){
 google_user_create <- function(key, email, plan = "free"){
 	if(missing(key))
 		stop("Missing key")
-	
+
 	url <- sprintf(
-		"%s?documentId=%s&key=%s", 
-		google_base_url(), 
+		"%s?documentId=%s&key=%s",
+		google_base_url(),
 		URLencode(email),
 		key
 	)
@@ -51,10 +51,10 @@ google_user_create <- function(key, email, plan = "free"){
 	)
 
 	req <- httr::POST(
-		url, 
-		body = body, 
+		url,
+		body = body,
 		encode = "json",
 		httr::content_type_json()
 	)
-	httr::content(req)	
+	httr::content(req)
 }

--- a/components/base/R/ggplot-theme.R
+++ b/components/base/R/ggplot-theme.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 library(systemfonts)
 
 #' The plot theme to be used for figures in the OmicsPlayground app.

--- a/components/base/R/ui-DropDownMenu.R
+++ b/components/base/R/ui-DropDownMenu.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 #--------------------------------------------------------------------------------
 # This JS code is responsible for activating and desactivating the class `active`,
 # defined on `scss/components/_dropdownmenu.scss` when clicking a dropdown button.

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 loading_table_datasets_ui <- function(id, height, width) {
   ns <- shiny::NS(id)
 

--- a/components/board.loading/R/loading_table_datasets_shared.R
+++ b/components/board.loading/R/loading_table_datasets_shared.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 loading_table_datasets_shared_ui <- function(id, height, width) {
   ns <- shiny::NS(id)
 

--- a/components/board.tcga/R/tcga_server.R
+++ b/components/board.tcga/R/tcga_server.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ## DEAN ATTALI code recommendation:
 ## example of how a board module should be written (TcgaBoard)
 ##

--- a/components/board.tcga/R/tcga_ui.R
+++ b/components/board.tcga/R/tcga_ui.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ## DEAN ATTALI code recommendation:
 ## example of how a board module should be written (TcgaBoard)
 ##

--- a/dev/01_start.R
+++ b/dev/01_start.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 # Building a Prod-Ready, Robust Shiny Application.
 #
 # README: each step of the dev files is optional, and you don't have to

--- a/dev/02_doc.R
+++ b/dev/02_doc.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 # Building a Prod-Ready, Robust Shiny Application.
 #
 # README: each step of the dev files is optional, and you don't have to

--- a/dev/03_cicd.R
+++ b/dev/03_cicd.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 # Building a Prod-Ready, Robust Shiny Application.
 #
 # README: each step of the dev files is optional, and you don't have to

--- a/dev/04_deploy.R
+++ b/dev/04_deploy.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 # Building a Prod-Ready, Robust Shiny Application.
 #
 # README: each step of the dev files is optional, and you don't have to

--- a/dev/05_run.R
+++ b/dev/05_run.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 # Sass code compilation
 sass::sass(input = sass::sass_file("inst/app/www/custom.sass"), output = "inst/app/www/custom.css", cache = NULL)
 

--- a/dev/create_source_all.R
+++ b/dev/create_source_all.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 
 ## Create global "source_all" file
 

--- a/dev/dev-utils.R
+++ b/dev/dev-utils.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ##appdir="~/R/golem/omics.app";wd="packages/board1"
 
 get_appdir <- function() {

--- a/dev/sass.R
+++ b/dev/sass.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 output <- sass::sass(
   sass::sass_file(
     'scss/main.scss'

--- a/dev/update_description.R
+++ b/dev/update_description.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 ## Copy DESCRIPTION ----
 ## Add meta data about your application
 ##

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 
 local({
 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 if(requireNamespace('spelling', quietly = TRUE))
   spelling::spell_check_test(vignettes = TRUE, error = FALSE,
                              skip_on_cran = TRUE)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 library(testthat)
 library(testpackage)
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 test_that("multiplication works", {
   expect_equal(2 * 2, 4)
 })

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -1,3 +1,8 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
 
 # Configure this test to fit your need.
 # testServer() function makes it possible to test code in server functions and modules, without needing to run the full Shiny application


### PR DESCRIPTION
## Description
Updated the Copyright script to place copyright statement on R files that do not have it. And catch .r extension as well as .R

## Notes
Updated the [wiki article](https://github.com/bigomics/omicsplayground/wiki/Updating-copyright-year-globally) with this new capabilities.

This is related to PR #260 and Issue #89 