### PR TITLE
fix: select correct rows

### DIFF
--- a/components/board.correlation/R/correlation_plot_table_corr.R
+++ b/components/board.correlation/R/correlation_plot_table_corr.R
@@ -114,6 +114,7 @@ correlation_plot_table_corr_server <- function(id,
       sel <- 1:pcor_ntop
       shiny::req(sel)
 
+      if(length(sel) > nrow(R)) sel <- 1:nrow(R)
       rho <- R[sel, "cor"]
       if (length(sel) == 1) names(rho) <- rownames(R)[sel]
 


### PR DESCRIPTION
This closes #318 

## Description
The error was being originated when evaluating the following line https://github.com/bigomics/omicsplayground/commit/64bbccffee30ae9e0804ba5ee68484f3b152baf4#diff-7fee6935f3c7a80f87c56c1d2d61dfad16e2bc9bdce3f6530753c7e4ab0490d3R118

The error was that the `sel` row selector was targeting rows non existent on the `R` table. 

This `sel` vector is defined [here](https://github.com/bigomics/omicsplayground/commit/64bbccffee30ae9e0804ba5ee68484f3b152baf4#diff-7fee6935f3c7a80f87c56c1d2d61dfad16e2bc9bdce3f6530753c7e4ab0490d3R114), it is basically a `1:N` vector where `N` is selected on the righ-bar-settings, when filtering genes this `R` table had less than `N` rows so it crashed.

Now we check if `N` is bigger than the rows of `R`.