### PR TITLE
Fix frozen welcome page

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -186,12 +186,10 @@ app_server <- function(input, output, session) {
         }
         
         info("[SERVER:getPGXINFO] updating datasets-info.csv")
-        pgx.showCartoonModal()
-        try(getPGXINFO())
-        shiny::removeModal()
-        
+        pgx.showSmallModal()
+        getPGXINFO()
+        shiny::removeModal(session)
     })
-
 
     ## Global reactive values for app-wide triggering
     r_global <- reactiveValues(

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -176,6 +176,22 @@ app_server <- function(input, output, session) {
       info
     })
 
+    shiny::observeEvent(auth$logged(), {
+        ## trigger on login
+        logged <- auth$logged()
+
+        if (!logged) {
+          warning("[SERVER:getPGXINFO] user not logged in!")
+          return(NULL)
+        }
+        
+        info("[SERVER:getPGXINFO] updating datasets-info.csv")
+        pgx.showCartoonModal()
+        getPGXINFO()
+        shiny::removeModal()
+        
+    })
+
 
     ## Global reactive values for app-wide triggering
     r_global <- reactiveValues(

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -187,7 +187,7 @@ app_server <- function(input, output, session) {
         
         info("[SERVER:getPGXINFO] updating datasets-info.csv")
         pgx.showCartoonModal()
-        getPGXINFO()
+        try(getPGXINFO())
         shiny::removeModal()
         
     })
@@ -694,17 +694,7 @@ Upgrade today and experience advanced analysis features without the time limit.<
         ## trigger on change of USER
         logged <- auth$logged()
         info("[server.R & TIMEOUT>0] change in user log status : logged = ",logged)
-        
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        info("CALLING PGX INFO FUNCTION")
-        
-        getPGXINFO()
+
         ##--------- start timer --------------
         if(TIMEOUT>0 && logged) {
           info("[server.R] starting session timer!!!")

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -473,7 +473,6 @@ LoadingBoard <- function(id,
     ## -----------------------------------------------------------------------------
     ## READ initial PGX file info
     ## -----------------------------------------------------------------------------
-
   
     getPGXINFO_SHARED <- shiny::eventReactive({
       rl$reload_pgxdir_shared
@@ -504,6 +503,7 @@ LoadingBoard <- function(id,
       for(s in missing.cols) info[[s]] <- rep(NA,nrow(info))
       ii <- match(info.colnames,colnames(info))
       info <- info[,ii]
+
       info
     })
 
@@ -557,6 +557,7 @@ LoadingBoard <- function(id,
                     not showing table!")
         return(NULL)
       }
+      pgx.showSmallModal()
       df <- getPGXINFO_SHARED()
       shiny::req(df)
 
@@ -583,6 +584,8 @@ LoadingBoard <- function(id,
       ))
       kk <- intersect(kk, colnames(df))
       df <- df[, kk, drop = FALSE]
+
+      shiny::removeModal(session)
       df
     })
 
@@ -613,6 +616,9 @@ LoadingBoard <- function(id,
         return(NULL)
       }
 
+      # add modal
+      pgx.showSmallModal()
+
       ## update meta files
       shiny::withProgress(message = "Updating shared library...", value = 0.33, {
         dbg("[loading_server.R:getPGXINFO_SHARED] calling scanInfoFile()")
@@ -640,6 +646,9 @@ LoadingBoard <- function(id,
 
       pgxdir <- getPGXDIR()
       pgxfiles <- dir(pgxdir, pattern = '__from__')
+
+      # remove modal
+      shiny::removeModal(session)
       pgxfiles
     })
 

--- a/components/modules/WelcomeBoard.R
+++ b/components/modules/WelcomeBoard.R
@@ -5,6 +5,7 @@
 
 WelcomeBoard <- function(id, auth, enable_upload, r_global) {
   moduleServer(id, function(input, output, session) {
+    shiny::removeModal()
     ns <- session$ns ## NAMESPACE
 
     output$welcome <- shiny::renderText({


### PR DESCRIPTION
This fixes #503 

**Path to solution:**
-  I tried MANY things with the `getPGXINFO` and `getPGXDIR` in the loading board. Nothing works as these functions are triggered before any button in the welcome page can be clicked. That means we will have to wait 5-60 seconds to see a response from server when clicking any button in welcome page.
- solution was to move `getPGXINFO` and `getPGXDIR` to server, so it gives more flexibility when to call these functions.
- I decided to create an observer that checks if user is logged in, and if yes, it will release a modal in the welcome page. This was not possilble before, when these functions were in loading board.
- Note that this issue only happens in special cases where the `datasets-sigdb.h5`, `datasets-allFC.csv`, `datasets-info.csv` need to be updated.

**Possible future developments:**
- separate UMAP and tSNE calculation from these functions, so that UMAP, tSNE are only triggered when really needed. Which could be loading board table clicked (?). This should make welcome page be released quicker, postponing the computation overhead.
- Run the  `getPGXINFO` and `getPGXDIR` as background computation, as they can take some time.
- Bring the  `getPGXINFO` and `getPGXDIR' even earlier, when user first authenticate. This is the earlist I could get without having to do a lot more dangerous things.
- Find a better place to call `getPGXINFO` and `getPGXDIR`, maybe when we click any button in welcome page? This will need a lot of evaluation, as there's a lot of reactivity behind.

**tests:**
- logged, not logged
- starting OPG with and without `datasets-sigdb.h5`, `datasets-allFC.csv`, `datasets-info.csv`
- adding a pgx in data/

**Please help with tests, as this is a critical module in OPG!**