### PR TITLE
fix sharing email lower/upper case mismatch

### DIFF
--- a/components/board.loading/R/loading_module_received.R
+++ b/components/board.loading/R/loading_module_received.R
@@ -34,7 +34,8 @@ upload_module_received_server <- function(id,
         refresh_table()
         pgxfiles <- dir(
           path = pgx_shared_dir,
-          pattern = paste0("__to__", auth$email(), "__from__.*__$")
+          pattern = paste0("__to__", auth$email(), "__from__.*__$"),
+          ignore.case = TRUE
         )
         return(pgxfiles)
       })

--- a/components/board.loading/R/loading_module_shared.R
+++ b/components/board.loading/R/loading_module_shared.R
@@ -33,7 +33,8 @@ upload_module_shared_server <- function(id,
         refresh()
         pgxfiles <- dir(
           path = pgx_shared_dir,
-          pattern = paste0("__to__.*__from__", auth$email(), "__$")
+          pattern = paste0("__to__.*__from__", auth$email(), "__$"),
+          ignore.case = TRUE
         )
         return(pgxfiles)
       })

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -367,8 +367,8 @@ loading_table_datasets_server <- function(id,
           )
         }
 
+        ## instead of disabling we grey out and have a popup message
         ##        if(enable_delete) {
-
         if (TRUE) {
           delete_pgx_menuitem <- shiny::actionButton(
             ns(paste0("delete_dataset_row_", i)),
@@ -680,6 +680,7 @@ loading_table_datasets_server <- function(id,
       if (!is.null(input$share_user2) && input$share_user2 != "") {
         share_user <- input$share_user2
       }
+      share_user <- tolower(share_user) ## force lower case email
       share_user
     })
 
@@ -737,9 +738,7 @@ loading_table_datasets_server <- function(id,
               "Please contact your administrator."
             )
           )
-
           share_pgx(NULL)
-
           return()
         }
 
@@ -752,7 +751,6 @@ loading_table_datasets_server <- function(id,
               "address to share pgx files with other users."
             )
           )
-
           share_pgx(NULL)
           return()
         }
@@ -769,9 +767,7 @@ loading_table_datasets_server <- function(id,
               "Please contact your administrator."
             )
           )
-
           share_pgx(NULL)
-
           return()
         }
 


### PR DESCRIPTION
From Murat:

In data sharing, do email addresses and usernames have to match exactly when exchanging data? I mean, is the matching case sensitive?

For example, here is a real case example: Alice.PEO1v_PEO4.all.pgx__to__Alice.filipe@*******__from__blstccs@******* where Cristina shared a dataset with Alice. She entered Alice.filipe@****** but Alice's account is alice.filipe@****** Does she get a notification and the dataset?

**FIXED**
- sender email is converted to lowercase before sending
- received files are matched with 'ignore.case=TRUE'
