### PR TITLE
Fix #452: plotmodule has too much bottom padding with bslib update

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -297,6 +297,7 @@ PlotModuleUI <- function(id,
     style = paste0("height:", height.1, ";overflow: visible;"),
     bslib::as.card_item(div(header)),
     bslib::card_body(
+      gap = "0px",
       if (cards) {
         plot_cards$content
       } else {


### PR DESCRIPTION
This closes #452 

## Description

On a PlotModule instance we have three different elements inside the `bslib::card_body`. The [plot](https://github.com/bigomics/omicsplayground/blob/master/components/ui/ui-PlotModule.R#L300-L304), the [modal](https://github.com/bigomics/omicsplayground/blob/master/components/ui/ui-PlotModule.R#L305-L314) and the plot [editor](https://github.com/bigomics/omicsplayground/blob/master/components/ui/ui-PlotModule.R#L331-L340). The `gap` argument controls the distance between the different elements of a `bslib::card_body`, in our case, we have three elements but only the first is being displayed, therefore we have the plot + 2 gaps (Figure 1). By setting the `gap` argument to `0px`, we achieve the expected result (Figure 2).

**Figure 1:**
![image](https://github.com/bigomics/omicsplayground/assets/10220503/6444b5d9-33cd-4efb-aef7-bee079893126)

**Figure 2:**
![image](https://github.com/bigomics/omicsplayground/assets/10220503/36e32242-5188-43ab-8d0d-13eebce9fde8)
