### PR TITLE
Refactor public table

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -209,14 +209,19 @@ LoadingBoard <- function(id,
 
       pgxtable_public <- loading_table_datasets_public_server(
         id = "pgxtable_public",
-        table = reactive(rl$pgxTablePublic_data),
-        pgxtable_data = getPGXDIR
+        getPGXDIR = getPGXDIR,
+        pgx_public_dir = pgx_public_dir,
+        rl = rl,
+        auth = auth,
+        enable_delete = enable_delete,
+        limits = limits,
+        r_global = r_global
       )
 
       loading_tsne_server(
         id = "tsne_public",
         pgx.dir = reactive(pgx_public_dir),
-        info.table = getFilteredPGXINFO_PUBLIC,
+        info.table = reactive(pgxtable_public$data()),
         r_selected = reactive(pgxtable_public$rows_all()),
         watermark = WATERMARK
       )

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -48,17 +48,9 @@ loading_table_datasets_ui <- function(
         ns("loadbutton"),
         label = "Load dataset",
         icon = icon("file-import"),
-        ##        class = "btn btn-outline-primary",
         class = "btn btn-primary",
         width = NULL
       )
-      ## shiny::actionButton(
-      ##   ns("deletebutton"),
-      ##   label = "Delete dataset",
-      ##   icon = icon("file-delete"),
-      ##   class = "btn btn-outline-danger",
-      ##   width = NULL
-      ## )
     ) ## end of buttons div
   )
 

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -40,7 +40,7 @@ LoadingUI <- function(id) {
       width = 1,
       heights_equal = "row",
       height = "calc(100vh - 180px)",
-      uiOutput(ns("sharing_alert")),      
+      uiOutput(ns("sharing_alert")),
       bslib::layout_column_wrap(
         width = 1,
         style = htmltools::css(grid_template_columns = "7fr 5fr"),
@@ -90,23 +90,15 @@ LoadingUI <- function(id) {
           height = c("calc(100vh - 330px)", 700),
           width = c("auto",  "100%")
         )
-      ), ## end of 7fr-5fr
-      div(
-        id = "load-action-buttons",
-        shiny::actionButton(
-          ns("importbutton"),
-          label = "Import dataset", icon = icon("file-import"),
-              class = "btn btn-outline-primary"
-        )
-          ) ## end of buttons div
+      ) ## end of 7fr-5fr
     ) ## end first layout_column_wrap
   ) ## end of Public tabPanel
-  
+
   sharing_tabpanel <- shiny::tabPanel(
     'Sharing',
     bslib::layout_column_wrap(
       width = 1,
-      heights_equal = "row",          
+      heights_equal = "row",
       height = "calc(100vh - 180px)",
       bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
       bslib::layout_column_wrap(
@@ -114,7 +106,7 @@ LoadingUI <- function(id) {
         height = "calc(100vh - 180px)",
         uiOutput(ns("sharing_panel_ui"))
       )
-    ) 
+    )
   ) ## end of Public tabPanel
 
 
@@ -125,7 +117,7 @@ LoadingUI <- function(id) {
   if(!dir.exists(public_dir)) {
     public_tabpanel <- NULL
   }
-  
+
   ## ============================ Board object ===========================
   div(
     class = "p-0",


### PR DESCRIPTION
This PR cleans the loading server and removes a lot of triggers that were previously needed to communicate back-and-forth between the public table server and the loading server. Now, all of the relevant actions are contained within the public table server as they should be.