### PR TITLE
Fix #457: increase box size to allow contrast name visibility

### DIFF
--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -23,70 +23,72 @@ upload_module_makecontrast_ui <- function(id) {
     bslib::layout_column_wrap(
       width = 1,
       height = "calc(100vh - 200px)",
-      heights_equal = "row",
+      heights_equal = "all",
       bslib::layout_column_wrap(
           width = 1, #fill = FALSE,
-          #fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr;"),
           bslib::card(
+            full_screen = TRUE,
             style = "border-width: 0px;",
             bslib::card_body(
               shiny::h4("Create comparisons:"),
-              shiny::div(
-                  style = "display: flex; justify-content: space-between; height: 50px; align-items: baseline;",
-                  shiny::div(
-                      style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
-                      padding: 0px; margin-right: 5px; margin-left 5px; margin-top 10px; padding-top: 10px;",
-                      shiny::HTML("<b>Phenotype:</b>"),
-                      withTooltip(
-                          shiny::selectInput(ns("param"),
-                                            NULL,
-                                            choices = NULL,
-                                            selected = NULL,
-                                            multiple = TRUE
-                          ),
-                          "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
-                          placement = "left", options = list(container = "body")
-                      )
-                  ),
-                  shiny::div(
-                      shiny::conditionalPanel(
-                          style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
-                          padding: 10px; margin: 5px;",
-                          "input.param == '<gene>'",
-                          ns = ns,
-                          shiny::HTML("<b>Gene:</b>"),
-                          shiny::selectizeInput(ns("gene"),
-                                                NULL,
-                                                choices = NULL,
-                                                multiple = FALSE
+                  shiny::fillRow(
+                      style = "gap: 10px; height: 75px !important;",
+                      shiny::div(
+                          shiny::HTML("<b>Phenotype:</b>"),
+                          withTooltip(
+                              shiny::selectInput(ns("param"),
+                                                 NULL,
+                                                 choices = NULL,
+                                                 selected = NULL,
+                                                 multiple = TRUE
+                              ),
+                              "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
+                              placement = "left", options = list(container = "body")
+                          )
+                      ),
+                      shiny::div(
+                          shiny::conditionalPanel(
+                              "input.param == '<gene>'",
+                              ns = ns,
+                              shiny::HTML("<b>Gene:</b>"),
+                              shiny::selectizeInput(ns("gene"),
+                                                    NULL,
+                                                    choices = NULL,
+                                                    multiple = FALSE
+                              )
+                          )
+                      ),
+                      shiny::div(
+                          shiny::HTML("<b>Comparison name:</b>"),
+                          withTooltip(
+                              shiny::textInput(ns("newname"),
+                                               NULL,
+                                               placeholder = "e.g. MAIN_vs_CONTROL"
+                              ),
+                              "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
+                              placement = "left", options = list(container = "body")
+                          )
+                      ),
+                      shiny::div(
+                          style = "position: absolute; botton: 0;",
+                          shiny::actionButton(ns("addcontrast"),
+                                              "add comparison",
+                                              icon = icon("plus"),
+                                              class = "btn-outline-primary"
                           )
                       )
                   ),
                   shiny::div(
-                      style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
-                      padding: 10px; margin: 5px;",
-                      shiny::HTML("<b>Comparison name:</b>"),
+                      style = "overflow: auto;",
                       withTooltip(
-                          shiny::textInput(ns("newname"),
-                                              NULL,
-                                              placeholder = "e.g. MAIN_vs_CONTROL"
+                          shiny::uiOutput(ns("createcomparison"),
+                                          style = "font-size:13px; height: 280px;"
                           ),
-                          "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
-                          placement = "left", options = list(container = "body")
+                          "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
+                          placement = "top", options = list(container = "body")
                       )
-                    )
-                  ),
-              shiny::div(
-                style = "overflow: auto;",
-                withTooltip(
-                  shiny::uiOutput(ns("createcomparison"),
-                  style = "font-size:13px; height: 280px;"
-                  ),
-                  "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
-                  placement = "top", options = list(container = "body")
                   )
-                )
               )
           ),
           makecontrast_plot_pcaplot_ui(
@@ -98,39 +100,37 @@ upload_module_makecontrast_ui <- function(id) {
             width = c("auto", 800)
             )
             ),
-          shiny::div(
-              shiny::actionButton(ns("addcontrast"),
-                                  "add comparison",
-                                  icon = icon("plus"),
-                                  class = "btn-outline-primary"
-                                  )
-          ),
           bslib::card(
               fill = TRUE,
               style = "border-width: 0px;",
               bslib::card_body(
                   shiny::h4("Contrast table:"),
                   shiny::fillRow(
-                      height = 45,
-                      flex = c(NA, 0.05, NA, NA, 1),
-                      withTooltip(
-                          shiny::actionButton(ns("autocontrast"),
-                                              "add auto-contrasts",
-                                              icon = icon("plus"),
-                                              class = "small-button btn-outline-primary"
+                      style = "gap: 10px;",
+                      flex = c(NA, 1),
+                      shiny::fillCol(
+                          height = 45,
+                          flex = c(NA, 0.05, NA, NA, 1),
+                          withTooltip(
+                              shiny::actionButton(ns("autocontrast"),
+                                                  "add auto-contrasts",
+                                                  icon = icon("plus"),
+                                                  class = "small-button btn-outline-primary"
+                              ),
+                              "If you are feeling lucky, try this to automatically create contrasts.",
+                              placement = "top", options = list(container = "body")
                           ),
-                          "If you are feeling lucky, try this to automatically create contrasts.",
-                          placement = "top", options = list(container = "body")
+                          shiny::br(),
+                          shiny::div(shiny::HTML("<b>Strata:</b>"), style = "padding: 4px 4px;"),
+                          shiny::selectInput(ns("strata"), NULL, choices = NULL, width = "120px"),
+                          shiny::br()
                       ),
-                      shiny::br(),
-                      shiny::div(shiny::HTML("<b>Strata:</b>"), style = "padding: 4px 4px;"),
-                      shiny::selectInput(ns("strata"), NULL, choices = NULL, width = "120px"),
-                      shiny::br()
-                  ),
-                  bslib::layout_column_wrap(
-                      width = 1,
-                      DT::dataTableOutput(ns("contrastTable"))
+                      bslib::layout_column_wrap(
+                          width = 1,
+                          DT::dataTableOutput(ns("contrastTable"))
+                      )
                   )
+
               )
         )
     )
@@ -457,7 +457,8 @@ upload_module_makecontrast_server <- function(id, phenoRT, contrRT, countsRT, he
               scrollResize = TRUE,
               pageLength = 999,
               ## autoWidth = TRUE, ## scrollX=TRUE,
-              scrollY = "300px",
+              # scrollY = "300px",
+              scrollY = "25vh",
               columnDefs = list(
                 list(width = "20px", targets = c(0, 2, 3)),
                 list(width = "150px", targets = c(1)),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -54,7 +54,7 @@ upload_module_makecontrast_ui <- function(id) {
                           ),
                           shiny::br(),
                           withTooltip(
-                              shiny::textInput(ns("newname"),
+                              shiny::textAreaInput(ns("newname"),
                                                "Comparison name:",
                                                placeholder = "e.g. MAIN_vs_CONTROL"
                               ),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -111,6 +111,7 @@ upload_module_makecontrast_ui <- function(id) {
               bslib::card_body(
                   shiny::h4("Contrast table:"),
                   shiny::fillRow(
+                      height = 24,
                       flex = c(NA, 0.05, NA, NA, 1),
                       withTooltip(
                           shiny::actionButton(ns("autocontrast"),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -111,7 +111,7 @@ upload_module_makecontrast_ui <- function(id) {
               bslib::card_body(
                   shiny::h4("Contrast table:"),
                   shiny::fillRow(
-                      height = 24,
+                      height = 45,
                       flex = c(NA, 0.05, NA, NA, 1),
                       withTooltip(
                           shiny::actionButton(ns("autocontrast"),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -17,7 +17,7 @@ MakeContrastGadget <- function(X, pheno, height = 720) {
 
 upload_module_makecontrast_ui <- function(id) {
   ns <- shiny::NS(id)
-  
+
 
   shiny::tagList(
     bslib::layout_column_wrap(
@@ -29,46 +29,51 @@ upload_module_makecontrast_ui <- function(id) {
           style = htmltools::css(grid_template_columns = "9fr 3fr;"),
                   div(
                     shiny::h4("Create comparisons:"),
-                    bslib::layout_column_wrap(
-                      width = 1,
-                      height = "100px",
-                      style = htmltools::css(grid_template_columns = "1fr 2fr 3fr 1fr 2fr 3fr"),
-                      shiny::HTML("<b>Phenotype:</b>"),
-                      withTooltip(
-                          shiny::selectInput(ns("param"),
-                                              NULL,
-                                              choices = NULL,
-                                              selected = NULL,
-                                              multiple = TRUE
-                          ),
-                          "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
-                          placement = "left", options = list(container = "body")
-                      ),
-                      shiny::conditionalPanel(
-                          "input.param == '<gene>'",
-                          ns = ns,
-                          shiny::HTML("<b>Gene:</b>"),
-                          shiny::selectizeInput(ns("gene"),
-                                                "Gene:",
-                                                choices = NULL,
-                                                multiple = FALSE
-                          )
-                      ),
-                      shiny::HTML("<b>Comparison name:</b>"),
-                      withTooltip(
-                          shiny::textAreaInput(ns("newname"),
-                                            NULL,
-                                            placeholder = "e.g. MAIN_vs_CONTROL"
-                          ),
-                          "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
-                          placement = "left", options = list(container = "body")
-                      ),
-                      shiny::actionButton(ns("addcontrast"),
-                                          "add comparison",
-                                          icon = icon("plus"),
-                                          class = "btn-outline-primary"
-                      )
-                  ),
+                    shiny::div(
+                        style = "display: flex; justify-content: space-between;",
+                        shiny::div(
+                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                            padding: 10px; margin: 5px;",
+                            shiny::HTML("<b>Phenotype:</b>"),
+                            withTooltip(
+                                shiny::selectInput(ns("param"),
+                                                   NULL,
+                                                   choices = NULL,
+                                                   selected = NULL,
+                                                   multiple = TRUE
+                                ),
+                                "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
+                                placement = "left", options = list(container = "body")
+                            )
+                        ),
+                        shiny::div(
+                            shiny::conditionalPanel(
+                                style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                                padding: 10px; margin: 5px;",
+                                "input.param == '<gene>'",
+                                ns = ns,
+                                shiny::HTML("<b>Gene:</b>"),
+                                shiny::selectizeInput(ns("gene"),
+                                                      NULL,
+                                                      choices = NULL,
+                                                      multiple = FALSE
+                                )
+                            )
+                        ),
+                        shiny::div(
+                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                            padding: 10px; margin: 5px;",
+                            shiny::HTML("<b>Comparison name:</b>"),
+                            withTooltip(
+                                shiny::textInput(ns("newname"),
+                                                     NULL,
+                                                     placeholder = "e.g. MAIN_vs_CONTROL"
+                                ),
+                                "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
+                                placement = "left", options = list(container = "body")
+                            )
+                        )
+                    ),
                   withTooltip(
                           shiny::uiOutput(ns("createcomparison"),
                                           style = "font-size:13px; height: 280px; overflow-y: scroll;"
@@ -436,7 +441,7 @@ upload_module_makecontrast_server <- function(id, phenoRT, contrRT, countsRT, he
               scrollResize = TRUE,
               pageLength = 999,
               ## autoWidth = TRUE, ## scrollX=TRUE,
-              scrollY = "300px", 
+              scrollY = "300px",
               columnDefs = list(
                 list(width = "20px", targets = c(0, 2, 3)),
                 list(width = "150px", targets = c(1)),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -28,11 +28,11 @@ upload_module_makecontrast_ui <- function(id) {
           #fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr;"),
                   div(
+                    shiny::h4("Create comparisons:"),
                     bslib::layout_column_wrap(
                       width = 1,
                       height = "100px",
-                      style = htmltools::css(grid_template_columns = "2fr 3fr 3fr 2fr 2fr;", "overflow-y:"="auto;"),
-                      shiny::h4("Create comparisons:"),
+                      style = htmltools::css(grid_template_columns = "3fr 3fr 3fr 3fr"),
                       withTooltip(
                           shiny::selectInput(ns("param"),
                                               "Phenotype:",

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -27,10 +27,6 @@ upload_module_makecontrast_ui <- function(id) {
           width = 1, #fill = FALSE,
           #fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr"),
-          bslib::card(
-              # max_height = "330px",
-              style = "border-width: 0px;",
-              bslib::card_body(
                   bslib::layout_column_wrap(
                     width = 1,
                     # style = htmltools::css(grid_template_columns = "3fr 8fr"),
@@ -70,10 +66,7 @@ upload_module_makecontrast_ui <- function(id) {
                                           icon = icon("plus"),
                                           class = "btn-outline-primary"
                       )
-                  )
                   ),
-                  bslib::layout_column_wrap(
-                    width = 1,
                     withTooltip(
                           shiny::uiOutput(ns("createcomparison"),
                                           style = "font-size:13px; height: 280px; overflow-y: scroll;"
@@ -81,10 +74,7 @@ upload_module_makecontrast_ui <- function(id) {
                           "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
                           placement = "top", options = list(container = "body")
                       )
-
-                  )
-              )
-          ),
+              ),
           makecontrast_plot_pcaplot_ui(ns("pcaplot"),
                                        title = "PCA/tSNE plot",
                                        info.text = "",

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -76,7 +76,7 @@ upload_module_makecontrast_ui <- function(id) {
                     ),
                   withTooltip(
                           shiny::uiOutput(ns("createcomparison"),
-                                          style = "font-size:13px; height: 280px; overflow-y: scroll;"
+                                          style = "font-size:13px; height: 280px;"
                           ),
                           "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
                           placement = "top", options = list(container = "body")

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -30,7 +30,7 @@ upload_module_makecontrast_ui <- function(id) {
                   shiny::h4("Create comparisons"),
                   bslib::layout_column_wrap(
                     width = NULL,
-                    style = htmltools::css(grid_template_columns = "4fr 8fr"),
+                    style = htmltools::css(grid_template_columns = "3fr 8fr"),
                     shiny::fillCol(
                           flex = c(NA, NA, NA, NA, 1),
                           withTooltip(

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -28,78 +28,82 @@ upload_module_makecontrast_ui <- function(id) {
           width = 1, #fill = FALSE,
           #fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr;"),
+          bslib::card(
+            style = "border-width: 0px;",
+            bslib::card_body(
+              shiny::h4("Create comparisons:"),
+              shiny::div(
+                  style = "display: flex; justify-content: space-between; height: 50px; align-items: baseline;",
                   shiny::div(
-                    style = "overflow: hidden;",
-                    shiny::h4("Create comparisons:"),
-                    shiny::div(
-                        style = "display: flex; justify-content: space-between; height: 50px; align-items: baseline;",
-                        shiny::div(
-                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
-                            padding: 0px; margin-right: 5px; margin-left 5px; margin-top 10px; padding-top: 10px;",
-                            shiny::HTML("<b>Phenotype:</b>"),
-                            withTooltip(
-                                shiny::selectInput(ns("param"),
-                                                   NULL,
-                                                   choices = NULL,
-                                                   selected = NULL,
-                                                   multiple = TRUE
-                                ),
-                                "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
-                                placement = "left", options = list(container = "body")
-                            )
-                        ),
-                        shiny::div(
-                            shiny::conditionalPanel(
-                                style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
-                                padding: 10px; margin: 5px;",
-                                "input.param == '<gene>'",
-                                ns = ns,
-                                shiny::HTML("<b>Gene:</b>"),
-                                shiny::selectizeInput(ns("gene"),
-                                                      NULL,
-                                                      choices = NULL,
-                                                      multiple = FALSE
-                                )
-                            )
-                        ),
-                        shiny::div(
-                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
-                            padding: 10px; margin: 5px;",
-                            shiny::HTML("<b>Comparison name:</b>"),
-                            withTooltip(
-                                shiny::textInput(ns("newname"),
-                                                     NULL,
-                                                     placeholder = "e.g. MAIN_vs_CONTROL"
-                                ),
-                                "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
-                                placement = "left", options = list(container = "body")
-                            )
-                        )
-                    ),
-                  shiny::div(
-                     style = "overflow: auto;",
-                     withTooltip(
-                          shiny::uiOutput(ns("createcomparison"),
-                                          style = "font-size:13px; height: 280px;"
+                      style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                      padding: 0px; margin-right: 5px; margin-left 5px; margin-top 10px; padding-top: 10px;",
+                      shiny::HTML("<b>Phenotype:</b>"),
+                      withTooltip(
+                          shiny::selectInput(ns("param"),
+                                            NULL,
+                                            choices = NULL,
+                                            selected = NULL,
+                                            multiple = TRUE
                           ),
-                          "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
-                          placement = "top", options = list(container = "body")
+                          "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
+                          placement = "left", options = list(container = "body")
                       )
+                  ),
+                  shiny::div(
+                      shiny::conditionalPanel(
+                          style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                          padding: 10px; margin: 5px;",
+                          "input.param == '<gene>'",
+                          ns = ns,
+                          shiny::HTML("<b>Gene:</b>"),
+                          shiny::selectizeInput(ns("gene"),
+                                                NULL,
+                                                choices = NULL,
+                                                multiple = FALSE
+                          )
+                      )
+                  ),
+                  shiny::div(
+                      style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                      padding: 10px; margin: 5px;",
+                      shiny::HTML("<b>Comparison name:</b>"),
+                      withTooltip(
+                          shiny::textInput(ns("newname"),
+                                              NULL,
+                                              placeholder = "e.g. MAIN_vs_CONTROL"
+                          ),
+                          "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
+                          placement = "left", options = list(container = "body")
+                      )
+                    )
+                  ),
+              shiny::div(
+                style = "overflow: auto;",
+                withTooltip(
+                  shiny::uiOutput(ns("createcomparison"),
+                  style = "font-size:13px; height: 280px;"
+                  ),
+                  "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
+                  placement = "top", options = list(container = "body")
                   )
-                ),
-          makecontrast_plot_pcaplot_ui(ns("pcaplot"),
-                                       title = "PCA/tSNE plot",
-                                       info.text = "",
-                                       caption = "",
-                                       height = c("100%", 700),
-                                       width = c("auto", 800))
+                )
+              )
           ),
+          makecontrast_plot_pcaplot_ui(
+            ns("pcaplot"),
+            title = "PCA/tSNE plot",
+            info.text = "",
+            caption = "",
+            height = c("100%", 700),
+            width = c("auto", 800)
+            )
+            ),
           shiny::div(
               shiny::actionButton(ns("addcontrast"),
                                   "add comparison",
                                   icon = icon("plus"),
                                   class = "btn-outline-primary"
-              )
+                                  )
           ),
           bslib::card(
               fill = TRUE,

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -28,12 +28,13 @@ upload_module_makecontrast_ui <- function(id) {
           width = 1, #fill = FALSE,
           #fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr;"),
-                  div(
+                  shiny::div(
+                    style = "overflow: hidden;",
                     shiny::h4("Create comparisons:"),
                     shiny::div(
                         style = "display: flex; justify-content: space-between;",
                         shiny::div(
-                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;;
                             padding: 10px; margin: 5px;",
                             shiny::HTML("<b>Phenotype:</b>"),
                             withTooltip(
@@ -75,13 +76,16 @@ upload_module_makecontrast_ui <- function(id) {
                             )
                         )
                     ),
-                  withTooltip(
+                  shiny::div(
+                     style = "overflow: auto;",
+                     withTooltip(
                           shiny::uiOutput(ns("createcomparison"),
                                           style = "font-size:13px; height: 280px;"
                           ),
                           "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
                           placement = "top", options = list(container = "body")
                       )
+                  )
                 ),
           makecontrast_plot_pcaplot_ui(ns("pcaplot"),
                                        title = "PCA/tSNE plot",
@@ -90,7 +94,7 @@ upload_module_makecontrast_ui <- function(id) {
                                        height = c("100%", 700),
                                        width = c("auto", 800))
           ),
-          div(
+          shiny::div(
               shiny::actionButton(ns("addcontrast"),
                                   "add comparison",
                                   icon = icon("plus"),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -24,13 +24,14 @@ upload_module_makecontrast_ui <- function(id) {
           fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr"),
           bslib::card(
-              max_height = "calc(100vh - 330px)",
+              max_height = "330px",
               style = "border-width: 0px;",
               bslib::card_body(
                   shiny::h4("Create comparisons"),
-                  shiny::fillRow(
-                      flex = c(1, 4),
-                      shiny::fillCol(
+                  bslib::layout_column_wrap(
+                    width = NULL,
+                    style = htmltools::css(grid_template_columns = "4fr 8fr"),
+                    shiny::fillCol(
                           flex = c(NA, NA, NA, NA, 1),
                           withTooltip(
                               shiny::selectInput(ns("param"),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -17,14 +17,18 @@ MakeContrastGadget <- function(X, pheno, height = 720) {
 
 upload_module_makecontrast_ui <- function(id) {
   ns <- shiny::NS(id)
+  
 
   shiny::tagList(
+    bslib::layout_column_wrap(
+      width = 1,
+      height = "calc(100vh - 200px)",
       bslib::layout_column_wrap(
-          width = NULL, fill = FALSE,
-          fixed_width = TRUE,
+          width = 1, #fill = FALSE,
+          #fixed_width = TRUE,
           style = htmltools::css(grid_template_columns = "9fr 3fr"),
           bslib::card(
-              max_height = "330px",
+              # max_height = "330px",
               style = "border-width: 0px;",
               bslib::card_body(
                   shiny::h4("Create comparisons"),
@@ -83,38 +87,38 @@ upload_module_makecontrast_ui <- function(id) {
                                        title = "PCA/tSNE plot",
                                        info.text = "",
                                        caption = "",
-                                       height = c(320, 700),
+                                       height = c("100%", 700),
                                        width = c("auto", 800))
-      ),
-      bslib::card(
-          fill = FALSE,
-          style = "border-width: 0px;",
-          bslib::card_body(
-              shiny::h4("Contrast table"),
-              shiny::fillRow(
-                  height = 24,
-                  flex = c(NA, 0.05, NA, NA, 1),
-                  withTooltip(
-                      shiny::actionButton(ns("autocontrast"),
-                                          "add auto-contrasts",
-                                          icon = icon("plus"),
-                                          class = "small-button btn-outline-primary"
+          ),
+          bslib::card(
+              fill = TRUE,
+              style = "border-width: 0px;",
+              bslib::card_body(
+                  shiny::h4("Contrast table"),
+                  shiny::fillRow(
+                      height = 24,
+                      flex = c(NA, 0.05, NA, NA, 1),
+                      withTooltip(
+                          shiny::actionButton(ns("autocontrast"),
+                                              "add auto-contrasts",
+                                              icon = icon("plus"),
+                                              class = "small-button btn-outline-primary"
+                          ),
+                          "If you are feeling lucky, try this to automatically create contrasts.",
+                          placement = "top", options = list(container = "body")
                       ),
-                      "If you are feeling lucky, try this to automatically create contrasts.",
-                      placement = "top", options = list(container = "body")
+                      shiny::br(),
+                      shiny::div(shiny::HTML("<b>Strata:</b>"), style = "padding: 4px 4px;"),
+                      shiny::selectInput(ns("strata"), NULL, choices = NULL, width = "120px"),
+                      shiny::br()
                   ),
-                  shiny::br(),
-                  shiny::div(shiny::HTML("<b>Strata:</b>"), style = "padding: 4px 4px;"),
-                  shiny::selectInput(ns("strata"), NULL, choices = NULL, width = "120px"),
-                  shiny::br()
-              ),
-              bslib::layout_column_wrap(
-                  width = 1,
-                  DT::dataTableOutput(ns("contrastTable")),
-                  style = "font-size:13px; height: 300px; margin-top: 20px;overflow-y: scroll;"
+                  bslib::layout_column_wrap(
+                      width = 1,
+                      DT::dataTableOutput(ns("contrastTable"))
+                  )
               )
-          )
-      )
+        )
+    )
   )
 }
 
@@ -427,16 +431,18 @@ upload_module_makecontrast_server <- function(id, phenoRT, contrRT, countsRT, he
 
           DT::datatable(
             df,
-            fillContainer = FALSE,
+            fillContainer = TRUE,
             rownames = FALSE,
             escape = c(-1),
             selection = "none",
             class = "compact cell-border",
+            plugins = 'scrollResize',
             options = list(
               dom = "t",
+              scrollResize = TRUE,
               pageLength = 999,
-              lengthMenu = list(c(6, -1), c('6', 'All')),
               ## autoWidth = TRUE, ## scrollX=TRUE,
+              scrollY = "300px", 
               columnDefs = list(
                 list(width = "20px", targets = c(0, 2, 3)),
                 list(width = "150px", targets = c(1)),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -32,10 +32,11 @@ upload_module_makecontrast_ui <- function(id) {
                     bslib::layout_column_wrap(
                       width = 1,
                       height = "100px",
-                      style = htmltools::css(grid_template_columns = "3fr 3fr 3fr 3fr"),
+                      style = htmltools::css(grid_template_columns = "1fr 2fr 3fr 1fr 2fr 3fr"),
+                      shiny::HTML("<b>Phenotype:</b>"),
                       withTooltip(
                           shiny::selectInput(ns("param"),
-                                              "Phenotype:",
+                                              NULL,
                                               choices = NULL,
                                               selected = NULL,
                                               multiple = TRUE
@@ -46,15 +47,17 @@ upload_module_makecontrast_ui <- function(id) {
                       shiny::conditionalPanel(
                           "input.param == '<gene>'",
                           ns = ns,
+                          shiny::HTML("<b>Gene:</b>"),
                           shiny::selectizeInput(ns("gene"),
                                                 "Gene:",
                                                 choices = NULL,
                                                 multiple = FALSE
                           )
                       ),
+                      shiny::HTML("<b>Comparison name:</b>"),
                       withTooltip(
                           shiny::textAreaInput(ns("newname"),
-                                            "Comparison name:",
+                                            NULL,
                                             placeholder = "e.g. MAIN_vs_CONTROL"
                           ),
                           "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -23,6 +23,7 @@ upload_module_makecontrast_ui <- function(id) {
     bslib::layout_column_wrap(
       width = 1,
       height = "calc(100vh - 200px)",
+      heights_equal = "row",
       bslib::layout_column_wrap(
           width = 1, #fill = FALSE,
           #fixed_width = TRUE,
@@ -88,6 +89,13 @@ upload_module_makecontrast_ui <- function(id) {
                                        caption = "",
                                        height = c("100%", 700),
                                        width = c("auto", 800))
+          ),
+          div(
+              shiny::actionButton(ns("addcontrast"),
+                                  "add comparison",
+                                  icon = icon("plus"),
+                                  class = "btn-outline-primary"
+              )
           ),
           bslib::card(
               fill = TRUE,

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -35,9 +35,9 @@ upload_module_makecontrast_ui <- function(id) {
                     width = 1,
                     # style = htmltools::css(grid_template_columns = "3fr 8fr"),
                     bslib::layout_column_wrap(
-                      width = 1/5,
-                      shiny::h4("Create comparisons"),
-
+                      width = 1,
+                      style = htmltools::css(grid_template_columns = "2fr 3fr 3fr 2fr 2fr"),
+                      shiny::h4("Create comparisons:"),
                       withTooltip(
                           shiny::selectInput(ns("param"),
                                               "Phenotype:",
@@ -96,7 +96,7 @@ upload_module_makecontrast_ui <- function(id) {
               fill = TRUE,
               style = "border-width: 0px;",
               bslib::card_body(
-                  shiny::h4("Contrast table"),
+                  shiny::h4("Contrast table:"),
                   shiny::fillRow(
                       height = 24,
                       flex = c(NA, 0.05, NA, NA, 1),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -26,13 +26,12 @@ upload_module_makecontrast_ui <- function(id) {
       bslib::layout_column_wrap(
           width = 1, #fill = FALSE,
           #fixed_width = TRUE,
-          style = htmltools::css(grid_template_columns = "9fr 3fr"),
-                  bslib::layout_column_wrap(
-                    width = 1,
-                    # style = htmltools::css(grid_template_columns = "3fr 8fr"),
+          style = htmltools::css(grid_template_columns = "9fr 3fr;"),
+                  div(
                     bslib::layout_column_wrap(
                       width = 1,
-                      style = htmltools::css(grid_template_columns = "2fr 3fr 3fr 2fr 2fr"),
+                      height = "100px",
+                      style = htmltools::css(grid_template_columns = "2fr 3fr 3fr 2fr 2fr;", "overflow-y:"="auto;"),
                       shiny::h4("Create comparisons:"),
                       withTooltip(
                           shiny::selectInput(ns("param"),
@@ -67,14 +66,14 @@ upload_module_makecontrast_ui <- function(id) {
                                           class = "btn-outline-primary"
                       )
                   ),
-                    withTooltip(
+                  withTooltip(
                           shiny::uiOutput(ns("createcomparison"),
                                           style = "font-size:13px; height: 280px; overflow-y: scroll;"
                           ),
                           "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
                           placement = "top", options = list(container = "body")
                       )
-              ),
+                ),
           makecontrast_plot_pcaplot_ui(ns("pcaplot"),
                                        title = "PCA/tSNE plot",
                                        info.text = "",

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -32,10 +32,10 @@ upload_module_makecontrast_ui <- function(id) {
                     style = "overflow: hidden;",
                     shiny::h4("Create comparisons:"),
                     shiny::div(
-                        style = "display: flex; justify-content: space-between;",
+                        style = "display: flex; justify-content: space-between; height: 50px; align-items: baseline;",
                         shiny::div(
-                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;;
-                            padding: 10px; margin: 5px;",
+                            style = "display: grid; grid-template-columns: auto auto; grid-gap: 10px;
+                            padding: 0px; margin-right: 5px; margin-left 5px; margin-top 10px; padding-top: 10px;",
                             shiny::HTML("<b>Phenotype:</b>"),
                             withTooltip(
                                 shiny::selectInput(ns("param"),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -111,7 +111,6 @@ upload_module_makecontrast_ui <- function(id) {
               bslib::card_body(
                   shiny::h4("Contrast table:"),
                   shiny::fillRow(
-                      height = 24,
                       flex = c(NA, 0.05, NA, NA, 1),
                       withTooltip(
                           shiny::actionButton(ns("autocontrast"),

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -31,55 +31,57 @@ upload_module_makecontrast_ui <- function(id) {
               # max_height = "330px",
               style = "border-width: 0px;",
               bslib::card_body(
-                  shiny::h4("Create comparisons"),
                   bslib::layout_column_wrap(
-                    width = NULL,
-                    style = htmltools::css(grid_template_columns = "3fr 8fr"),
-                    shiny::fillCol(
-                          flex = c(NA, NA, NA, NA, 1),
-                          withTooltip(
-                              shiny::selectInput(ns("param"),
-                                                 "Phenotype:",
-                                                 choices = NULL,
-                                                 selected = NULL,
-                                                 multiple = TRUE
-                              ),
-                              "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
-                              placement = "left", options = list(container = "body")
+                    width = 1,
+                    # style = htmltools::css(grid_template_columns = "3fr 8fr"),
+                    bslib::layout_column_wrap(
+                      width = 1/5,
+                      shiny::h4("Create comparisons"),
+
+                      withTooltip(
+                          shiny::selectInput(ns("param"),
+                                              "Phenotype:",
+                                              choices = NULL,
+                                              selected = NULL,
+                                              multiple = TRUE
                           ),
-                          shiny::conditionalPanel(
-                              "input.param == '<gene>'",
-                              ns = ns,
-                              shiny::selectizeInput(ns("gene"),
-                                                    "Gene:",
-                                                    choices = NULL,
-                                                    multiple = FALSE
-                              )
-                          ),
-                          shiny::br(),
-                          withTooltip(
-                              shiny::textAreaInput(ns("newname"),
-                                               "Comparison name:",
-                                               placeholder = "e.g. MAIN_vs_CONTROL"
-                              ),
-                              "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
-                              placement = "left", options = list(container = "body")
-                          ),
-                          shiny::br(),
-                          shiny::actionButton(ns("addcontrast"),
-                                              "add comparison",
-                                              icon = icon("plus"),
-                                              class = "btn-outline-primary"
-                          ),
-                          shiny::br()
+                          "Select phenotype(s) to create conditions for your groups. Select &ltgene&gt if you want to split by high/low expression of some gene. Select &ltsamples&gt if you want to group manually on sample names. You can select multiple phenotypes to create combinations.",
+                          placement = "left", options = list(container = "body")
+                      ),
+                      shiny::conditionalPanel(
+                          "input.param == '<gene>'",
+                          ns = ns,
+                          shiny::selectizeInput(ns("gene"),
+                                                "Gene:",
+                                                choices = NULL,
+                                                multiple = FALSE
+                          )
                       ),
                       withTooltip(
+                          shiny::textAreaInput(ns("newname"),
+                                            "Comparison name:",
+                                            placeholder = "e.g. MAIN_vs_CONTROL"
+                          ),
+                          "Give a name for your contrast as MAIN_vs_CONTROL, with the name of the main group first. You must keep _vs_ in the name to separate the names of the two groups.",
+                          placement = "left", options = list(container = "body")
+                      ),
+                      shiny::actionButton(ns("addcontrast"),
+                                          "add comparison",
+                                          icon = icon("plus"),
+                                          class = "btn-outline-primary"
+                      )
+                  )
+                  ),
+                  bslib::layout_column_wrap(
+                    width = 1,
+                    withTooltip(
                           shiny::uiOutput(ns("createcomparison"),
                                           style = "font-size:13px; height: 280px; overflow-y: scroll;"
                           ),
                           "Create comparisons by dragging conditions into the main or control groups on the right. Then press add comparison to add the contrast to the table.",
                           placement = "top", options = list(container = "body")
                       )
+
                   )
               )
           ),


### PR DESCRIPTION
This closes #457 

## Description
Did three things

- Added breathing space to the column itself
- Moved more pieces to `bslib`
- Used `textAreaInput` for multiple line input

@mauromiguelm Let me know if the dimensions and usability are what you expected, if not I will increase/decrease them.