### PR TITLE
fix: cluster features UMAP broken coloring

### DIFF
--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -172,7 +172,6 @@ FeatureMapBoard <- function(id, pgx) {
           cex.legend = 0.9,
           cex.lab = 1.2,
           bty = "n",
-          col = "grey70",
           dlim = c(0.05, 0.05),
           hilight = hmarks,
           hilight2 = NULL,


### PR DESCRIPTION
This closes #403 

## Description
Very simple fix, we were passing a global color for the plot. A recent update on `playbase` seems to have triggered this (I assume it was not properly implemented before).