### PR TITLE
ENABLE_USER_SHARE prevents shared datasets messages

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -64,6 +64,11 @@ LoadingBoard <- function(id,
     )
 
     if (enable_user_share==FALSE) {
+      
+      output$sharing_alert <- renderUI({
+        bs_alert(HTML("This table shows the <b>available datasets</b> in your library. The table reports a brief description of each dataset. The <b>Signature t-SNE</b> shows similarity clustering of fold-change signatures using t-SNE. Select a dataset in the table and load the data by clicking the <b>Load Dataset</b> button below."))
+      })
+
       output$sharing_panel_ui <- renderUI(
         "The demo version does not allow sharing of datasets."
       )

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -91,16 +91,22 @@ LoadingBoard <- function(id,
         shiny::HTML(paste(msg, "Please check the Sharing panel."))
       )
     })
-    browser()
+
     if (enable_user_share==TRUE) {
-    
+      
       output$sharing_panel_ui <- renderUI({
+        
+        received_files <- pgxreceived$getReceivedFiles()
+        shared_files <- pgxshared$getSharedFiles()
+        num_received <- length(received_files)
+        num_shared <- length(shared_files)
+        
         if (num_received == 0 && num_shared == 0) {
           return(paste("No datasets being shared."))
         }
 
         out <- tagList()
-        if (length(out) == 0) browser()/{
+        if (length(out) == 0){
           if (num_received > 0) {
             out1 <- shiny::wellPanel(
               shiny::HTML("<b>Received datasets.</b> Accept or refuse the received dataset using the action buttons on the right."),
@@ -124,10 +130,7 @@ LoadingBoard <- function(id,
             }
           }
         }
-        received_files <- pgxreceived$getReceivedFiles()
-        shared_files <- pgxshared$getSharedFiles()
-        num_received <- length(received_files)
-        num_shared <- length(shared_files)
+        
 
          shiny::tabPanel(
           "Sharing",
@@ -143,7 +146,6 @@ LoadingBoard <- function(id,
             )
           )
         )
-        return(out)
       })
     } else {
       output$sharing_panel_ui <- renderUI({NULL})

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -63,37 +63,43 @@ LoadingBoard <- function(id,
       refresh = refresh_shared
     )
 
-    output$sharing_alert <- renderUI({
-      received_files <- pgxreceived$getReceivedFiles()
-      shared_files <- pgxshared$getSharedFiles()
-      num_received <- length(received_files)
-      num_shared <- length(shared_files)
-
-
-      if (num_received == 0 && num_shared == 0) {
-        tag <- bs_alert(HTML("This table shows the <b>available datasets</b> in your library. The table reports a brief description of each dataset. The <b>Signature t-SNE</b> shows similarity clustering of fold-change signatures using t-SNE. Select a dataset in the table and load the data by clicking the <b>Load Dataset</b> button below."))
-        return(tag)
-      }
-
-
-      ## If not show alerts for sharing
-      msg <- c()
-      if (num_received > 0) {
-        msg <- paste("You have received <strong>", num_received, "datasets</strong> that you need to accept.")
-      }
-      if (num_shared > 0) {
-        msg1 <- paste("You have still <strong>", num_shared, "shared datasets</strong> waiting in the queue.")
-        msg <- c(msg, msg1)
-      }
-      bs_alert(
-        style = "warning",
-        conditional = FALSE,
-        shiny::HTML(paste(msg, "Please check the Sharing panel."))
+    if (enable_user_share==FALSE) {
+      output$sharing_panel_ui <- renderUI(
+        "The demo version does not allow sharing of datasets."
       )
-    })
-
+    }
+    
     if (enable_user_share==TRUE) {
-      
+
+      output$sharing_alert <- renderUI({
+        received_files <- pgxreceived$getReceivedFiles()
+        shared_files <- pgxshared$getSharedFiles()
+        num_received <- length(received_files)
+        num_shared <- length(shared_files)
+
+
+        if (num_received == 0 && num_shared == 0) {
+          tag <- bs_alert(HTML("This table shows the <b>available datasets</b> in your library. The table reports a brief description of each dataset. The <b>Signature t-SNE</b> shows similarity clustering of fold-change signatures using t-SNE. Select a dataset in the table and load the data by clicking the <b>Load Dataset</b> button below."))
+          return(tag)
+        }
+
+
+        ## If not show alerts for sharing
+        msg <- c()
+        if (num_received > 0) {
+          msg <- paste("You have received <strong>", num_received, "datasets</strong> that you need to accept.")
+        }
+        if (num_shared > 0) {
+          msg1 <- paste("You have still <strong>", num_shared, "shared datasets</strong> waiting in the queue.")
+          msg <- c(msg, msg1)
+        }
+        bs_alert(
+          style = "warning",
+          conditional = FALSE,
+          shiny::HTML(paste(msg, "Please check the Sharing panel."))
+        )
+      })
+
       output$sharing_panel_ui <- renderUI({
         
         received_files <- pgxreceived$getReceivedFiles()

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -70,7 +70,6 @@ LoadingBoard <- function(id,
     }
     
     if (enable_user_share==TRUE) {
-
       output$sharing_alert <- renderUI({
         received_files <- pgxreceived$getReceivedFiles()
         shared_files <- pgxshared$getSharedFiles()
@@ -101,7 +100,6 @@ LoadingBoard <- function(id,
       })
 
       output$sharing_panel_ui <- renderUI({
-        
         received_files <- pgxreceived$getReceivedFiles()
         shared_files <- pgxshared$getSharedFiles()
         num_received <- length(received_files)
@@ -137,19 +135,9 @@ LoadingBoard <- function(id,
           }
         }
          
-        bslib::layout_column_wrap(
-          width = 1,
-          heights_equal = "row",
-          height = "calc(100vh - 180px)",
-          bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
-          bslib::layout_column_wrap(
-            width = 1,
-            height = "calc(100vh - 180px)",
-            out
-          )
-        )
+        return(out)
       })
-    } ## end of Public tabPanel
+    } ## end of Shared tabPanel
 
 
     ## ======================================================================

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -91,45 +91,63 @@ LoadingBoard <- function(id,
         shiny::HTML(paste(msg, "Please check the Sharing panel."))
       )
     })
-
-    output$sharing_panel_ui <- renderUI({
-      received_files <- pgxreceived$getReceivedFiles()
-      shared_files <- pgxshared$getSharedFiles()
-      num_received <- length(received_files)
-      num_shared <- length(shared_files)
-
-      if (num_received == 0 && num_shared == 0) {
-        return(paste("No datasets being shared."))
-      }
-
-      out <- tagList()
-      if (length(out) == 0) {
-        if (num_received > 0) {
-          out1 <- shiny::wellPanel(
-            shiny::HTML("<b>Received datasets.</b> Accept or refuse the received dataset using the action buttons on the right."),
-            br(), br(),
-            pgxreceived$receivedPGXtable(),
-            br()
-          )
-          out <- tagList(out, out1)
+    browser()
+    if (enable_user_share==TRUE) {
+    
+      output$sharing_panel_ui <- renderUI({
+        if (num_received == 0 && num_shared == 0) {
+          return(paste("No datasets being shared."))
         }
-        if (num_shared > 0) {
-          out2 <- shiny::wellPanel(
-            shiny::HTML("<b>Shared datasets.</b> Resend a message to the receiver or cancel sharing using the action buttons on the right."),
-            br(), br(),
-            pgxshared$sharedPGXtable(),
-            br()
-          )
-          if (length(out) == 0) {
-            out <- out2
-          } else {
-            out <- tagList(out, br(), out2)
+
+        out <- tagList()
+        if (length(out) == 0) browser()/{
+          if (num_received > 0) {
+            out1 <- shiny::wellPanel(
+              shiny::HTML("<b>Received datasets.</b> Accept or refuse the received dataset using the action buttons on the right."),
+              br(), br(),
+              pgxreceived$receivedPGXtable(),
+              br()
+            )
+            out <- tagList(out, out1)
+          }
+          if (num_shared > 0) {
+            out2 <- shiny::wellPanel(
+              shiny::HTML("<b>Shared datasets.</b> Resend a message to the receiver or cancel sharing using the action buttons on the right."),
+              br(), br(),
+              pgxshared$sharedPGXtable(),
+              br()
+            )
+            if (length(out) == 0) {
+              out <- out2
+            } else {
+              out <- tagList(out, br(), out2)
+            }
           }
         }
-      }
+        received_files <- pgxreceived$getReceivedFiles()
+        shared_files <- pgxshared$getSharedFiles()
+        num_received <- length(received_files)
+        num_shared <- length(shared_files)
 
-      return(out)
-    })
+         shiny::tabPanel(
+          "Sharing",
+          bslib::layout_column_wrap(
+            width = 1,
+            heights_equal = "row",
+            height = "calc(100vh - 180px)",
+            bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
+            bslib::layout_column_wrap(
+              width = 1,
+              height = "calc(100vh - 180px)",
+              out
+            )
+          )
+        )
+        return(out)
+      })
+    } else {
+      output$sharing_panel_ui <- renderUI({NULL})
+    } ## end of Public tabPanel
 
 
     ## ======================================================================

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -130,25 +130,19 @@ LoadingBoard <- function(id,
             }
           }
         }
-        
-
-         shiny::tabPanel(
-          "Sharing",
+         
+        bslib::layout_column_wrap(
+          width = 1,
+          heights_equal = "row",
+          height = "calc(100vh - 180px)",
+          bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
           bslib::layout_column_wrap(
             width = 1,
-            heights_equal = "row",
             height = "calc(100vh - 180px)",
-            bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
-            bslib::layout_column_wrap(
-              width = 1,
-              height = "calc(100vh - 180px)",
-              out
-            )
+            out
           )
         )
       })
-    } else {
-      output$sharing_panel_ui <- renderUI({NULL})
     } ## end of Public tabPanel
 
 

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -94,40 +94,9 @@ LoadingUI <- function(id) {
     ) ## end first layout_column_wrap
   ) ## end of Public tabPanel
 
-  sharing_tabpanel <- shiny::tabPanel(
-    "Sharing",
-    bslib::layout_column_wrap(
-      width = 1,
-      heights_equal = "row",
-      height = "calc(100vh - 180px)",
-      bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
-      bslib::layout_column_wrap(
-        width = 1,
-        height = "calc(100vh - 180px)",
-        uiOutput(ns("sharing_panel_ui"))
-      )
-    )
-  ) ## end of Public tabPanel
-
-
-  ## ------------------------------------------------------------------------
-
-  sharing_tabpanel <- shiny::tabPanel(
-    "Sharing",
-    bslib::layout_column_wrap(
-      width = 1,
-      heights_equal = "row",
-      height = "calc(100vh - 180px)",
-      bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
-      bslib::layout_column_wrap(
-        width = 1,
-        height = "calc(100vh - 180px)",
-        uiOutput(ns("sharing_panel_ui"))
-      )
-    )
-  ) ## end of Public tabPanel
-
-
+ 
+  uiOutput(ns("sharing_panel_ui"))
+  
   ## ------------------------------------------------------------------------
 
   ## disable/hide public tabpanel if public folder does not exists

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -93,13 +93,12 @@ LoadingUI <- function(id) {
       ) ## end of 7fr-5fr
     ) ## end first layout_column_wrap
   ) ## end of Public tabPanel
