### PR TITLE
fix sample information plotting options

### DIFF
--- a/components/board.dataview/R/dataview_plot_phenoassociation.R
+++ b/components/board.dataview/R/dataview_plot_phenoassociation.R
@@ -60,7 +60,7 @@ dataview_plot_phenoassociation_server <- function(id, pgx, r.samples, watermark 
       }
       
 
-      if (check_diversity_in_colums(res$annot)) {
+      if (check_diversity_in_colums(res$annot) && is.data.frame(res$annot)) {
         ## NOTE: the package doesnt allow to change the typeface, the spacing of the legend, sizes + formatting of labels, ...
         ## TODO: reimplement in plotly (not me as code is complex and not intuitive at all)
         pq <- playbase::pgx.testPhenoCorrelation(

--- a/components/board.dataview/R/dataview_plot_phenoheatmap.R
+++ b/components/board.dataview/R/dataview_plot_phenoheatmap.R
@@ -72,7 +72,7 @@ dataview_plot_phenoheatmap_server <- function(id, pgx, r.samples, watermark = FA
             ) >1
       }
       
-      if (check_diversity_in_colums(res$annot)) {
+      if (check_diversity_in_colums(res$annot) && is.data.frame(res$annot)) {
         ## TODO: Color palettes should be unique, not the same for condition and time
         ## NOTE: the package doesnt allow to change the typeface, the position of the legend, the label placement, ...
         ## TODO: reimplement in plotly (not me as code is complex and not intuitive at all)


### PR DESCRIPTION
**Problem**: The function `playbase::pgx.testPhenoCorrelation` activelly removes single value columns of phenotypes. Some of the combination of feature selection creates a dataframe where all columns (exceot samples) have unique value, making the plot crash.

**ps:** the previous two commits on master are also part of this PR.

**Solution:**
- detect when input to the sample information plots have no "diversity". i.e. all dataframe columns have a single unique value.
- trigger a message to select other input in this case.

**Alternative solution not implemented:**

- Plot phenotypes with a single value, but that's boring and will make the plot crowded when we have many phenotypes. So activelly removing "boring" phenotypes (the same across samples) is a good thing, and I opted not go remove that option.

Test: 
- on example data only, but should work for any pgx:
<img width="961" alt="image" src="https://user-images.githubusercontent.com/28757711/233124764-c9c4a860-e5fd-42f2-87f1-487a4eeb0543.png">