### PR TITLE
Fix wordcloud #426

### DIFF
--- a/components/board.wordcloud/R/wordcloud_server.R
+++ b/components/board.wordcloud/R/wordcloud_server.R
@@ -57,7 +57,19 @@ WordCloudBoard <- function(id, pgx) {
 
       contr <- input$wc_contrast
       gsea1 <- res$gsea[[contr]]
+      
+      # sometimes we have words that NA is tsne, make sure we remove them (likely special characters) in windows or wsl
+      res$tsne <- res$tsne[!is.na(rownames(res$tsne)),]
+      res$umap <- res$umap[!is.na(rownames(res$umap)),]
+      
+      ordered_words <- gsea1$word
+      res$tsne <- res$tsne[ordered_words,]
+      res$umap <- res$umap[ordered_words,]
+
+      # end sometimes we have words that NA is tsne, make sure we remove them (likely special characters) in windows or wsl
+
       topFreq <- data.frame(gsea1, tsne = res$tsne, umap = res$umap)
+      
       topFreq <- topFreq[order(-topFreq$NES), ]
 
       return(topFreq)


### PR DESCRIPTION
- linked to https://github.com/bigomics/playbase/pull/14
- this issue happens when I compute in wsl but not windows, likely special characters in genesets. I get NA in tsne and UMAP for some words.
- Solution: remove NAs and reorder the data frames.

this fixed #426