### PR TITLE
Fix #475: Right settings bar remains closed on dataview tab if it was in closed state before loading a dataset

### DIFF
--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -78,7 +78,7 @@ const sidebarOpen = () => {
 
 const settingsClose = () => {
 	if($('#settings-container').hasClass('settings-expanded'))
-		$('#settings-container').trigger('mouseenter');
+		$('#settings-container').trigger('mouseleave');
 
 }
 

--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -78,12 +78,13 @@ const sidebarOpen = () => {
 
 const settingsClose = () => {
 	if($('#settings-container').hasClass('settings-expanded'))
-	    $('.setting-label').trigger('click');
+		$('#settings-container').trigger('mouseenter');
+
 }
 
 const settingsOpen = () => {
-	if($('#settings-container').hasClass('sidebar-collapsed'))
-	    $('.settings-label').trigger('click');
+	if($('#settings-container').hasClass('settings-collapsed'))
+		$('#settings-container').trigger('mouseenter');
 }
 
 const settingsLock = () => {

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -180,17 +180,10 @@ LoadingBoard <- function(id,
           type = "warning",
           closeOnClickOutside = FALSE
         )
-        #r_global$load_example_trigger <- NULL
         return(NULL)
       } else {
-
-        # close the right sidebar
-        #shinyjs::runjs("$('#settings-container').trigger('click');")
-        #shinyjs::runjs("$('#settings-container').trigger('mouseleave');")
-
         # open the left & right sidebar
         bigdash.openSettings(lock=TRUE)
-        shinyjs::runjs("$('#settings-container').trigger('mouseenter');")
         bigdash.openSidebar()
 
         # go to dataview

--- a/components/modules/WelcomeBoard.R
+++ b/components/modules/WelcomeBoard.R
@@ -44,14 +44,8 @@ WelcomeBoard <- function(id, auth, enable_upload, r_global) {
     })
 
     observeEvent(input$btn_load_data, {
-      # close the right sidebar
-      #shinyjs::runjs("$('#settings-container').trigger('click');")
-      #shinyjs::runjs("$('#settings-container').trigger('mouseleave');")
-
       bigdash.openSettings(lock=TRUE)
-      shinyjs::runjs("$('#settings-container').trigger('mouseenter');")      
       bigdash.openSidebar()
-
       bigdash.selectTab( session, "load-tab" )
     })
 


### PR DESCRIPTION
This closes #475 

## Description
There was a JS issue. We were clicking on a label that no longer has click behaviour (this changed when the hover settings bar was introduced). By changing the click event to `mouseenter` (to open it) and `mouseleave` (to close it), the bug is fixed. Funny enough, this was already discovered some time ago ([here](https://github.com/bigomics/omicsplayground/blob/master/components/modules/WelcomeBoard.R#L52)) but it was not added to the JS file itself.

PD: This is also reflected on CSS/JS migration branch (PR coming soon).