### PR TITLE
Define root independently of /omicsplayground

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -46,8 +46,11 @@ TABLE_HEIGHT_MODAL <<- "75vh"
 reticulate::use_miniconda('r-reticulate')
 
 get_opg_root <- function() {
-    pwd <- strsplit(getwd(),split='/')[[1]]
-    paste(pwd[1:max(grep("omicsplayground",pwd))],collapse='/')
+  pwd <- getwd() 
+  dirs <- unlist(strsplit(pwd, "/"))
+  root_dirs <- head(dirs, -3)
+  root <- paste(root_dirs, collapse = "/")
+  return(root)
 }
 
 ## Set folders


### PR DESCRIPTION
**Description:**
- previously we had to name the folder omicsplayground in order for `get_opg_root` to define the root.
- This is prone to errors, as one could have omicsplayground_repo/omicsplayground. 
- Similarly, a git worktree with root name as branch, the `get_opg_root` would not work and crash.
- Problem was solved for both `Makefile` and `shiny::runApp()` by directing root to the third immediate parent.
- We can now use worktrees efficiently.

**Future:**
- Traditionally root should be where the .Rproj file is, so we could implement a more clean solution that works for both  `Makefile` and `shiny::runApp()`.