### PR TITLE
fix: #354 Proportions plot bug in singlecell board 

### DIFF
--- a/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
+++ b/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
@@ -231,8 +231,8 @@ singlecell_plot_crosstabPlot_server <- function(id,
       if (gene != "<none>") {
         grp.score2 <- getProportionsTable(pheno = gene, is.gene = TRUE)
         kk <- colnames(grp.score2)[order(grp.score2[1, ])]
-        grp.score2 <- grp.score2[, match(kk, colnames(grp.score2))]
-        grp.score1 <- grp.score1[, match(kk, colnames(grp.score1))]
+        grp.score2 <- grp.score2[, match(kk, colnames(grp.score2)), drop = F]
+        grp.score1 <- grp.score1[, match(kk, colnames(grp.score1)), drop = F]
       }
 
       jj <- match(colnames(grp.score1), names(grp.counts))


### PR DESCRIPTION
This closes #354 

## Description
Simple problem, there was only 1 match at [this line](https://github.com/bigomics/omicsplayground/compare/fix-%23354?expand=1#diff-04810dd45ad52692a7aa683f4ae9c1ed76b43fba3ac4ee8ce0c4f9bfa3eb11fbR235) with the proposed configuration of the issue, therefore instead of a `data.frame` we had a named vector and [this](https://github.com/bigomics/omicsplayground/compare/fix-%23354?expand=1#diff-04810dd45ad52692a7aa683f4ae9c1ed76b43fba3ac4ee8ce0c4f9bfa3eb11fbR238) `colnames` did not work. Used `drop = F` to solve it.

For safety, also added the `drop = F` to [this line](https://github.com/bigomics/omicsplayground/compare/fix-%23354?expand=1#diff-04810dd45ad52692a7aa683f4ae9c1ed76b43fba3ac4ee8ce0c4f9bfa3eb11fbR234).