### PR TITLE
Input files cleaning and warnings moved to playbase

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -267,7 +267,6 @@ UploadBoard <- function(id,
             IS_EXPRESSION <- grepl("expression", fn1, ignore.case = TRUE)
             IS_SAMPLE <- grepl("sample", fn1, ignore.case = TRUE)
             IS_CONTRAST <- grepl("contrast", fn1, ignore.case = TRUE)
-            
             if (IS_COUNT || IS_EXPRESSION) {
               ## allows duplicated rownames
               df0 <- playbase::read.as_matrix(fn2)
@@ -291,12 +290,12 @@ UploadBoard <- function(id,
             }
 
             if (COUNTS_check$PASS && IS_COUNT) {
-                df <- as.matrix(df0$df)
+                df <- as.matrix(COUNTS_check$df)
                 matname <- "counts.csv"
               }
 
               if (COUNTS_check$PASS && IS_EXPRESSION) {
-                df <- as.matrix(df0$df)
+                df <- as.matrix(COUNTS_check$df)
                 message("[UploadModule::upload_files] converting expression to counts...")
                 df <- 2**df
                 matname <- "counts.csv"
@@ -324,7 +323,7 @@ UploadBoard <- function(id,
             }
 
             if (SAMPLES_check$PASS && IS_SAMPLE) {
-                df <- as.data.frame(df0$df)
+                df <- as.data.frame(SAMPLE_check$df)
                 matname <- "samples.csv"
               }
             
@@ -350,7 +349,7 @@ UploadBoard <- function(id,
             }
 
             if (CONTRAST_check$PASS && IS_CONTRAST) {
-                df <- as.matrix(df0)
+                df <- as.matrix(CONTRAST_check$df)
                 matname <- "contrasts.csv"
               }
 
@@ -361,6 +360,8 @@ UploadBoard <- function(id,
           }
         }
       }
+
+      browser()
 
       ## put the matrices in the reactive values 'uploaded'
       files.needed <- c("counts.csv", "samples.csv", "contrasts.csv")

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -278,11 +278,12 @@ UploadBoard <- function(id,
                   error_id <- names(COUNTS_check$check)[idx]
                   error_log <- COUNTS_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
+                  error_length <- length(error_log)
                   ifelse(length(error_log) > 5, error_log <- error_log[1:5], error_log)
 
                   shinyalert::shinyalert(
                     title = error_detail$title,
-                    text = paste(error_detail$message,"\n", paste(error_log, collapse = " "), sep = " "),
+                    text = paste(error_detail$message,"\n",paste(error_length, "cases identified, examples:"), paste(error_log, collapse = " "), sep = " "),
                     type = error_detail$warning_type,
                     closeOnClickOutside = FALSE
                   )

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -258,7 +258,6 @@ UploadBoard <- function(id,
         error_list <- playbase::PGX_CHECKS
 
         if (length(uploadnames) > 0) {
-          i <- 1
           for (i in 1:length(uploadnames)) {
             fn1 <- inputnames[i]
             fn2 <- uploadnames[i]
@@ -289,8 +288,9 @@ UploadBoard <- function(id,
                   )
                 })
               }
+            }
 
-              if (COUNTS_check$PASS && IS_COUNT) {
+            if (COUNTS_check$PASS && IS_COUNT) {
                 df <- as.matrix(df0$df)
                 matname <- "counts.csv"
               }
@@ -301,7 +301,6 @@ UploadBoard <- function(id,
                 df <- 2**df
                 matname <- "counts.csv"
               }
-            }
 
             if (IS_SAMPLE) {
               df0 <- playbase::read.as_matrix(fn2)
@@ -322,13 +321,12 @@ UploadBoard <- function(id,
                   )
                 })
               }
+            }
 
-              if (SAMPLES_check$PASS && IS_SAMPLE) {
+            if (SAMPLES_check$PASS && IS_SAMPLE) {
                 df <- as.data.frame(df0$df)
                 matname <- "samples.csv"
               }
-
-            }
             
             if (IS_CONTRAST) {
               df0 <- playbase::read.as_matrix(fn2)
@@ -349,12 +347,14 @@ UploadBoard <- function(id,
                   )
                 })
               }
+            }
 
-              if (CONTRAST_check$PASS && IS_CONTRAST) {
+            if (CONTRAST_check$PASS && IS_CONTRAST) {
                 df <- as.matrix(df0)
                 matname <- "contrasts.csv"
               }
-            }
+
+
             if (!is.null(matname)) {
               matlist[[matname]] <- df
             }

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -259,7 +259,6 @@ UploadBoard <- function(id,
 
         if (length(uploadnames) > 0) {
           for (i in 1:length(uploadnames)) {
-            browser()
             fn1 <- inputnames[i]
             fn2 <- uploadnames[i]
             matname <- NULL
@@ -288,9 +287,8 @@ UploadBoard <- function(id,
                   )
                 })
               }