-
-  # show sharing tabpanel if uiouput is not NULL using conditional exists
-  
-  
+    
   sharing_tabpanel <- shiny::tabPanel(
-          "Sharing",
-          uiOutput(ns("sharing_panel_ui")))
+    "Sharing",
+    uiOutput(ns("sharing_panel_ui")
+    )
+  )
   
   ## ------------------------------------------------------------------------
 

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -96,8 +96,18 @@ LoadingUI <- function(id) {
     
   sharing_tabpanel <- shiny::tabPanel(
     "Sharing",
-    uiOutput(ns("sharing_panel_ui")
-    )
+    bslib::layout_column_wrap(
+          width = 1,
+          heights_equal = "row",
+          height = "calc(100vh - 180px)",
+          bs_alert(HTML("This Sharing panel shows <strong>received datasets</strong> that are not yet imported to your library, and your <strong>shared datasets</strong> that are still waiting to be accepted by the receiver. Please accept or refust each received file, and/or resend a message or cancel your shared datasets.")),
+          bslib::layout_column_wrap(
+            width = 1,
+            height = "calc(100vh - 180px)",
+            uiOutput(ns("sharing_panel_ui")
+          )
+        )
+      )
   )
   
   ## ------------------------------------------------------------------------

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -94,8 +94,12 @@ LoadingUI <- function(id) {
     ) ## end first layout_column_wrap
   ) ## end of Public tabPanel
 
