### PR TITLE
Fix #422: Gene UMAP not displaying mouse gene acronyms in V3.11 and V3 (3.0.RC6.230.426)

### DIFF
--- a/components/board.featuremap/R/featuremap_plot_table_gene_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_gene_map.R
@@ -84,7 +84,6 @@ featuremap_plot_gene_map_server <- function(id,
     })
 
     plot_data <- shiny::reactive({
-
       ## pos <- pgx$cluster.genes$pos[['umap2d']]
       pos <- getGeneUMAP()
       colnames(pos) <- c("x","y")
@@ -200,12 +199,14 @@ featuremap_plot_gene_map_server <- function(id,
       if(!r_fulltable()) {
         if(!is.null(sel.genes)) {
           filt.genes <- selGenes()
-          sel.genes <- intersect(sel.genes, filt.genes)
+          sel.genes_aux <- match(filt.genes |> stringr::str_to_upper(), sel.genes |> stringr::str_to_upper())
+          sel.genes_aux <- sel.genes_aux[!is.na(sel.genes_aux)]
+          sel.genes <- sel.genes[sel.genes_aux]
         } else {
           sel.genes <- selGenes()
         }
       }
-      
+
       pheno <- "tissue"
       pheno <- sigvar()
       is.fc <- FALSE

--- a/components/board.featuremap/R/featuremap_plot_table_gene_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_gene_map.R
@@ -76,18 +76,18 @@ featuremap_plot_gene_map_server <- function(id,
 
     ns <- session$ns
 
-    selGenes <- shiny::reactive({
+    filteredGenes <- shiny::reactive({
       shiny::req(pgx)
       sel <- filter_genes()
-      selgenes <- playdata::FAMILIES[[sel]]
-      selgenes
+      filtgenes <- playdata::FAMILIES[[sel]]
+      filtgenes
     })
 
     plot_data <- shiny::reactive({
       ## pos <- pgx$cluster.genes$pos[['umap2d']]
       pos <- getGeneUMAP()
       colnames(pos) <- c("x","y")
-      hilight <- selGenes()
+      hilight <- filteredGenes()
       colgamma <- as.numeric(input$umap_gamma)
       colorby <- input$umap_colorby
       nlabel <- as.integer(input$umap_nlabel)
@@ -198,12 +198,12 @@ featuremap_plot_gene_map_server <- function(id,
 
       if(!r_fulltable()) {
         if(!is.null(sel.genes)) {
-          filt.genes <- selGenes()
+          filt.genes <- filteredGenes()
           sel.genes_aux <- match(filt.genes |> stringr::str_to_upper(), sel.genes |> stringr::str_to_upper())
           sel.genes_aux <- sel.genes_aux[!is.na(sel.genes_aux)]
           sel.genes <- sel.genes[sel.genes_aux]
         } else {
-          sel.genes <- selGenes()
+          sel.genes <- filteredGenes()
         }
       }
 

--- a/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
@@ -82,7 +82,7 @@ featuremap_plot_table_geneset_map_server <- function(id,
     ##
     ns <- session$ns
 
-    selGsets <- shiny::reactive({
+    filteredGsets <- shiny::reactive({
       shiny::req(pgx)
       db <- filter_gsets()
       gsets <- rownames(pgx$gsetX)
@@ -96,7 +96,7 @@ featuremap_plot_table_geneset_map_server <- function(id,
       pos <- getGsetUMAP()
       colnames(pos) <- c("x","y")
 
-      hilight <- selGsets()
+      hilight <- filteredGsets()
       colgamma <- as.numeric(input$gsmap_gamma)
       nlabel <- as.integer(input$gsmap_nlabel)
       colorby <- input$gsmap_colorby
@@ -206,10 +206,10 @@ featuremap_plot_table_geneset_map_server <- function(id,
 
       if(!r_fulltable()) {
         if (!is.null(sel.gsets)) {
-          filt.gsets <- selGsets()
+          filt.gsets <- filteredGsets()
           sel.gsets <- intersect(sel.gsets, filt.gsets)
         } else {
-          sel.gsets <- selGsets()
+          sel.gsets <- filteredGsets()
         }
       }
       

--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -69,11 +69,10 @@ FeatureMapBoard <- function(id, pgx) {
     ## hilight=hilight2=NULL;source="";plotlib='base';cex=0.9
     plotUMAP <- function(pos, var, hilight = NULL, nlabel = 20, title = "",
                          zlim = NULL, cex = 0.9, cex.label = 1, source = "", plotlib = "base") {
-
       if (!is.null(hilight)) {
-
-          hilight <- intersect(hilight, rownames(pos))
-          hilight <- intersect(hilight, names(var))
+          hilight <- match(hilight |> stringr::str_to_upper(), names(var) |> stringr::str_to_upper())
+          hilight <- hilight[!is.na(hilight)]
+          hilight <- names(var)[hilight]
           hilight <- hilight[order(-var[hilight])]
 
           if (min(var, na.rm = TRUE) < 0) {


### PR DESCRIPTION
This closes #422 

## Description
There was a mismatch due to different capitalization on mouse genes. I have used `str_to_upper` to solve it. I first get the indexes to use the correctly capitalized strings downstream. I am not 100% sure this approach is OK. We can discuss it before merging.