### PR TITLE
Fix frozen welcome page v2 (simplified)

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -500,6 +500,8 @@ LoadingBoard <- function(id,
         warning("[LoadingBoard:getPGXINFO] user not logged in!")
         return(NULL)
       }
+
+      pgx.showSmallModal()
       info <- NULL
       pdir <- getPGXDIR()
       shiny::withProgress(message = "Updating library...", value = 0.33, {
@@ -520,6 +522,7 @@ LoadingBoard <- function(id,
       for(s in missing.cols) info[[s]] <- rep(NA,nrow(info))
       ii <- match(info.colnames,colnames(info))
       info <- info[,ii]
+      removeModal(session)
       info
     })
 

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -607,6 +607,7 @@ LoadingBoard <- function(id,
                     not showing table!")
         return(NULL)
       }
+      pgx.showSmallModal()
       df <- getPGXINFO_SHARED()
       shiny::req(df)
 
@@ -633,6 +634,7 @@ LoadingBoard <- function(id,
       ))
       kk <- intersect(kk, colnames(df))
       df <- df[, kk, drop = FALSE]
+      shiny::removeModal(session)
       df
     })
 
@@ -663,6 +665,9 @@ LoadingBoard <- function(id,
         return(NULL)
       }
 
+            # add modal
+      pgx.showSmallModal()
+
       ## update meta files
       shiny::withProgress(message = "Updating shared library...", value = 0.33, {
         dbg("[loading_server.R:getPGXINFO_SHARED] calling scanInfoFile()")
@@ -691,7 +696,9 @@ LoadingBoard <- function(id,
 
       pgxdir <- getPGXDIR()
       pgxfiles <- dir(pgxdir, pattern = '__from__')
+      shiny::removeModal()
       pgxfiles
+
     })
 
     makebuttonInputs2 <- function(FUN, len, id, ...) {


### PR DESCRIPTION
This fixes https://github.com/bigomics/omicsplayground/issues/503

Path to solution:

- I tried MANY things with the getPGXINFO and getPGXDIR in the loading board w.r.t. reactivity. Nothing works to delay these functions are triggered before any button in the welcome page can be clicked. And adding response to buttons is not a good way to solve this.
- simplest solution was to add modal in welcome page. Ugly but does the job for now, especially for the cases where info files are updated (new logins...)

**Possible future developments:**

- separate UMAP and tSNE calculation from these functions, so that UMAP, tSNE are only triggered when really needed. Which could be loading board table clicked (?). This should make welcome page be released quicker, postponing the computation overhead.
- Run the getPGXINFO and getPGXDIR as background computation or assync, as they can take some time.
- Bring the getPGXINFO and `getPGXDIR' even earlier or to a better server spot.

**tests:**

logged, not logged
starting OPG with and without datasets-sigdb.h5, datasets-allFC.csv, datasets-info.csv
adding a pgx in data/

**Please help with tests, as this is a critical module in OPG!**