### PR TITLE
fix: dataset options icon cutoff on data load page

### DIFF
--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -106,13 +106,10 @@ loading_table_datasets_server <- function(id, rl, enable_pgxdownload=FALSE, enab
           rl$delete_pgx <- input$delete_pgx;
       }, ignoreInit = TRUE)
 
-      df$actions <- menus
-      colnames(df)[ncol(df)] <- ' '
-
       DT::datatable(
         df,
         class = "compact hover",
-        rownames = TRUE,
+        rownames = menus,
         escape = FALSE,
         editable = list(
           target = 'cell',


### PR DESCRIPTION
## Description
Very simple fix, we do not create the new column `actions` on the `df` `data.frame`.

Then, we pass the `menus` value to be the rownames.