### PR TITLE
Fix #406 Hidden sidebar tabs still show their horizontal rule

### DIFF
--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -412,10 +412,12 @@ Shiny.addCustomMessageHandler('bigdash-select-tab', (msg) => {
 
 Shiny.addCustomMessageHandler('bigdash-hide-menuitem', (msg) => {
     $(`.tab-trigger[data-target=${msg.value}]`).hide();
+    $(`.tab-trigger-hr[data-target=${msg.value}]`).hide();
 });
 
 Shiny.addCustomMessageHandler('bigdash-show-menuitem', (msg) => {
     $(`.tab-trigger[data-target=${msg.value}]`).show();
+	$(`.tab-trigger-hr[data-target=${msg.value}]`).show();
 });
 
 Shiny.addCustomMessageHandler('bigdash-hide-tab', (msg) => {


### PR DESCRIPTION
This closes #406 

## Description
Only the text boxes were being hidden when hiding beta tabs, the `hr` was left visible. Causing the UI bug: 
![image](https://github.com/bigomics/omicsplayground/assets/10220503/e1a815f4-5638-4ec4-93f7-82eb75a59238)

There is a linked PR on `bigdash` that adds the required `data-target` and `class` in order to target them from the JS. https://github.com/bigomics/bigdash/pull/17

Now, the menu looks like this:
![image](https://github.com/bigomics/omicsplayground/assets/10220503/a839910c-33f1-4200-ac63-c57c4181fd4f)

When testing this PR, make sure to clean the cache, as there is new JS (ctrl+F5)