### PR TITLE
Move all input file checks from OPG to playbase

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -480,8 +480,8 @@ UploadBoard <- function(id,
             })
           }
 
-          uploaded[["samples.csv"]] <- FILES_check$samples
-          uploaded[["counts.csv"]] <- FILES_check$counts
+          uploaded[["samples.csv"]] <- FILES_check$SAMPLES
+          uploaded[["counts.csv"]] <- FILES_check$COUNTS
           samples1 <- FILES_check$SAMPLES
           counts1 <- FILES_check$COUNTS
           a1 <- mean(rownames(samples1) %in% colnames(counts1))
@@ -513,8 +513,8 @@ UploadBoard <- function(id,
           SAMPLES = uploaded[["samples.csv"]],
           CONTRASTS = uploaded[["contrasts.csv"]]
         )
-        
-        uploaded[["samples.csv"]] <- FILES_check$samples
+
+        uploaded[["samples.csv"]] <- FILES_check$SAMPLES
         uploaded[["contrasts.csv"]] <- FILES_check$CONTRASTS
 
         if(length(FILES_check$check)>0) {
@@ -536,18 +536,13 @@ UploadBoard <- function(id,
 
         if(FILES_check$PASS == FALSE) {
           status["samples.csv"] <- "Error, please check your samples files."
-          status["counts.csv"] <- "Error, please check your counts files."
-          uploaded[["counts.csv"]] <- NULL
+          status["contrasts.csv"] <- "Error, please check your contrasts files."
+          uploaded[["samples.csv"]] <- NULL
           uploaded[["contrasts.csv"]] <- NULL
         }
 
-        if(FILES_check$PASS == TRUE) {
-            status["samples.csv"] <- "OK"
-            status["counts.csv"] <- "OK"
-          }
+        
       }
-
-      browser()
 
       MAXSAMPLES <- 25
       MAXCONTRASTS <- 5
@@ -596,7 +591,6 @@ UploadBoard <- function(id,
           status["counts.csv"] <- "please upload"
         }
       }
