### PR TITLE
Fix #499: settings-container does not appear in firefox

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -301,22 +301,6 @@ app_server <- function(input, output, session) {
           )
         })
 
-        # this is a function - like "handleSettings()" in bigdash- needed to
-        # make the settings sidebar show up for the inserted tabs
-        shinyjs::runjs(
-            "  $('.big-tab')
-    .each((index, el) => {
-      let settings = $(el)
-        .find('.tab-settings')
-        .first();
-
-      $(settings).data('target', $(el).data('name'));
-      $(settings).appendTo('#settings-content');
-    });"
-        )
-        bigdash.selectTab(session, selected = 'dataview-tab')
-        bigdash.openSettings()
-
         shiny::withProgress(message="Preparing your dashboard (server)...", value=0, {
 
           if(ENABLED['dataview'])  {
@@ -420,6 +404,22 @@ app_server <- function(input, output, session) {
 
           info("[server.R] calling modules done!")
         })
+
+        # this is a function - like "handleSettings()" in bigdash- needed to
+        # make the settings sidebar show up for the inserted tabs
+        shinyjs::runjs(
+            "  $('.big-tab')
+    .each((index, el) => {
+      let settings = $(el)
+        .find('.tab-settings')
+        .first();
+
+      $(settings).data('target', $(el).data('name'));
+      $(settings).appendTo('#settings-content');
+    });"
+        )
+        bigdash.selectTab(session, selected = 'dataview-tab')
+        bigdash.openSettings()
 
         ## remove modal from LoadingBoard
         shiny::removeModal()


### PR DESCRIPTION
This closes #499 

## Description
The issue seems to be related with the evaluation of JS + change of tab (as noted by @ncullen93 on the issue). Evaluating after calling the servers of the boards solves both the settings bar issue + the tab change issue. To be honest I am not 100% sure why this worked everywhere except Firefox.

@ncullen93 Before merging, can you please double check on your end + with Safari. Thank you!