### PR TITLE
Fix #467 Bootstrap tooltip does not dissapear

### DIFF
--- a/components/ui/ui-tooltip.R
+++ b/components/ui/ui-tooltip.R
@@ -13,15 +13,16 @@ withTooltip <- function(
   if(!is.null(trigger)) {
 #    warning("`trigger` is ignored, used to be in shinyBS::tippify")
   }
-  
+
   if(!is.null(options)) {
 #    warning("`options` is ignored, used to be in shinyBS::tippify")
   }
-  
+
   htmltools::tagAppendAttributes(
     el,
     title = title,
     `data-bs-placement` = placement,
-    `data-bs-toggle` = "tooltip"
+    `data-bs-toggle` = "tooltip",
+    `data-bs-trigger` = "hover"
   )
 }


### PR DESCRIPTION
This closes #467 

## Description
By default the Boostrap 5 tooltip we are using gets triggered on `hover` and `active`. If one item is left as `active` by the user, the tooltip will remain visible. By changing this behaviour to `hover` only, when the user is not hovering a tooltip asset, there won't be any rogue tooltips.