### PR TITLE
fix: plot options menu trigger early disappear: cannot select submenu

### DIFF
--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -493,11 +493,7 @@ app_ui <- function() {
                     UserUI("user")
                 )
             ),
-            tagList(footer),
-            # This JS script is sourced at this point because if sourced before creating
-            # the UI elements, the snippet to prevent `dropdown-menu` to propagate clicks
-            # will not be applied
-            tags$script(src = "dropdown-helper.js")
+            tagList(footer)
         )
     }
 

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -344,7 +344,8 @@ PlotModuleUI <- function(id,
         shiny::tags$head(shiny::tags$style(modaldialog.style)),
         shiny::tags$head(shiny::tags$style(modalbody.style)),
         shiny::tags$head(shiny::tags$style(modalcontent.style)),
-        shiny::tags$head(shiny::tags$style(modalfooter.none))
+        shiny::tags$head(shiny::tags$style(modalfooter.none)),
+        shiny::tags$script(src = "dropdown-helper.js")
       )
     ),
     bslib::card_body(
@@ -508,13 +509,13 @@ PlotModuleServer <- function(id,
           content = function(file) {
             png.width <- input$pdf_width * 80
             png.height <- input$pdf_height * 80
-            resx <- 4 ## upresolution            
+            resx <- 4 ## upresolution
             shiny::withProgress(
               {
                 ## unlink(PNGFILE) ## do not remove!
                 if (plotlib == "plotly") {
                   p <- func()
-                  p$width <- png.width 
+                  p$width <- png.width
                   p$height <- png.height
                   plotlyExport(p, PNGFILE, width = p$width, height = p$height, scale=resx)
                 } else if (plotlib == "iheatmapr") {

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -131,7 +131,8 @@ TableModuleUI <- function(id,
               )
          ),
          shiny::tagList(
-           shiny::tags$head(shiny::tags$style(modalfooter.none))
+           shiny::tags$head(shiny::tags$style(modalfooter.none)),
+           shiny::tags$script(src = "dropdown-helper.js")
          )
       ),
       bslib::card_body(
@@ -225,9 +226,9 @@ TableModuleServer <- function(id,
       module <- list(
         data = shiny::reactive(func()$x$data),
         rows_current = shiny::reactive(input$datatable_rows_current),
-        rows_selected = shiny::reactive(input$datatable_rows_selected),        
+        rows_selected = shiny::reactive(input$datatable_rows_selected),
         rows_all = shiny::reactive(input$datatable_rows_all),
-        row_last_clicked = shiny::reactive(input$row_last_clicked),        
+        row_last_clicked = shiny::reactive(input$row_last_clicked),
         rownames_current = shiny::reactive({
           rns <- rownames(func()$x$data)
           if(is.null(rns)) rns <- 1:nrow(func()$x$data)


### PR DESCRIPTION
This closes #398 

## Description
Bug introduced by latest `insertUI` addition. Before, we targeted all the plot/table elements created, with the introduction of `insertUI` we create the plots/tables afterwards, therefore it was not acting on the analysis plots/tables (but yes on the data load ones). More than a problem with `insertUI` it highlights a not-so-good prior implementation.

Now we make sure to target each new plot/table created (so if in the future we dynamically generate some new tabs they will work properly). 