### PR TITLE
Fix margins plots

### DIFF
--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -222,6 +222,7 @@ expression_plot_maplot_server <- function(id,
       plotlib = "plotly",
       func = plotly.RENDER,
       func2 = modal_plotly.RENDER,
+      remove_margins = FALSE,
       csvFunc = plot_data, ##  *** downloadable data as CSV
       res = c(80, 95), ## resolution of plots
       pdf.width = 6, pdf.height = 6,

--- a/components/board.expression/R/expression_plot_topfoldchange.R
+++ b/components/board.expression/R/expression_plot_topfoldchange.R
@@ -130,6 +130,7 @@ expression_plot_topfoldchange_server <- function(id,
       "pltmod",
       plotlib = "plotly",
       func = plotly.RENDER,
+      remove_margins = FALSE,
       # func2 = modal_plotly.RENDER,
       csvFunc = plot_data, ##  *** downloadable data as CSV
       res = c(80, 95), ## resolution of plots

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -210,6 +210,7 @@ expression_plot_volcano_server <- function(id,
       plotlib = "plotly",
       func = plotly.RENDER,
       func2 = modal_plotly.RENDER,
+      remove_margins = FALSE,
       csvFunc = plot_data, ##  *** downloadable data as CSV
       res = c(80, 95), ## resolution of plots
       pdf.width = 6, pdf.height = 6,

--- a/components/board.pathway/R/functional_plot_go_actmap.R
+++ b/components/board.pathway/R/functional_plot_go_actmap.R
@@ -168,6 +168,7 @@ functional_plot_go_actmap_server <- function(id,
         csvFunc = plot_data,
         res = 72,
         pdf.width = 9,
+        remove_margins = FALSE,
         pdf.height = 9,
         add.watermark = watermark
       )

--- a/components/board.pathway/R/functional_plot_wikipathway_actmap.R
+++ b/components/board.pathway/R/functional_plot_wikipathway_actmap.R
@@ -119,6 +119,7 @@ functional_plot_wikipathway_actmap_server <- function(id,
         func2 = plot_RENDER2,
         csvFunc = plot_data,
         res = c(100,140),
+        remove_margins = FALSE,
         pdf.height = 11,
         pdf.width = 6,
         add.watermark = watermark


### PR DESCRIPTION
**Fix margins in the plots below:**

Expression > Diff exp > plot > volcano plot
Expression > Diff exp > plot > Bland-Altman (MA) plot
Expression > Diff exp > plot > Gene in contrasts
Enrichment > Pathway analysis > Reactome > Activation matrix
Enrichment > Pathway analysis > GO graph > Activation matrix

This is a follow-up on #319 and will close this issue.