### PR TITLE
Fix #412 Cannot download Wikipathways and Reactome figures from V3

### DIFF
--- a/components/board.pathway/R/functional_plot_reactome_graph.R
+++ b/components/board.pathway/R/functional_plot_reactome_graph.R
@@ -28,16 +28,11 @@ functional_plot_reactome_graph_ui <- function(
     id = ns("plotmodule"),
     title = title,
     label = label,
-    ##    plotlib = "image",
-    plotlib = "generic",
-    plotlib2 = "generic",
-    outputFunc = svgPanZoom::svgPanZoomOutput,
-    outputFunc2 = svgPanZoom::svgPanZoomOutput,
+    plotlib = "svgPanZoom",
     info.text = info.text,
     info.width = info.width,
     options = NULL,
-    download.fmt = NULL,
-    # download.fmt = c("png","csv"),
+    download.fmt = c("png","pdf"),
     height = height,
     width = width
   )
@@ -213,12 +208,8 @@ functional_plot_reactome_graph_server <- function(id,
 
       PlotModuleServer(
         "plotmodule",
-        plotlib = "generic",
         func = plot_RENDER,
-        func2 = plot_RENDER,
-        renderFunc = svgPanZoom::renderSvgPanZoom,
-        renderFunc2 = svgPanZoom::renderSvgPanZoom,
-        ## csvFunc = plot_data,
+        plotlib = "svgPanZoom",
         add.watermark = watermark
       )
 

--- a/components/board.pathway/R/functional_plot_wikipathway_graph.R
+++ b/components/board.pathway/R/functional_plot_wikipathway_graph.R
@@ -28,16 +28,11 @@ functional_plot_wikipathway_graph_ui <- function(
     id = ns("plotmodule"),
     title = title,
     label = label,
-    ##    plotlib = "image",
-    plotlib = "generic",
-    plotlib2 = "generic",
-    outputFunc = svgPanZoom::svgPanZoomOutput,
-    outputFunc2 = svgPanZoom::svgPanZoomOutput,
+    plotlib = "svgPanZoom",
     info.text = info.text,
     info.width = info.width,
     options = NULL,
-    download.fmt = NULL,
-    # download.fmt = c("png","csv"),
+    download.fmt = c("png", "pdf"),
     height = height,
     width = width
   )
@@ -176,12 +171,8 @@ functional_plot_wikipathway_graph_server <- function(id,
 
       PlotModuleServer(
         "plotmodule",
-        plotlib = "generic",
+        plotlib = "svgPanZoom",
         func = plot_RENDER,
-        func2 = plot_RENDER,
-        renderFunc = svgPanZoom::renderSvgPanZoom,
-        renderFunc2 = svgPanZoom::renderSvgPanZoom,
-        ## csvFunc = plot_data,
         add.watermark = watermark
       )
 

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -526,18 +526,17 @@ PlotModuleServer <- function(id,
                   p <- func()
                   iheatmapr::save_iheatmap(p, vwidth = png.width, vheight = png.height, PNGFILE)
                 } else if (plotlib == "visnetwork") {
-                  # download will not work if phantomjs is not installed
-                  # webshot::install_phantomjs() in case phantomjs is not installed
                   p <- func()
-                  #dbg("[plotModule] visnetwork download PNG : visSave : HTMLFILE=", HTMLFILE)
-                  #visNetwork::visSave(p, HTMLFILE)
-                  #dbg("[plotModule] visnetwork download PNG : webshot : PNGFILE = ", PNGFILE)
-                  #webshot::webshot(url = HTMLFILE, file = PNGFILE, vwidth = png.width, vheight = png.height)
-                  visPrint(p, file=PNGFILE, width=png.width*resx*2, height=png.height*resx*2, delay=vis.delay, zoom=1) 
+                  visPrint(p, file=PNGFILE,
+                    width = png.width*resx*2,
+                    height = png.height*resx*2,
+                    delay = vis.delay,
+                    zoom = 1) 
                 } else if (plotlib %in% c("htmlwidget", "pairsD3", "scatterD3")) {
                   p <- func()
                   htmlwidgets::saveWidget(p, HTMLFILE)
-                  webshot::webshot(url = HTMLFILE, file = PNGFILE, vwidth = png.width, vheight = png.height)
+                  webshot2::webshot(url = HTMLFILE, file = PNGFILE,
+                    vwidth = png.width*resx, vheight = png.height*resx)
                 } else if (plotlib %in% c("ggplot", "ggplot2")) {
                   ggplot2::ggsave(PNGFILE, plot = func(), dpi = 72*resx)
                 } else if (plotlib == "grid") {
@@ -573,7 +572,8 @@ PlotModuleServer <- function(id,
                 } else if (plotlib == "svgPanZoom") {
                   p <- func()
                   htmlwidgets::saveWidget(p, HTMLFILE)
-                  webshot::webshot(url = HTMLFILE, file = PNGFILE, vwidth = png.width, vheight = png.height)
+                  webshot2::webshot(url = HTMLFILE, file = PNGFILE,
+                    vwidth = png.width, vheight = png.height, zoom=4)
                 } else { ## end base
 
                   png(PNGFILE, pointsize = pdf.pointsize)
@@ -589,8 +589,7 @@ PlotModuleServer <- function(id,
                 if (TRUE && !add.watermark %in% c("none",FALSE) ) {
                   message("[plotModule] adding watermark to PNG...")
                   markfile = file.path(FILES, "watermark-logo.png")
-                  addWatermark.PNG2(file, w=png.width*resx, h=png.height*resx,
-                                    mark=markfile, position=add.watermark)
+                  addWatermark.PNG2(file, mark=markfile, position=add.watermark)
                 }
               },
               message = "Exporting to PNG",
@@ -622,15 +621,11 @@ PlotModuleServer <- function(id,
                   iheatmapr::save_iheatmap(p, vwidth = pdf.width * 80, vheight = pdf.height * 80, PDFFILE)
                 } else if (plotlib == "visnetwork") {
                   p <- func()
-                  #dbg("[plotModule] visnetwork :: download PDF : visSave : HTMLFILE=", HTMLFILE)
-                  #visNetwork::visSave(p, HTMLFILE)
-                  #dbg("[plotModule] visnetwork :: download PDF : webshot ; PDFFILE=", PDFFILE)
-                  #webshot::webshot(url = HTMLFILE, file = PDFFILE, vwidth = pdf.width * 100, vheight = pdf.height * 100)
                   visPrint(p, file=PDFFILE, width=pdf.width, height=pdf.height, delay=vis.delay, zoom=1)                   
                 } else if (plotlib %in% c("htmlwidget", "pairsD3", "scatterD3")) {
                   p <- func()
                   htmlwidgets::saveWidget(p, HTMLFILE)
-                  webshot::webshot(url = HTMLFILE, file = PDFFILE, vwidth = pdf.width * 100, vheight = pdf.height * 100)
+                  webshot2::webshot(url = HTMLFILE, file = PDFFILE, vwidth = pdf.width * 100, vheight = pdf.height * 100)
                 } else if (plotlib %in% c("ggplot", "ggplot2")) {
                   p <- func()
                   pdf(PDFFILE, width = pdf.width, height = pdf.height, pointsize = pdf.pointsize)
@@ -659,7 +654,8 @@ PlotModuleServer <- function(id,
                 } else if (plotlib == "svgPanZoom") {
                   p <- func()
                   htmlwidgets::saveWidget(p, HTMLFILE)
-                  webshot::webshot(url = HTMLFILE, file = PDFFILE, vwidth = pdf.width * 100, vheight = pdf.height * 100)
+                  webshot2::webshot(url = HTMLFILE, file = PDFFILE,
+                    vwidth = pdf.width * 100, vheight = pdf.height * 100)
                 } else { ## end base
                   pdf(PDFFILE, pointsize = pdf.pointsize)
                   plot.new()
@@ -674,7 +670,6 @@ PlotModuleServer <- function(id,
                 ## ImageMagick or pdftk
                 if (TRUE && !add.watermark %in% c(FALSE,"none")) {
                   message("[plotModule] adding watermark to PDF...")
-                  ##addWatermark.PDF(file)
                   markfile = file.path(FILES, "watermark-logo.pdf")
                   addWatermark.PDF2(file, w=pdf.width, h=pdf.height, mark=markfile)
                 }
@@ -1113,9 +1108,9 @@ plotlyExport <- function(p, file = "plot.pdf", format = tools::file_ext(file),
     if(0 && !export.ok) {
         tmp = paste0(tempfile(),".html")
         htmlwidgets::saveWidget(p, tmp)
-        err <- try(webshot::webshot(url=tmp,file=file,vwidth=width*100, vheight=height*100))
+        err <- try(webshot2::webshot(url=tmp,file=file,vwidth=width*100, vheight=height*100))
         export.ok <- class(err)!="try-error"
-        if(export.ok) message("[plotlyExport] --> exported with webshot::webshot()")
+        if(export.ok) message("[plotlyExport] --> exported with webshot2::webshot()")
     }
     if(!export.ok) {
         message("[plotlyExport] WARNING: export failed!")

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -55,6 +55,7 @@ PlotModuleUI <- function(id,
       iheatmapr = iheatmapr::iheatmaprOutput,
       image = shiny::imageOutput,
       base = shiny::plotOutput,
+      svgPanZoom = svgPanZoom::svgPanZoomOutput,
       shiny::plotOutput
     )
     FUN
@@ -569,6 +570,10 @@ PlotModuleServer <- function(id,
                   )
                   print(func())
                   dev.off() ## important!!
+                } else if (plotlib == "svgPanZoom") {
+                  p <- func()
+                  htmlwidgets::saveWidget(p, HTMLFILE)
+                  webshot::webshot(url = HTMLFILE, file = PNGFILE, vwidth = png.width, vheight = png.height)
                 } else { ## end base
 
                   png(PNGFILE, pointsize = pdf.pointsize)
@@ -651,6 +656,10 @@ PlotModuleServer <- function(id,
                   )
                   print(func())
                   dev.off() ## important!!
+                } else if (plotlib == "svgPanZoom") {
+                  p <- func()
+                  htmlwidgets::saveWidget(p, HTMLFILE)
+                  webshot::webshot(url = HTMLFILE, file = PDFFILE, vwidth = pdf.width * 100, vheight = pdf.height * 100)
                 } else { ## end base
                   pdf(PDFFILE, pointsize = pdf.pointsize)
                   plot.new()
@@ -702,6 +711,9 @@ PlotModuleServer <- function(id,
           ##
         } else if (plotlib == "base") {
           write("<body>R base plots cannot export to HTML</body>", HTMLFILE)
+        } else if (plotlib == "svgPanZoom") {
+          p <- func()
+          htmlwidgets::saveWidget(p, HTMLFILE)
         } else { ## end base
           write("<body>HTML export error</body>", file = HTMLFILE)
         }
@@ -886,6 +898,7 @@ PlotModuleServer <- function(id,
           iheatmapr = iheatmapr::renderIheatmap,
           image = shiny::renderImage,
           base = shiny::renderPlot,
+          svgPanZoom = svgPanZoom::renderSvgPanZoom,
           shiny::renderPlot
         )
       }

--- a/components/ui/ui-utils.R
+++ b/components/ui/ui-utils.R
@@ -59,12 +59,14 @@ addWatermark.PDF <- function(file) {
 }
 
 
-addWatermark.PNG2 <- function(file,
-                              w, h, out=file,
+addWatermark.PNG2 <- function(file, out=file,
                               mark=file.path(FILES,"watermark-logo.png"),
                               logo.scale=0.045, position="topright") {
     if(system("which convert",ignore.stdout=TRUE)==1) return ## if no pdftk installed...
     if(position %in% c(FALSE,"none")) return
+    img=png::readPNG(file)
+    w=dim(img)[2]
+    h=dim(img)[1]
     tmp <- paste0(gsub("file","plot",tempfile()),".png")
     logo.height = max(logo.scale*h , logo.scale*w/3)
     logo.width = logo.height * 4


### PR DESCRIPTION
This closes #412 

## Description
Added new `plotlib` for `svgPanZoom` objects. Added download handlers. Since those are basically `htmlwidgets` it is better to download the PDFs for better resolution.

Simple example: 
[example.pdf](https://github.com/bigomics/omicsplayground/files/11585062/example.pdf)
