### PR TITLE
Add option to user add custom gmt files in geneset computation

### DIFF
--- a/bin/pgxcreate_op.R
+++ b/bin/pgxcreate_op.R
@@ -42,6 +42,7 @@ pgx <- playbase::pgx.computePGX(
   max.genesets = params$max.genesets,
   gx.methods = params$gx.methods,
   gset.methods = params$gset.methods,
+  custom.genelists = params$custom.geneset,
   extra.methods = params$extra.methods,
   use.design = params$use.design,        ## no.design+prune are combined
   prune.samples = params$prune.samples,  ##

--- a/bin/pgxcreate_op.R
+++ b/bin/pgxcreate_op.R
@@ -42,7 +42,7 @@ pgx <- playbase::pgx.computePGX(
   max.genesets = params$max.genesets,
   gx.methods = params$gx.methods,
   gset.methods = params$gset.methods,
-  custom.genelists = params$custom.geneset,
+  custom.geneset = params$custom.geneset,
   extra.methods = params$extra.methods,
   use.design = params$use.design,        ## no.design+prune are combined
   prune.samples = params$prune.samples,  ##

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -173,6 +173,11 @@ ComputePgxServer <- function(
                                     choiceValues = EXTRA.METHODS,
                                     choiceNames = EXTRA.NAMES,
                                     selected = EXTRA.SELECTED
+                                ),
+                                fileInput2(
+                                    ns("upload_custom_genesets"),
+                                    shiny::h4("Custom genesets file"),
+                                    multiple = FALSE, accept = c(".csv", ".txt")
                                 )
                             ),
                             shiny::wellPanel(
@@ -229,6 +234,21 @@ ComputePgxServer <- function(
             temp_dir     <- reactiveVal(NULL)
             process_counter <- reactiveVal(0)
             reactive_timer  <- reactiveTimer(20000)  # Triggers every 10000 milliseconds (20 second)
+            custom_genesets <- list()
+
+            shiny::observeEvent(input$upload_custom_genesets, {
+
+                custom_genesets$gmt <- 1
+
+                # check file validity, can be csv or txt
+
+                # save contrasts and genesets info as a list (c)
+
+                # pass it params, and add gsets and  
+
+                # document in readdocs 
+            
+            })
 
             shiny::observeEvent( input$compute, {
                 ## shiny::req(input$upload_hugo,input$upload_filtergenes)

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -187,7 +187,8 @@ ComputePgxServer <- function(
                                             tags$a(
                                                 "here.",
                                                 href = path_gmt,
-                                                target = "_blank"
+                                                target = "_blank",
+                                                style = "text-decoration: underline;"
                                             )
                                         )
                                     ),

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -409,7 +409,11 @@ ComputePgxServer <- function(
                 libx.dir <- paste0(sub("/$","",lib.dir),"x") ## set to .../libx
                 dbg("[ComputePgxModule.R] libx.dir = ",libx.dir)
                 
+                
+                custom.geneset <- list(gmt = custom.genesets$gmt, info = custom.genesets$info)
+                
                 # Define create_pgx function arguments
+                
                 params <- list(
                     samples = samples,
                     counts = counts,
@@ -425,7 +429,7 @@ ComputePgxServer <- function(
                     cluster.contrasts = FALSE,
                     max.genes = max.genes,
                     max.genesets = max.genesets,
-                    custom.genesets = custom.genesets,
+                    custom.geneset = custom.geneset,
                     gx.methods = gx.methods,
                     gset.methods = gset.methods,
                     extra.methods = extra.methods,

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -173,14 +173,14 @@ ComputePgxServer <- function(
                                     choiceValues = EXTRA.METHODS,
                                     choiceNames = EXTRA.NAMES,
                                     selected = EXTRA.SELECTED
-                                ),
+                                )
+                            ),
+                            shiny::wellPanel(
                                 fileInput2(
                                     ns("upload_custom_genesets"),
                                     shiny::h4("Custom genesets file"),
                                     multiple = FALSE, accept = c(".txt")
-                                )
-                            ),
-                            shiny::wellPanel(
+                                ),
                                 shiny::checkboxGroupInput(
                                     ns('dev_options'),
                                     shiny::HTML('<h4>Developer options:</h4><br/>'),

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -180,10 +180,13 @@ ComputePgxServer <- function(
                             shiny::wellPanel(
                                 fileInput2(
                                     ns("upload_custom_genesets"),
-                                    shiny::h4("Custom genesets (.gmt) file:"),
-                                    multiple = FALSE, accept = c(".txt", ".gmt")
+                                    shiny::tagList(
+                                        tags$h4("Custom genesets (.gmt) file:"),
+                                        tags$h6("A GMT file as described", tags$a("here", href = path_gmt))
+                                    ),
+                                    multiple = FALSE,
+                                    accept = c(".txt", ".gmt")
                                 ),
-                                tags$h6("A GMT file as described", tags$a("here", href = path_gmt)),
                                 shiny::checkboxGroupInput(
                                     ns('dev_options'),
                                     shiny::HTML('<h4>Developer options:</h4><br/>'),

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -285,8 +285,6 @@ ComputePgxServer <- function(
 
                 }
 
-                
-
                 # error message if custom genesets not detected
                 if(is.null(custom.geneset$gmt)){
                     shinyWidgets::sendSweetAlert(
@@ -420,9 +418,8 @@ ComputePgxServer <- function(
                 dbg("[ComputePgxModule.R] libx.dir = ",libx.dir)
                 
                 
-                if(!is.null(custom.geneset$gmt)){
-                    custom.geneset <- list(gmt = custom.geneset$gmt, info = custom.geneset$info)
-                }
+                # get rid of reactive container
+                custom.geneset <- list(gmt = custom.geneset$gmt, info = custom.geneset$info)
                 
                 
                 # Define create_pgx function arguments
@@ -457,8 +454,9 @@ ComputePgxServer <- function(
                     this.date = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
                     date = this.date
                 )
-                saveRDS(params, file=path_to_params)
 
+                saveRDS(params, file=path_to_params)
+                
                 # Normalize paths
                 script_path <- normalizePath(file.path(get_opg_root(), "bin", "pgxcreate_op.R"))
                 tmpdir <- normalizePath(temp_dir())

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -61,6 +61,8 @@ ComputePgxServer <- function(
             DEV.NAMES = c("noLM + prune")
             DEV.SELECTED = c()
 
+            path_gmt <- "https://omicsplayground.readthedocs.io/en/latest/"
+
             output$UI <- shiny::renderUI({
                 shiny::fillCol(
                     height = height,
@@ -178,9 +180,10 @@ ComputePgxServer <- function(
                             shiny::wellPanel(
                                 fileInput2(
                                     ns("upload_custom_genesets"),
-                                    shiny::h4("Custom genesets file"),
-                                    multiple = FALSE, accept = c(".txt")
+                                    shiny::h4("Custom genesets (.gmt) file:"),
+                                    multiple = FALSE, accept = c(".txt", ".gmt")
                                 ),
+                                tags$h6("A GMT file as described", tags$a("here", href = path_gmt)),
                                 shiny::checkboxGroupInput(
                                     ns('dev_options'),
                                     shiny::HTML('<h4>Developer options:</h4><br/>'),
@@ -242,30 +245,24 @@ ComputePgxServer <- function(
 
                 fileName <- input$upload_custom_genesets$name
 
-                # check file validity, can be csv or txt
-
-                if(endsWith(filePath, ".txt")){
+                if(endsWith(filePath, ".txt") || endsWith(filePath, ".gmt")){
                     
                     custom.geneset$gmt <- playbase::read.gmt(filePath)
-
-
                     # perform some basic checks
                     gmt.length <- length(custom.geneset$gmt)
                     gmt.is.list <- is.list(custom.geneset$gmt)
 
                     # clean genesets
 
+                    # eventually we can add multiple files, but for now we only support one
+                    # just add more gmts to the list below
                     custom.geneset$gmt <- list(CUSTOM = custom.geneset$gmt)
 
                     # convert gmt to OPG standard
-                    # eventually we can add multiple files, but for now we only support one
-
                     custom.geneset$gmt <- playbase::clean_gmt(custom.geneset$gmt,"CUSTOM")
 
                     # compute custom geneset stats
-
                     custom.geneset$gmt <- custom.geneset$gmt[!duplicated(names(custom.geneset$gmt))]
-                
                     custom.geneset$info$GSET_SIZE <- sapply(custom.geneset$gmt,length)
                 
                     # tell user that custom genesets are "ok"

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -248,6 +248,28 @@ ComputePgxServer <- function(
 
                 if(endsWith(filePath, ".txt")){
                     custom.genesets$gmt <- playbase::read.gmt(filePath)
+
+
+                    # perform some basic checks
+                    gmt.length <- length(custom.genesets$gmt)
+                    gmt.is.list <- is.list(custom.genesets$gmt)
+
+
+                    # tell user that custom genesets are "ok"
+                    # we could perform an addicional check to verify that items in lists are genes
+                    if(gmt.length > 0 && gmt.is.list){
+                        ?shinyWidgets::sendSweetAlert(
+                            session = session,
+                            title = "Custom genesets uploaded!",
+                            text = "Your genesets will be incorporated in the analysis.",
+                            type = "success",
+                            btn_labels = "OK",
+                            ## btn_colors = "red",
+                            closeOnClickOutside = TRUE
+                            )
+
+                    }
+
                 }
 
                 # error message if custom genesets not detected
@@ -255,7 +277,7 @@ ComputePgxServer <- function(
                     shinyWidgets::sendSweetAlert(
                         session = session,
                         title = "Invalid custom genesets",
-                        text = "Please update a .csv or .txt file. See guidelines here <PLACEHOLDER>.",
+                        text = "Please update a .txt file. See guidelines here <PLACEHOLDER>.",
                         type = "error",
                         btn_labels = "OK",
                         ## btn_colors = "red",
@@ -271,10 +293,6 @@ ComputePgxServer <- function(
                 
                 custom.genesets$info$GSET_SIZE <- sapply(custom.genesets$gmt,length)
 
-                # pass it params, and add gsets and  
-
-                # document in readdocs 
-            
             })
 
             shiny::observeEvent( input$compute, {

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -177,7 +177,7 @@ ComputePgxServer <- function(
                                 fileInput2(
                                     ns("upload_custom_genesets"),
                                     shiny::h4("Custom genesets file"),
-                                    multiple = FALSE, accept = c(".csv", ".txt")
+                                    multiple = FALSE, accept = c(".txt")
                                 )
                             ),
                             shiny::wellPanel(
@@ -245,12 +245,6 @@ ComputePgxServer <- function(
                 fileName <- input$upload_custom_genesets$name
 
                 # check file validity, can be csv or txt
-
-                # check if file is csv
-
-                if(endsWith(filePath, ".csv")){
-                    custom.genesets$gmt <- read.csv(filePath, check.names = FALSE, stringsAsFactors = FALSE)
-                }
 
                 if(endsWith(filePath, ".txt")){
                     custom.genesets$gmt <- playbase::read.gmt(filePath)

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -408,7 +408,7 @@ ComputePgxServer <- function(
                 creator <- session$user
                 libx.dir <- paste0(sub("/$","",lib.dir),"x") ## set to .../libx
                 dbg("[ComputePgxModule.R] libx.dir = ",libx.dir)
-                browser()
+                
                 # Define create_pgx function arguments
                 params <- list(
                     samples = samples,

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -279,13 +279,11 @@ ComputePgxServer <- function(
                     # tell user that custom genesets are "ok"
                     # we could perform an addicional check to verify that items in lists are genes
                     if(gmt.length > 0 && gmt.is.list){
-                        shinyWidgets::sendSweetAlert(
-                            session = session,
+
+                      shinyalert::shinyalert(
                             title = "Custom genesets uploaded!",
                             text = "Your genesets will be incorporated in the analysis.",
                             type = "success",
-                            btn_labels = "OK",
-                            ## btn_colors = "red",
                             closeOnClickOutside = TRUE
                         )
 
@@ -295,13 +293,10 @@ ComputePgxServer <- function(
 
                 # error message if custom genesets not detected
                 if(is.null(custom.geneset$gmt)){
-                    shinyWidgets::sendSweetAlert(
-                        session = session,
+                      shinyalert::shinyalert(                  
                         title = "Invalid custom genesets",
                         text = "Please update a .txt file. See guidelines here <PLACEHOLDER>.",
                         type = "error",
-                        btn_labels = "OK",
-                        ## btn_colors = "red",
                         closeOnClickOutside = TRUE
                     )
                     custom.geneset <- list(gmt = NULL, info = NULL)

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -234,11 +234,9 @@ ComputePgxServer <- function(
             temp_dir     <- reactiveVal(NULL)
             process_counter <- reactiveVal(0)
             reactive_timer  <- reactiveTimer(20000)  # Triggers every 10000 milliseconds (20 second)
-            custom.genesets <- list()
+            custom.genesets <- reactiveValues(gmt = NULL, info = NULL)
 
             shiny::observeEvent(input$upload_custom_genesets, {
-
-                browser()
 
                 filePath <- input$upload_custom_genesets$datapath
 
@@ -247,6 +245,7 @@ ComputePgxServer <- function(
                 # check file validity, can be csv or txt
 
                 if(endsWith(filePath, ".txt")){
+                    
                     custom.genesets$gmt <- playbase::read.gmt(filePath)
 
 
@@ -254,11 +253,11 @@ ComputePgxServer <- function(
                     gmt.length <- length(custom.genesets$gmt)
                     gmt.is.list <- is.list(custom.genesets$gmt)
 
-
+                    
                     # tell user that custom genesets are "ok"
                     # we could perform an addicional check to verify that items in lists are genes
                     if(gmt.length > 0 && gmt.is.list){
-                        ?shinyWidgets::sendSweetAlert(
+                        shinyWidgets::sendSweetAlert(
                             session = session,
                             title = "Custom genesets uploaded!",
                             text = "Your genesets will be incorporated in the analysis.",
@@ -266,14 +265,14 @@ ComputePgxServer <- function(
                             btn_labels = "OK",
                             ## btn_colors = "red",
                             closeOnClickOutside = TRUE
-                            )
+                        )
 
                     }
 
                 }
 
                 # error message if custom genesets not detected
-                if(length(custom.genesets)==0){
+                if(is.null(custom.genesets$gmt)){
                     shinyWidgets::sendSweetAlert(
                         session = session,
                         title = "Invalid custom genesets",
@@ -409,7 +408,7 @@ ComputePgxServer <- function(
                 creator <- session$user
                 libx.dir <- paste0(sub("/$","",lib.dir),"x") ## set to .../libx
                 dbg("[ComputePgxModule.R] libx.dir = ",libx.dir)
-                
+                browser()
                 # Define create_pgx function arguments
                 params <- list(
                     samples = samples,

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -426,7 +426,7 @@ ComputePgxServer <- function(
                 
                 
                 # Define create_pgx function arguments
-                browser()
+                
                 params <- list(
                     samples = samples,
                     counts = counts,

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -181,8 +181,15 @@ ComputePgxServer <- function(
                                 fileInput2(
                                     ns("upload_custom_genesets"),
                                     shiny::tagList(
-                                        tags$h4("Custom genesets (.gmt) file:"),
-                                        tags$h6("A GMT file as described", tags$a("here", href = path_gmt))
+                                        shiny::tags$h4("Custom genesets (.gmt) file:"),
+                                        shiny::tags$h6(
+                                            "A GMT file as described", 
+                                            tags$a(
+                                                "here.",
+                                                href = path_gmt,
+                                                target = "_blank"
+                                            )
+                                        )
                                     ),
                                     multiple = FALSE,
                                     accept = c(".txt", ".gmt")

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -298,7 +298,7 @@ ComputePgxServer <- function(
                         ## btn_colors = "red",
                         closeOnClickOutside = TRUE
                     )
-                    custom.geneset <- list()
+                    custom.geneset <- list(gmt = NULL, info = NULL)
                     return(NULL)
                 }
 
@@ -420,7 +420,10 @@ ComputePgxServer <- function(
                 dbg("[ComputePgxModule.R] libx.dir = ",libx.dir)
                 
                 
-                custom.geneset <- list(gmt = custom.geneset$gmt, info = custom.geneset$info)
+                if(!is.null(custom.geneset$gmt)){
+                    custom.geneset <- list(gmt = custom.geneset$gmt, info = custom.geneset$info)
+                }
+                
                 
                 # Define create_pgx function arguments
                 browser()


### PR DESCRIPTION
**WARNING:** this PR is linked to the `dev-custom-gmt` in playbase and playdata.
https://github.com/bigomics/playbase/pull/12
https://github.com/bigomics/playdata/pull/4

**Improvements:**
- users can now add their own or a specific gmt file that is not present in OPG. That can be done within OPG or externally (very easy) with playbase.
- wrap gmt processing code into functions so they can be reused, shift code from playdata to playbase. This allows processing gmt files directly in playbase, aimed at developers and on demand applications.
- create an UI upload element for uploading GMT files (only 1x `.txt` or `.gmt` file allowed)
- perform checks to make sure gmt file is valid
- gmt files are geneset storage format with a formal definition, we currently only accept gmt files in their custom `.txt` or `.gmt` format.
- to create a gmt file, several tutorials are available in R and elsewhere. I will describe briefly in readthedocs and extensively in the wiki for developers.

**Possible future developments:**
- allow ability to add many gmt files (today limited to one). This will be very easy, but I decided to keep only 1 since they will have the "CUSTOM:" tag before it. If we decide for more files, we might need to switch from "CUSTOM:" to some sort of file name. That can be easily done (2-3 lines of code) in the upload module.
- add more tests that check gmt file is valid
- As soon as this gets approved, I will document process in the wiki (for devs) and readthedocs (for dummies).
- convert well panel "options" to cards.

**Tested with:**
example data and progeria datasets with and without custom GMTs.

related to issue #92