-            }
 
-            if (COUNTS_check$PASS && IS_COUNT) {
+              if (COUNTS_check$PASS && IS_COUNT) {
                 df <- as.matrix(COUNTS_check$df)
                 matname <- "counts.csv"
               }
@@ -301,6 +299,7 @@ UploadBoard <- function(id,
                 df <- 2**df
                 matname <- "counts.csv"
               }
+            }
 
             if (IS_SAMPLE) {
               df0 <- playbase::read.as_matrix(fn2)
@@ -321,12 +320,12 @@ UploadBoard <- function(id,
                   )
                 })
               }
-            }
 
-            if (SAMPLES_check$PASS && IS_SAMPLE) {
+              if (SAMPLES_check$PASS && IS_SAMPLE) {
                 df <- as.data.frame(SAMPLES_check$df)
                 matname <- "samples.csv"
               }
+            }
             
             if (IS_CONTRAST) {
               df0 <- playbase::read.as_matrix(fn2)
@@ -347,13 +346,13 @@ UploadBoard <- function(id,
                   )
                 })
               }
-            }
 
-            if (CONTRASTS_check$PASS && IS_CONTRAST) {
+              if (CONTRASTS_check$PASS && IS_CONTRAST) {
                 df <- as.matrix(CONTRASTS_check$df)
                 matname <- "contrasts.csv"
               }
 
+            }
 
             if (!is.null(matname)) {
               matlist[[matname]] <- df

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -313,11 +313,12 @@ UploadBoard <- function(id,
                   error_id <- names(SAMPLES_check$check)[idx]
                   error_log <- SAMPLES_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
+                  error_length <- length(error_log)
                   ifelse(length(error_log) > 5, error_log <- error_log[1:5], error_log)
                   
                   shinyalert::shinyalert(
                     title = error_detail$title,
-                    text = paste(error_detail$message,"\n", paste(error_log, collapse = " "), sep = " "),
+                    text = paste(error_detail$message,"\n",paste(error_length, "cases identified, examples:"), paste(error_log, collapse = " "), sep = " "),
                     type = error_detail$warning_type,
                     closeOnClickOutside = FALSE
                   )
@@ -340,11 +341,12 @@ UploadBoard <- function(id,
                   error_id <- names(CONTRASTS_check$check)[idx]
                   error_log <- CONTRASTS_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
+                  error_length <- length(error_log)
                   ifelse(length(error_log) > 5, error_log <- error_log[1:5], error_log)
 
                   shinyalert::shinyalert(
                     title = error_detail$title,
-                    text = paste(error_detail$message,"\n", paste(error_log, collapse = " "), sep = " "),
+                    text = paste(error_detail$message,"\n",paste(error_length, "cases identified, examples:"), paste(error_log, collapse = " "), sep = " "),
                     type = error_detail$warning_type,
                     closeOnClickOutside = FALSE
                   )

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -278,7 +278,8 @@ UploadBoard <- function(id,
                   error_id <- names(COUNTS_check$check)[idx]
                   error_log <- COUNTS_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
-                  
+                  ifelse(length(error_log) > 5, error_log <- error_log[1:5], error_log)
+
                   shinyalert::shinyalert(
                     title = error_detail$title,
                     text = paste(error_detail$message,"\n", paste(error_log, collapse = " "), sep = " "),
@@ -311,6 +312,7 @@ UploadBoard <- function(id,
                   error_id <- names(SAMPLES_check$check)[idx]
                   error_log <- SAMPLES_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
+                  ifelse(length(error_log) > 5, error_log <- error_log[1:5], error_log)
                   
                   shinyalert::shinyalert(
                     title = error_detail$title,
@@ -337,7 +339,8 @@ UploadBoard <- function(id,
                   error_id <- names(CONTRASTS_check$check)[idx]
                   error_log <- CONTRASTS_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
-                  
+                  ifelse(length(error_log) > 5, error_log <- error_log[1:5], error_log)
+
                   shinyalert::shinyalert(
                     title = error_detail$title,
                     text = paste(error_detail$message,"\n", paste(error_log, collapse = " "), sep = " "),

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -330,6 +330,31 @@ UploadBoard <- function(id,
 
             }
             
+            if (IS_CONTRAST) {
+              df0 <- playbase::read.as_matrix(fn2)
+              
+              CONTRAST_check <- playbase::pgx.checkPGX(df0, "CONTRASTS")
+
+              if(length(CONTRAST_check$check)>0) {
+                lapply(1:length(CONTRAST_check$check), function(idx){
+                  error_id <- names(CONTRAST_check$check)[idx]
+                  error_log <- CONTRAST_check$check[[idx]]
+                  error_detail <- error_list[error_list$error == error_id,]
+                  
+                  shinyalert::shinyalert(
+                    title = error_detail$title,
+                    text = paste(error_detail$message,"\n", paste(error_log, collapse = " "), sep = " "),
+                    type = error_detail$warning_type,
+                    closeOnClickOutside = FALSE
+                  )
+                })
+              }
+
+              if (CONTRAST_check$PASS && IS_CONTRAST) {
+                df <- as.matrix(df0)
+                matname <- "contrasts.csv"
+              }
+            }
             if (!is.null(matname)) {
               matlist[[matname]] <- df
             }

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -259,6 +259,7 @@ UploadBoard <- function(id,
 
         if (length(uploadnames) > 0) {
           for (i in 1:length(uploadnames)) {
+            browser()
             fn1 <- inputnames[i]
             fn2 <- uploadnames[i]
             matname <- NULL
@@ -304,7 +305,7 @@ UploadBoard <- function(id,
             if (IS_SAMPLE) {
               df0 <- playbase::read.as_matrix(fn2)
               
-              SAMPLE_check <- playbase::pgx.checkPGX(df0, "SAMPLES")
+              SAMPLES_check <- playbase::pgx.checkPGX(df0, "SAMPLES")
 
               if(length(SAMPLES_check$check)>0) {
                 lapply(1:length(SAMPLES_check$check), function(idx){
@@ -323,19 +324,19 @@ UploadBoard <- function(id,
             }
 
             if (SAMPLES_check$PASS && IS_SAMPLE) {
-                df <- as.data.frame(SAMPLE_check$df)
+                df <- as.data.frame(SAMPLES_check$df)
                 matname <- "samples.csv"
               }
             
             if (IS_CONTRAST) {
               df0 <- playbase::read.as_matrix(fn2)
               
-              CONTRAST_check <- playbase::pgx.checkPGX(df0, "CONTRASTS")
+              CONTRASTS_check <- playbase::pgx.checkPGX(df0, "CONTRASTS")
 
-              if(length(CONTRAST_check$check)>0) {
-                lapply(1:length(CONTRAST_check$check), function(idx){
-                  error_id <- names(CONTRAST_check$check)[idx]
-                  error_log <- CONTRAST_check$check[[idx]]
+              if(length(CONTRASTS_check$check)>0) {
+                lapply(1:length(CONTRASTS_check$check), function(idx){
+                  error_id <- names(CONTRASTS_check$check)[idx]
+                  error_log <- CONTRASTS_check$check[[idx]]
                   error_detail <- error_list[error_list$error == error_id,]
                   
                   shinyalert::shinyalert(
@@ -348,8 +349,8 @@ UploadBoard <- function(id,
               }
             }
 
-            if (CONTRAST_check$PASS && IS_CONTRAST) {
-                df <- as.matrix(CONTRAST_check$df)
+            if (CONTRASTS_check$PASS && IS_CONTRAST) {
+                df <- as.matrix(CONTRASTS_check$df)
                 matname <- "contrasts.csv"
               }
 
@@ -360,8 +361,6 @@ UploadBoard <- function(id,
           }
         }
       }
-
-      browser()
 
       ## put the matrices in the reactive values 'uploaded'
       files.needed <- c("counts.csv", "samples.csv", "contrasts.csv")

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -266,6 +266,9 @@ UploadBoard <- function(id,
               ## allows duplicated rownames
               df0 <- playbase::read.as_matrix(fn2)
               pass <- TRUE
+              
+              # PGX CHECK HERE #TODO
+
               ## check for duplicated rownames (but pass)
               if (TRUE && any(duplicated(rownames(df0)))) {
                 ndup <- sum(duplicated(rownames(df0)))
@@ -277,6 +280,9 @@ UploadBoard <- function(id,
                   closeOnClickOutside = FALSE,
                 )
               }
+
+              # PGX CHECK HERE #TODO
+              
               if (TRUE && any(rowSums(df0)==0)) {
                 nzero <- sum(rowSums(df0)==0)
                 shinyalert::shinyalert(
@@ -288,6 +294,9 @@ UploadBoard <- function(id,
                 )
                 df0 <- df0[rowSums(df0)>0,,drop=FALSE]
               }
+
+              # PGX CHECK HERE #TODO
+              
               if (TRUE && any(colSums(df0)==0)) {
                 nzero <- sum(colSums(df0)==0)
                 ##pass <- pass && FALSE
@@ -300,6 +309,9 @@ UploadBoard <- function(id,
                   closeOnClickOutside = FALSE
                 )
               }
+              
+              # PGX CHECK HERE #TODO
+              
               if (pass && nrow(df0) > 1 && NCOL(df0) > 1) {
                 df <- as.matrix(df0)
                 matname <- "counts.csv"
@@ -308,6 +320,9 @@ UploadBoard <- function(id,
               ## allows duplicated rownames
               df0 <- playbase::read.as_matrix(fn2)
               pass <- TRUE
+
+              # PGX CHECK HERE #TODO
+              
               if (TRUE && any(duplicated(rownames(df0)))) {
                 ndup <- sum(duplicated(rownames(df0)))
                 shinyalert::shinyalert(
@@ -318,6 +333,9 @@ UploadBoard <- function(id,
                   closeOnClickOutside = FALSE,
                 )
               }
+              
+              # PGX CHECK HERE #TODO
+              
               if (TRUE && any(apply(df0,1,sd)==0)) {
                 nzero <- sum(apply(df0,1,sd)==0)
                 pass <- FALSE
@@ -329,6 +347,9 @@ UploadBoard <- function(id,
                   closeOnClickOutside = FALSE
                 )
               }
+              
+              # PGX CHECK HERE #TODO
+              
               if (nrow(df0) > 1 && NCOL(df0) > 1) {
                 df <- as.matrix(df0)
                 message("[UploadModule::upload_files] converting expression to counts...")
@@ -337,6 +358,9 @@ UploadBoard <- function(id,
               }
             } else if (grepl("sample", fn1, ignore.case = TRUE)) {
               df0 <- playbase::read.as_matrix(fn2)
+              
+              # PGX CHECK HERE #TODO
+              
               if (any(duplicated(rownames(df0)))) {
                 dup.rows <- rownames(df0)[which(duplicated(rownames(df0)))]
                 msg <- paste(
@@ -349,12 +373,18 @@ UploadBoard <- function(id,
                   type = "error",
                   closeOnClickOutside = FALSE,
                 )
+                
+              # PGX CHECK HERE #TODO
+
               } else if (nrow(df0) > 1 && NCOL(df0) >= 1) {
                 df <- as.data.frame(df0)
                 matname <- "samples.csv"
               }
             } else if (grepl("contrast", fn1, ignore.case = TRUE)) {
               df0 <- playbase::read.as_matrix(fn2)
+              
+              # PGX CHECK HERE #TODO
+              
               if (any(duplicated(rownames(df0)))) {
                 dup.rows <- rownames(df0)[which(duplicated(rownames(df0)))]
                 msg <- paste(
@@ -367,6 +397,9 @@ UploadBoard <- function(id,
                   type = "error",
                   closeOnClickOutside = FALSE,
                 )
+
+                # PGX CHECK HERE #TODO
+                
               } else if (nrow(df0) > 1 && NCOL(df0) >= 1) {
                 df <- as.matrix(df0)
                 matname <- "contrasts.csv"

--- a/components/modules/ComputePgxModule.R
+++ b/components/modules/ComputePgxModule.R
@@ -333,16 +333,6 @@ ComputePgxServer <- function(
                     return(NULL)
                 }
 
-                has.contrasts <- !is.null(contrastsRT()) && NCOL(as.matrix(contrastsRT()))>0
-                if(!has.contrasts) {
-                    shinyalert::shinyalert(
-                      title = "ERROR",
-                      text = "You must define at least 1 contrast",
-                      type = "error"                      
-                    )
-                    return(NULL)
-                }
-
                 has.name <- input$upload_name != ""
                 has.description <- input$upload_description != ""
                 if(!has.name || !has.description) {


### PR DESCRIPTION
**WARNING:** This PR is coupled to the OPG PR of same name. https://github.com/bigomics/playbase/pull/17

- Remove input files cleaning and warnings from the UI and place them into `playbase::playbase::pgx.checkPGX()`.
- If errors are found in the input files, `playbase::playbase::pgx.checkPGX()` will return an error message.
- The return value of playbase::playbase::pgx.checkPGX() is the corrected dataframe (similar to what OPG does currently), with the parameter `PASS` indicating whether errors were found (TRUE means no errors were found), and the `error log` containing a list of all the errors found. Each element in the list represents a different error type.
- The possible error messages are stored in `playbase::PGX_CHECKS`.
- This modification will facilitate the expansion of both input file checks and enable Nick to incorporate these error messages into the dataset preview UI.