### PR TITLE
test: scroll zoom on plotly

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -955,7 +955,10 @@ PlotModuleServer <- function(id,
           render <- renderFunc({
             # By default remove plotly logo from all plots
             plot <- func() %>%
-              plotly::config(displaylogo = FALSE) %>%
+              plotly::config(
+                displaylogo = FALSE,
+                scrollZoom = TRUE
+              ) %>%
               plotly::plotly_build()
 
             if (remove_margins == TRUE) {
@@ -996,7 +999,10 @@ PlotModuleServer <- function(id,
           render2 <- renderFunc2({
             # By default remove plotly logo from all plots
             plot <- func2() %>%
-              plotly::config(displaylogo = FALSE) %>%
+              plotly::config(
+                displaylogo = FALSE,
+                scrollZoom = TRUE
+              ) %>%
               plotly::plotly_build()
             # If there is already custom buttons, append the edit one
             # (issue #2210 plotly/plotly.R)


### PR DESCRIPTION
This closes #371 

## Description
I have implemented the scroll feature for all plotly plots in this PR. Please test it, if you like how it works on the app let's merge it.

For some plots maybe this feature brings no value / diminishes the user experience, if that is the case we could add a new flag to the PlotModule to activate this feature casewise.