### PR TITLE
implement user options

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -17,7 +17,8 @@ LoadingBoard <- function(id,
                          enable_delete = TRUE,
                          enable_user_share = TRUE,
                          enable_public_share = TRUE,
-                         r_global) {
+                         r_global,
+                         is_data_loaded) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
 
@@ -438,6 +439,9 @@ LoadingBoard <- function(id,
     touchtable <- shiny::reactiveVal(0)
 
 
+    observeEvent(r_global$loadedDataset,{
+      if (r_global$loadedDataset != 0) is_data_loaded(r_global$loadedDataset)
+    })
     ## ------------------------------------------------
     ## Board return object
     ## ------------------------------------------------

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -244,15 +244,14 @@ loading_table_datasets_server <- function(id,
       !is.null(btn) && logged
     })
 
-
     shiny::observeEvent(load_react(), {
       if (!load_react()) {
         return(NULL)
       }
 
-      on.exit({
-        bigdash.showTabsGoToDataView(session) ## in ui-bigdashplus.R
-      })
+      #on.exit({
+      #  if (load_react()) bigdash.showTabsGoToDataView(session) ## in ui-bigdashplus.R
+      #})
 
       pgxfile <- NULL
 

--- a/omicsplayground.Rproj
+++ b/omicsplayground.Rproj
@@ -6,7 +6,7 @@ AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes
-NumSpacesForTab: 4
+NumSpacesForTab: 2
 Encoding: UTF-8
 
 RnwWeave: Sweave


### PR DESCRIPTION
This PR implements user options. However, the auth code is quite inconsistent (for example, auth$logged() triggers all observers when the app starts and not just when the user is logged in like you might expect) and the bigdash actions (particularly when menu items are hidden/shown) are hard to track down. So there are seemingly some issues with signing out and signing in again, or refreshing the page. That should be tested thoroughly.

The approach was to wait until the user logs in to call the LoadingBoard and the UploadBoard with the user-modified OPTIONS. Since the app was not designed for this and expects LoadingBoard and UploadBoard to be called from the app start, there are some unintended reactivity issues. Another approach would be to keep the structure as it is but make the options into reactives that are passed to LoadingBoard and UploadBoard on app start.

A good example to test this PR is the following:
- sign in with jane / demo and then sign out
- go into the data/jane/OPTIONS file that was created and change "ENABLE_USER_SHARE" to False
- sign in with jane again and go to the loading data table, open the menu for a pgx file in the table, and you should see that jane cannot share with another user
- now sign in with tarzan / demo and you should see that he can still share data because that is the default