- 
-  sharing_tabpanel <- shiny::uiOutput(ns("sharing_panel_ui"))
+  # show sharing tabpanel if uiouput is not NULL using conditional exists
+  
+  
+  sharing_tabpanel <- shiny::tabPanel(
+          "Sharing",
+          uiOutput(ns("sharing_panel_ui")))
   
   ## ------------------------------------------------------------------------
 

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -95,7 +95,7 @@ LoadingUI <- function(id) {
   ) ## end of Public tabPanel
 
  
-  uiOutput(ns("sharing_panel_ui"))
+  sharing_tabpanel <- shiny::uiOutput(ns("sharing_panel_ui"))
   
   ## ------------------------------------------------------------------------
 


### PR DESCRIPTION
**Summary:**
- `ENABLE_USER_SHARE` now disables all shared dataset messages when set to FALSE.
- Even if user has shared datasets, `ENABLE_USER_SHARE = FALSE` will not show those messages. This is important if user goes from paid to free/demo, where it will not be allowed to share datasets anymore.

**Possible future improvements:**
- Hide Sharing tab if no datasets available OR if `ENABLE_USER_SHARE = FALSE`. This was the initial idea, but its nice to have the sharing tab with the message, so user knows the functionality exists but it is disabled.


**Tested with combinations of the following conditions:**
- ENABLE_USER_SHARE set to FALSE or TRUE
- With and without shared datasets

this fixes #549 