### PR TITLE
add tab-info-alert toggle to profile page

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -200,7 +200,7 @@ app_server <- function(input, output, session) {
 
           if(ENABLED['dataview'])  {
             info("[server.R] calling module dataview")
-            DataViewBoard("dataview", pgx=PGX)
+            DataViewBoard("dataview", pgx=PGX, user=env$user)
           }
 
           if(ENABLED['clustersamples']) {
@@ -356,7 +356,7 @@ app_server <- function(input, output, session) {
             ##bigdash.toggleTab(session, "upload-tab", opt$ENABLE_UPLOAD)
             shinyjs::runjs("sidebarClose()")
             shinyjs::runjs("settingsClose()")
-            bigdash.selectTab(session, selected = 'welcome-tab')            
+            bigdash.selectTab(session, selected = 'welcome-tab')
             return(NULL)
         }
 
@@ -366,10 +366,10 @@ app_server <- function(input, output, session) {
 
         ## do we have libx libraries?
         has.libx <- dir.exists(file.path(OPG,"libx"))
-        
+
         ## Beta features
         info("[server.R] disabling beta features")
-        bigdash.toggleTab(session, "comp-tab", show.beta)  ## compare datasets        
+        bigdash.toggleTab(session, "comp-tab", show.beta)  ## compare datasets
         bigdash.toggleTab(session, "tcga-tab", show.beta && has.libx)
         toggleTab("drug-tabs","Connectivity map (beta)", show.beta)   ## too slow
         toggleTab("pathway-tabs","Enrichment Map (beta)", show.beta)   ## too slow
@@ -378,7 +378,7 @@ app_server <- function(input, output, session) {
         ## Dynamically show upon availability in pgx object
         info("[server.R] disabling extra features")
         tabRequire(PGX, session, "wgcna-tab", "wgcna", TRUE)
-        tabRequire(PGX, session, "cmap-tab", "connectivity", has.libx)        
+        tabRequire(PGX, session, "cmap-tab", "connectivity", has.libx)
         tabRequire(PGX, session, "drug-tab", "drugs", TRUE)
         tabRequire(PGX, session, "wordcloud-tab", "wordcloud", TRUE)
         tabRequire(PGX, session, "cell-tab", "deconv", TRUE)

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -12,13 +12,21 @@
 #' @param pgx Reactive expression that provides the input pgx data object
 #'
 #' @export
-DataViewBoard <- function(id, pgx) {
+DataViewBoard <- function(id, pgx, user) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
     rowH <- 355 ## row height of panels
     imgH <- 315 ## height of images
     fullH <- 750 ## full height of panel
     tabH <- 600 ## height of tables
+
+    ## bs alerts
+
+    output$bs_alert1 <- renderUI({
+        if (user$enable_tabinfo()) {
+            bs_alert("This Gene overview panel displays data for a selected gene. The 'gene info' box provides more information about the gene and hyperlinks to external databases. The upper plots show the expression level, average expression ranking, and distribution of expression among the samples. The remaining plots, display the most correlated genes and expression in the GTEX tissue database.")
+        }
+    })
 
     ## ----------------------------------------------------------------------
     ## More Info (pop up window)

--- a/components/board.dataview/R/dataview_ui.R
+++ b/components/board.dataview/R/dataview_ui.R
@@ -75,7 +75,7 @@ DataViewUI <- function(id) {
         width = 1,
         height = fullH,
         heights_equal = "row",
-        bs_alert("This Gene overview panel displays data for a selected gene. The 'gene info' box provides more information about the gene and hyperlinks to external databases. The upper plots show the expression level, average expression ranking, and distribution of expression among the samples. The remaining plots, display the most correlated genes and expression in the GTEX tissue database."),
+        uiOutput(ns('bs_alert1')),
         bslib::layout_column_wrap(
           width = 1,
           height = "100%",

--- a/components/board.user/R/user_server.R
+++ b/components/board.user/R/user_server.R
@@ -101,6 +101,9 @@ UserBoard <- function(id, user) {
     res <- list(
       enable_beta = reactive({
         as.logical(input$enable_beta)
+      }),
+      enable_tabinfo = reactive({
+          as.logical(input$enable_tabinfo)
       })
     )
     return(res)

--- a/components/board.user/R/user_ui.R
+++ b/components/board.user/R/user_ui.R
@@ -24,7 +24,8 @@ UserUI <- function(id) {
                       height = "calc(100vh - 183px)",
                       width = 1,
                       tagList(
-                          shinyWidgets::prettySwitch(ns("enable_beta"), "enable beta features")
+                          shinyWidgets::prettySwitch(ns("enable_beta"), "enable beta features"),
+                          shinyWidgets::prettySwitch(ns("enable_tabinfo"), "enable tab info / alerts")
                       )
                   )
               ),


### PR DESCRIPTION
This PR provides an option on the user profile/settings page to enable or disable the blue bs_alerts on each page that provide info about the page or tab. These are something the user probably shouldn't see more than once (like when they first use the app) because they are text-heavy (i.e., likely skipped) and take up a lot of vertical space. 

Right now this is only implemented for the very first bs_alert on the dataview page, so that the implementation can be discussed.

Ref issue:
https://github.com/bigomics/omicsplayground/issues/380