### PR TITLE
Fix card footer height

### DIFF
--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -17,6 +17,7 @@ html {
         padding: 2px 0 0 2px;
         height: 3em !important;
         max-height: 3em !important;
+        min-height: 3em !important;
         display: none;
     }
     

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -15,9 +15,9 @@ html {
     .card-footer {
         background-color: #F7FAFD;
         padding: 2px 0 0 2px;
-	height: 3em !important;
-	// height: 0em !important;
-	display: none;
+        height: 3em !important;
+        max-height: 3em !important;
+        display: none;
     }
     
     .card-footer-switch{


### PR DESCRIPTION
fix for #525, legend were too small or too big, app wide. This is now fixed with min and max height.

<img width="758" alt="image" src="https://github.com/bigomics/omicsplayground/assets/28757711/00cd1636-99c7-48aa-9e2a-0be2d375b121">
