### PR TITLE
fix: #341 GTEX: No need to display HEX colour

### DIFF
--- a/components/board.dataview/R/dataview_plot_tissue.R
+++ b/components/board.dataview/R/dataview_plot_tissue.R
@@ -32,7 +32,7 @@ dataview_plot_tissue_ui <- function(
 
 dataview_plot_tissue_server <- function(id, pgx, r.gene, r.data_type, watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
-    
+
     plot_data <- shiny::reactive({
       shiny::req(pgx$X)
       shiny::req(r.gene(), r.data_type())
@@ -114,7 +114,6 @@ dataview_plot_tissue_server <- function(id, pgx, r.gene, r.data_type, watermark 
         df, tissue = forcats::fct_reorder(stringr::str_to_title(paste(tissue, " ")), x))
 
       # df$tissue <- factor(df$tissue, levels = df$tissue)
-
       plotly::plot_ly(
         data = df,
         ## name = pd$gene
@@ -123,7 +122,8 @@ dataview_plot_tissue_server <- function(id, pgx, r.gene, r.data_type, watermark 
         type = "bar",
         orientation = "h",
         color = ~color, ## TODO: use variable that encodes grouping
-        colors = omics_pal_d()(length(unique(df$color)))
+        colors = omics_pal_d()(length(unique(df$color))),
+        hovertemplate = '%{y}: %{x}<extra></extra>'
       ) %>%
         plotly::layout(
           yaxis = list(title = FALSE),


### PR DESCRIPTION
This closes #341 

## Description
Redid the hover template specifically leaving empty the <extra> so the grouping variable is not shown.

Also, the hover info is a little bit more tidy.

![image](https://user-images.githubusercontent.com/10220503/234705661-9f738852-466b-4e9c-a9b3-f46077d70c68.png)