-
 
       if (!is.null(uploaded$contrasts.csv) &&
         (is.null(uploaded$counts.csv) ||

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -273,7 +273,7 @@ UploadBoard <- function(id,
               ## allows duplicated rownames
               df0 <- playbase::read.as_matrix(fn2)
               
-              COUNTS_check <- playbase::pgx.checkPGX(df0, "COUNTS")
+              COUNTS_check <- playbase::pgx.checkINPUT(df0, "COUNTS")
 
               if(length(COUNTS_check$check)>0) {
                 lapply(1:length(COUNTS_check$check), function(idx){
@@ -308,7 +308,7 @@ UploadBoard <- function(id,
             if (IS_SAMPLE) {
               df0 <- playbase::read.as_matrix(fn2)
               
-              SAMPLES_check <- playbase::pgx.checkPGX(df0, "SAMPLES")
+              SAMPLES_check <- playbase::pgx.checkINPUT(df0, "SAMPLES")
 
               if(length(SAMPLES_check$check)>0) {
                 lapply(1:length(SAMPLES_check$check), function(idx){
@@ -336,7 +336,7 @@ UploadBoard <- function(id,
             if (IS_CONTRAST) {
               df0 <- playbase::read.as_matrix(fn2)
               
-              CONTRASTS_check <- playbase::pgx.checkPGX(df0, "CONTRASTS")
+              CONTRASTS_check <- playbase::pgx.checkINPUT(df0, "CONTRASTS")
 
               if(length(CONTRASTS_check$check)>0) {
                 lapply(1:length(CONTRASTS_check$check), function(idx){
@@ -425,7 +425,6 @@ UploadBoard <- function(id,
       }
     })
 
-
     ## =====================================================================
     ## ===================== checkTables ===================================
     ## =====================================================================
@@ -457,7 +456,7 @@ UploadBoard <- function(id,
         ## check rownames of samples.csv
         if (status["samples.csv"] == "OK" && status["counts.csv"] == "OK") {
 
-          FILES_check <- playbase::pgx.checkPGX_all(
+          FILES_check <- playbase::pgx.crosscheckINPUT(
             SAMPLES = uploaded[["samples.csv"]],
             COUNTS = uploaded[["counts.csv"]]
             )
@@ -506,7 +505,7 @@ UploadBoard <- function(id,
 
         if (status["contrasts.csv"] == "OK" && status["samples.csv"] == "OK") {
           
-          FILES_check <- playbase::pgx.checkPGX_all(
+          FILES_check <- playbase::pgx.crosscheckINPUT(
             SAMPLES = uploaded[["samples.csv"]],
             CONTRASTS = uploaded[["contrasts.csv"]]
             )

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -448,6 +448,8 @@ UploadBoard <- function(id,
         }
       }
 
+      browser()
+
       has.pgx <- ("pgx" %in% names(uploaded))
       if (has.pgx) has.pgx <- has.pgx && !is.null(uploaded[["pgx"]])
       if (has.pgx == TRUE) {
@@ -469,81 +471,81 @@ UploadBoard <- function(id,
 
         ## check files: matching dimensions
         if (status["counts.csv"] == "OK" && status["samples.csv"] == "OK") {
-          nsamples <- max(ncol(uploaded[["counts.csv"]]), nrow(uploaded[["samples.csv"]]))
-          ok.samples <- intersect(
-            rownames(uploaded$samples.csv),
-            colnames(uploaded$counts.csv)
-          )
-          n.ok <- length(ok.samples)
-          message("[UploadModule::checkTables] n.ok = ", n.ok)
-          if (n.ok > 0 && n.ok < nsamples) {
-            ## status["counts.csv"]  = "WARNING: some samples with missing annotation)"
-          }
+          # nsamples <- max(ncol(uploaded[["counts.csv"]]), nrow(uploaded[["samples.csv"]]))
+          # ok.samples <- intersect(
+          #   rownames(uploaded$samples.csv),
+          #   colnames(uploaded$counts.csv)
+          # )
+          # n.ok <- length(ok.samples)
+          # message("[UploadModule::checkTables] n.ok = ", n.ok)
+          # if (n.ok > 0 && n.ok < nsamples) {
+          #   ## status["counts.csv"]  = "WARNING: some samples with missing annotation)"
+          # }
 
-          if (n.ok > 0) {
-            message("[UploadModule::checkTables] conforming samples/counts...")
-            uploaded[["samples.csv"]] <- uploaded$samples.csv[ok.samples, , drop = FALSE]
-            uploaded[["counts.csv"]] <- uploaded$counts.csv[, ok.samples, drop = FALSE]
-          }
+          # if (n.ok > 0) {
+          #   message("[UploadModule::checkTables] conforming samples/counts...")
+          #   uploaded[["samples.csv"]] <- uploaded$samples.csv[ok.samples, , drop = FALSE]
+          #   uploaded[["counts.csv"]] <- uploaded$counts.csv[, ok.samples, drop = FALSE]
+          # }
 
-          if (n.ok == 0) {
-            status["counts.csv"] <- "ERROR: colnames do not match (with samples)"
-            status["samples.csv"] <- "ERROR: rownames do not match (with counts)"
-          }
+          # if (n.ok == 0) {
+          #   status["counts.csv"] <- "ERROR: colnames do not match (with samples)"
+          #   status["samples.csv"] <- "ERROR: rownames do not match (with counts)"
+          # }
         }
 
         if (status["contrasts.csv"] == "OK" && status["samples.csv"] == "OK") {
-          samples1 <- uploaded[["samples.csv"]]
-          contrasts1 <- uploaded[["contrasts.csv"]]
-          group.col <- grep("group", tolower(colnames(samples1)))
-          old1 <- (length(group.col) > 0 &&
-            nrow(contrasts1) < nrow(samples1) &&
-            all(rownames(contrasts1) %in% samples1[, group.col[1]])
-          )
-          old2 <- all(rownames(contrasts1) == rownames(samples1)) &&
-            all(unique(as.vector(contrasts1)) %in% c(-1, 0, 1, NA))
+          # samples1 <- uploaded[["samples.csv"]]
+          # contrasts1 <- uploaded[["contrasts.csv"]]
+          # group.col <- grep("group", tolower(colnames(samples1)))
+          # old1 <- (length(group.col) > 0 &&
+          #   nrow(contrasts1) < nrow(samples1) &&
+          #   all(rownames(contrasts1) %in% samples1[, group.col[1]])
+          # )
+          # old2 <- all(rownames(contrasts1) == rownames(samples1)) &&
+          #   all(unique(as.vector(contrasts1)) %in% c(-1, 0, 1, NA))
 
-          old.style <- (old1 || old2)
-          if (old.style && old1) {
-            message("[UploadModule] WARNING: converting old1 style contrast to new format")
-            new.contrasts <- samples1[, 0]
-            if (NCOL(contrasts1) > 0) {
-              new.contrasts <- playbase::contrastAsLabels(contrasts1)
-              grp <- as.character(samples1[, group.col])
-              new.contrasts <- new.contrasts[grp, , drop = FALSE]
-              rownames(new.contrasts) <- rownames(samples1)
-            }
-            contrasts1 <- new.contrasts
-          }
-          if (old.style && old2) {
-            message("[UploadModule] WARNING: converting old2 style contrast to new format")
-            new.contrasts <- samples1[, 0]
-            if (NCOL(contrasts1) > 0) {
-              new.contrasts <- playbase::contrastAsLabels(contrasts1)
-              rownames(new.contrasts) <- rownames(samples1)
-            }
-            contrasts1 <- new.contrasts
-          }
+          # old.style <- (old1 || old2)
+          # if (old.style && old1) {
+          #   message("[UploadModule] WARNING: converting old1 style contrast to new format")
+          #   new.contrasts <- samples1[, 0]
+          #   if (NCOL(contrasts1) > 0) {
+          #     new.contrasts <- playbase::contrastAsLabels(contrasts1)
+          #     grp <- as.character(samples1[, group.col])
+          #     new.contrasts <- new.contrasts[grp, , drop = FALSE]
+          #     rownames(new.contrasts) <- rownames(samples1)
+          #   }
+          #   contrasts1 <- new.contrasts
+          # }
+          # if (old.style && old2) {
+          #   message("[UploadModule] WARNING: converting old2 style contrast to new format")
+          #   new.contrasts <- samples1[, 0]
+          #   if (NCOL(contrasts1) > 0) {
+          #     new.contrasts <- playbase::contrastAsLabels(contrasts1)
+          #     rownames(new.contrasts) <- rownames(samples1)
+          #   }
+          #   contrasts1 <- new.contrasts
+        #   # }
 
-          dbg("[UploadModule] 1 : dim.contrasts1 = ", dim(contrasts1))
-          dbg("[UploadModule] 1 : dim.samples1   = ", dim(samples1))
+        #   dbg("[UploadModule] 1 : dim.contrasts1 = ", dim(contrasts1))
+        #   dbg("[UploadModule] 1 : dim.samples1   = ", dim(samples1))
 
-          ok.contrast <- length(intersect(rownames(samples1), rownames(contrasts1))) > 0
-          if (ok.contrast && NCOL(contrasts1) > 0) {
-            ## always clean up
-            contrasts1 <- apply(contrasts1, 2, as.character)
-            rownames(contrasts1) <- rownames(samples1)
-            for (i in 1:ncol(contrasts1)) {
-              isz <- (contrasts1[, i] %in% c(NA, "NA", "NA ", "", " ", "  ", "   ", " NA"))
-              if (length(isz)) contrasts1[isz, i] <- NA
-            }
-            uploaded[["contrasts.csv"]] <- contrasts1
-            status["contrasts.csv"] <- "OK"
-          } else {
-            uploaded[["contrasts.csv"]] <- NULL
-            status["contrasts.csv"] <- "ERROR: dimension mismatch"
-          }
-        }
+        #   ok.contrast <- length(intersect(rownames(samples1), rownames(contrasts1))) > 0
+        #   if (ok.contrast && NCOL(contrasts1) > 0) {
+        #     ## always clean up
+        #     contrasts1 <- apply(contrasts1, 2, as.character)
+        #     rownames(contrasts1) <- rownames(samples1)
+        #     for (i in 1:ncol(contrasts1)) {
+        #       isz <- (contrasts1[, i] %in% c(NA, "NA", "NA ", "", " ", "  ", "   ", " NA"))
+        #       if (length(isz)) contrasts1[isz, i] <- NA
+        #     }
+        #     uploaded[["contrasts.csv"]] <- contrasts1
+        #     status["contrasts.csv"] <- "OK"
+        #   } else {
+        #     uploaded[["contrasts.csv"]] <- NULL
+        #     status["contrasts.csv"] <- "ERROR: dimension mismatch"
+        #   }
+        # }
 
         MAXSAMPLES <- 25
         MAXCONTRASTS <- 5
@@ -568,13 +570,13 @@ UploadBoard <- function(id,
         }
 
         ## check samples.csv: must have group column defined
-        if (status["samples.csv"] == "OK" && status["contrasts.csv"] == "OK") {
-          samples1 <- uploaded[["samples.csv"]]
-          contrasts1 <- uploaded[["contrasts.csv"]]
-          if (!all(rownames(contrasts1) %in% rownames(samples1))) {
-            status["contrasts.csv"] <- "ERROR: contrasts do not match samples"
-          }
-        }
+        # if (status["samples.csv"] == "OK" && status["contrasts.csv"] == "OK") {
+        #   samples1 <- uploaded[["samples.csv"]]
+        #   contrasts1 <- uploaded[["contrasts.csv"]]
+        #   # if (!all(rownames(contrasts1) %in% rownames(samples1))) {
+        #   #   status["contrasts.csv"] <- "ERROR: contrasts do not match samples"
+        #   # }
+        # }
       } ## end-if-from-pgx
 
       e1 <- grepl("ERROR", status["samples.csv"])

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -447,6 +447,7 @@ UploadBoard <- function(id,
         }
       }
 
+      error_list <- playbase::PGX_CHECKS
 
       has.pgx <- ("pgx" %in% names(uploaded))
       if (has.pgx) has.pgx <- has.pgx && !is.null(uploaded[["pgx"]])
@@ -480,11 +481,8 @@ UploadBoard <- function(id,
 
           uploaded[["samples.csv"]] <- FILES_check$samples
           uploaded[["counts.csv"]] <- FILES_check$counts
-
-
           samples1 <- FILES_check$SAMPLES
           counts1 <- FILES_check$COUNTS
-          
           a1 <- mean(rownames(samples1) %in% colnames(counts1))
           a2 <- mean(samples1[, 1] %in% colnames(counts1))
 
@@ -508,7 +506,7 @@ UploadBoard <- function(id,
           FILES_check <- playbase::pgx.crosscheckINPUT(
             SAMPLES = uploaded[["samples.csv"]],
             CONTRASTS = uploaded[["contrasts.csv"]]
-            )
+          )
           
           uploaded[["samples.csv"]] <- FILES_check$samples
           uploaded[["contrasts.csv"]] <- FILES_check$CONTRASTS
@@ -557,18 +555,8 @@ UploadBoard <- function(id,
           }
           if (nrow(uploaded[["samples.csv"]]) > MAXSAMPLES) {
             status["samples.csv"] <- paste("ERROR: max", MAXSAMPLES, "samples allowed")
-          }
         }
-
-        ## check samples.csv: must have group column defined
-        # if (status["samples.csv"] == "OK" && status["contrasts.csv"] == "OK") {
-        #   samples1 <- uploaded[["samples.csv"]]
-        #   contrasts1 <- uploaded[["contrasts.csv"]]
-        #   # if (!all(rownames(contrasts1) %in% rownames(samples1))) {
-        #   #   status["contrasts.csv"] <- "ERROR: contrasts do not match samples"
-        #   # }
-        # }
-      } ## end-if-from-pgx
+      }
 
       e1 <- grepl("ERROR", status["samples.csv"])
       e2 <- grepl("ERROR", status["contrasts.csv"])

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -448,7 +448,7 @@ UploadBoard <- function(id,
         }
       }
 
-      browser()
+      # browser()
 
       has.pgx <- ("pgx" %in% names(uploaded))
       if (has.pgx) has.pgx <- has.pgx && !is.null(uploaded[["pgx"]])
@@ -457,8 +457,17 @@ UploadBoard <- function(id,
       } else if (!has.pgx) {
         ## check rownames of samples.csv
         if (status["samples.csv"] == "OK" && status["counts.csv"] == "OK") {
-          samples1 <- uploaded[["samples.csv"]]
-          counts1 <- uploaded[["counts.csv"]]
+          
+          
+          
+          FILES_check <- playbase::pgx.checkPGX_all(
+            SAMPLES = uploaded[["samples.csv"]],
+            COUNTS = counts1 <- uploaded[["counts.csv"]]
+            )
+
+          samples1 <- FILES_check$SAMPLES
+          counts1 <- FILES_check$COUNTS
+          
           a1 <- mean(rownames(samples1) %in% colnames(counts1))
           a2 <- mean(samples1[, 1] %in% colnames(counts1))
 
@@ -546,6 +555,7 @@ UploadBoard <- function(id,
         #     status["contrasts.csv"] <- "ERROR: dimension mismatch"
         #   }
         # }
+        }
 
         MAXSAMPLES <- 25
         MAXCONTRASTS <- 5

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -500,37 +500,12 @@ UploadBoard <- function(id,
             status["counts.csv"] <- "Error, please check your counts files."
             uploaded[["counts.csv"]] <- NULL
             uploaded[["samples.csv"]] <- NULL
+            }
           }
         }
 
-        ## check files: matching dimensions
-        
-          # nsamples <- max(ncol(uploaded[["counts.csv"]]), nrow(uploaded[["samples.csv"]]))
-          # ok.samples <- intersect(
-          #   rownames(uploaded$samples.csv),
-          #   colnames(uploaded$counts.csv)
-          # )
-          # n.ok <- length(ok.samples)
-          # message("[UploadModule::checkTables] n.ok = ", n.ok)
-          # if (n.ok > 0 && n.ok < nsamples) {
-          #   ## status["counts.csv"]  = "WARNING: some samples with missing annotation)"
-          # }
-
-          # if (n.ok > 0) {
-          #   message("[UploadModule::checkTables] conforming samples/counts...")
-          #   uploaded[["samples.csv"]] <- uploaded$samples.csv[ok.samples, , drop = FALSE]
-          #   uploaded[["counts.csv"]] <- uploaded$counts.csv[, ok.samples, drop = FALSE]
-          # }
-
-          # if (n.ok == 0) {
-          #   status["counts.csv"] <- "ERROR: colnames do not match (with samples)"
-          #   status["samples.csv"] <- "ERROR: rownames do not match (with counts)"
-          # }
-        }
-
         if (status["contrasts.csv"] == "OK" && status["samples.csv"] == "OK") {
-
-
+          
           FILES_check <- playbase::pgx.checkPGX_all(
             SAMPLES = uploaded[["samples.csv"]],
             CONTRASTS = uploaded[["contrasts.csv"]]
@@ -556,67 +531,12 @@ UploadBoard <- function(id,
             })
           }
 
-
-
           if(FILES_check$PASS == FALSE) {
             status["samples.csv"] <- "Error, please check your samples files."
             status["counts.csv"] <- "Error, please check your counts files."
             uploaded[["counts.csv"]] <- NULL
             uploaded[["contrasts.csv"]] <- NULL
           }
-
-          
-          # samples1 <- uploaded[["samples.csv"]]
-          # contrasts1 <- uploaded[["contrasts.csv"]]
-          # group.col <- grep("group", tolower(colnames(samples1)))
-          # old1 <- (length(group.col) > 0 &&
-          #   nrow(contrasts1) < nrow(samples1) &&
-          #   all(rownames(contrasts1) %in% samples1[, group.col[1]])
-          # )
-          # old2 <- all(rownames(contrasts1) == rownames(samples1)) &&
-          #   all(unique(as.vector(contrasts1)) %in% c(-1, 0, 1, NA))
-
-          # old.style <- (old1 || old2)
-          # if (old.style && old1) {
-          #   message("[UploadModule] WARNING: converting old1 style contrast to new format")
-          #   new.contrasts <- samples1[, 0]
-          #   if (NCOL(contrasts1) > 0) {
-          #     new.contrasts <- playbase::contrastAsLabels(contrasts1)
-          #     grp <- as.character(samples1[, group.col])
-          #     new.contrasts <- new.contrasts[grp, , drop = FALSE]
-          #     rownames(new.contrasts) <- rownames(samples1)
-          #   }
-          #   contrasts1 <- new.contrasts
-          # }
-          # if (old.style && old2) {
-          #   message("[UploadModule] WARNING: converting old2 style contrast to new format")
-          #   new.contrasts <- samples1[, 0]
-          #   if (NCOL(contrasts1) > 0) {
-          #     new.contrasts <- playbase::contrastAsLabels(contrasts1)
-          #     rownames(new.contrasts) <- rownames(samples1)
-          #   }
-          #   contrasts1 <- new.contrasts
-        #   # }
-
-        #   dbg("[UploadModule] 1 : dim.contrasts1 = ", dim(contrasts1))
-        #   dbg("[UploadModule] 1 : dim.samples1   = ", dim(samples1))
-
-        #   ok.contrast <- length(intersect(rownames(samples1), rownames(contrasts1))) > 0
-        #   if (ok.contrast && NCOL(contrasts1) > 0) {
-        #     ## always clean up
-        #     contrasts1 <- apply(contrasts1, 2, as.character)
-        #     rownames(contrasts1) <- rownames(samples1)
-        #     for (i in 1:ncol(contrasts1)) {
-        #       isz <- (contrasts1[, i] %in% c(NA, "NA", "NA ", "", " ", "  ", "   ", " NA"))
-        #       if (length(isz)) contrasts1[isz, i] <- NA
-        #     }
-        #     uploaded[["contrasts.csv"]] <- contrasts1
-        #     status["contrasts.csv"] <- "OK"
-        #   } else {
-        #     uploaded[["contrasts.csv"]] <- NULL
-        #     status["contrasts.csv"] <- "ERROR: dimension mismatch"
-        #   }
-        # }
         }
 
         MAXSAMPLES <- 25


### PR DESCRIPTION
**WARNING: This requires https://github.com/bigomics/playbase/pull/19**

On this PR I moved all input checks of input files that were in OPG to playbase, as funcional calls..

**Goal:**
-  Allow users (DNAnexus) to check their files before creating pgx externally. Before this was not possible, as these checks were not funcional calls.
- Easy to add new checks and tests.
- Avoid corrupted input files ingestion into omicsplayground/pgx compute
- Allow Nick to show check errors in data preview.

This will close multiple issues, as we avoid corrupted pgx injection into compute pgx. 

For example, this issue is now fixed. https://github.com/bigomics/omicsplayground/issues/507
<img width="1073" alt="image" src="https://github.com/bigomics/omicsplayground/assets/28757711/b13cd80e-436a-44c3-90af-cc89e16a3db3">

Output of check functions:
- Corrected input files (if possible and safe to do so)
- List of checks and behaviors are here: `playbase::PGX_CHECKS`. Most checks (but not all) are yet implemented, you can search for the error ID in the upload module (e1, e2, e3..). The ones with description are implemented.

Checks I performed:
- Short and long contrast forms
- MANY datasets with and without problems.

Future:
- This will eventually be used by Nick on data preview.
- Expand checks based on testing and _ad hoc_ knowledge.

**This is a critical PR, please help me checking!**

