### PR TITLE
Fix cropped card dropdown

### DIFF
--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -12,39 +12,16 @@
 ## second version of Carson (see email 9jul23)
 dropdown.jsCode.SAVE <- function(id) {
   paste0("
-$('#", id, "').on('click', function(){
-  if($('#", id, "').hasClass('active')){
-    $('#", id, "').toggleClass('active');
-    return 0;
-  }
-  $('.dropdown-button.active').toggleClass('active');
-  if(!$('#", id, "').hasClass('active')){
-    $('#", id, "').toggleClass('active');
-  }
-})
-function restoreDropdownMenu() {
-  var menuBody = $('body > .dropdown-menu-body');
-  if (menuBody.length > 0) {
-    menuBody.removeClass('dropdown-menu-body');
-    var id = menuBody.attr('data-toggle-id');
-    $('#' + id).parent().append(menuBody.detach());
-  }
-}
-$('#", id, "').on('shown.bs.dropdown', function () {
-  restoreDropdownMenu();
-  if (!this.id) {
-    console.error('Expected dropdown toggle to have an id attribute');
-  }
-  setTimeout(function() {
-    var menu = $(this).parent().find('.dropdown-menu');
-    menu.addClass('dropdown-menu-body');
-    menu.attr('data-toggle-id', this.id);
-    $('body').append(menu.detach());
-  },1);
-});
-$('#", id, "').on('hidden.bs.dropdown', function () {
-  restoreDropdownMenu();
-});
+    $('#", id, "').on('shown.bs.dropdown', function () {
+      restoreDropdownMenu();
+      if (!this.id) {
+        console.error('Expected dropdown toggle to have an id attribute');
+      }
+      var menu = $(this).parent().find('.dropdown-menu');
+      menu.addClass('dropdown-menu-body');
+      menu.attr('data-toggle-id', this.id);
+      menu.detach();
+      setTimeout(function() { $('body').append(menu); }, 0);
 ") ## end of paste0
 }
 

--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -11,7 +11,27 @@
 
 ## second version of Carson (see email 9jul23)
 dropdown.jsCode.SAVE <- function(id) {
-  paste0("
+  paste0(
+    "
+    $('#", id, "').on('click', function(){
+    if($('#", id, "').hasClass('active')){
+      $('#", id, "').toggleClass('active');
+      return 0;
+    }
+    $('.dropdown-button.active').toggleClass('active');
+    if(!$('#", id, "').hasClass('active')){
+      $('#", id, "').toggleClass('active');
+    }
+    })
+    function restoreDropdownMenu() {
+      var menuBody = $('body > .dropdown-menu-body');
+      if (menuBody.length > 0) {
+        menuBody.removeClass('dropdown-menu-body');
+        var id = menuBody.attr('data-toggle-id');
+        $('#' + id).parent().append(menuBody.detach());
+      }
+    }
+    
     $('#", id, "').on('shown.bs.dropdown', function () {
       restoreDropdownMenu();
       if (!this.id) {
@@ -22,7 +42,8 @@ dropdown.jsCode.SAVE <- function(id) {
       menu.attr('data-toggle-id', this.id);
       menu.detach();
       setTimeout(function() { $('body').append(menu); }, 0);
-") ## end of paste0
+      "
+    ) ## end of paste0
 }
 
 ## first version of Carson

--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -84,6 +84,13 @@ $('#", id, "').on('hidden.bs.dropdown', function () {
 ") ## end of paste0
 }
 
+dropdown.assets <- function(id) {
+  tagList(
+    shiny::singleton(tags$style(HTML(".dropdown-menu:not(.dropdown-menu-body) { display: none; }"))),
+    tags$script(HTML(dropdown.jsCode(id)))
+  )
+}
+
 DropdownMenu <- function(..., size = "default", status = "default", icon = NULL, width = "auto", margin = "10px") {
   id <- bigdash:::make_id()
   tags$div(
@@ -118,7 +125,7 @@ DropdownMenu <- function(..., size = "default", status = "default", icon = NULL,
         error = function(w) {}
       )
     ),
-    tags$script(HTML(dropdown.jsCode(id)))
+    dropdown.assets(id)
   )
 }
 
@@ -159,6 +166,6 @@ actionMenu <- function(..., size = "default", status = "default", icon = NULL, m
         error = function(w) {}
       )
     ),
-    tags$script(HTML(dropdown.jsCode(id)))
+    dropdown.assets(id)
   )
 }

--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -75,7 +75,8 @@ $('#", id, "').on('shown.bs.dropdown', function () {
   var menu = $(this).parent().find('.dropdown-menu');
   menu.addClass('dropdown-menu-body');
   menu.attr('data-toggle-id', this.id);
-  $('body').append(menu.detach());
+  menu.detach();
+  setTimeout(function() { $('body').append(menu); }, 0);
 });
 $('#", id, "').on('hidden.bs.dropdown', function () {
   restoreDropdownMenu();

--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -9,44 +9,6 @@
 # It also has logic implemented so that when clicking a different dropdown item,
 # the active one gets desactivated.
 
-## second version of Carson (see email 9jul23)
-dropdown.jsCode.SAVE <- function(id) {
-  paste0(
-    "
-    $('#", id, "').on('click', function(){
-    if($('#", id, "').hasClass('active')){
-      $('#", id, "').toggleClass('active');
-      return 0;
-    }
-    $('.dropdown-button.active').toggleClass('active');
-    if(!$('#", id, "').hasClass('active')){
-      $('#", id, "').toggleClass('active');
-    }
-    })
-    function restoreDropdownMenu() {
-      var menuBody = $('body > .dropdown-menu-body');
-      if (menuBody.length > 0) {
-        menuBody.removeClass('dropdown-menu-body');
-        var id = menuBody.attr('data-toggle-id');
-        $('#' + id).parent().append(menuBody.detach());
-      }
-    }
-    
-    $('#", id, "').on('shown.bs.dropdown', function () {
-      restoreDropdownMenu();
-      if (!this.id) {
-        console.error('Expected dropdown toggle to have an id attribute');
-      }
-      var menu = $(this).parent().find('.dropdown-menu');
-      menu.addClass('dropdown-menu-body');
-      menu.attr('data-toggle-id', this.id);
-      menu.detach();
-      setTimeout(function() { $('body').append(menu); }, 0);
-      "
-    ) ## end of paste0
-}
-
-## first version of Carson
 dropdown.jsCode <- function(id) {
   paste0("
 $('#", id, "').on('click', function(){

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -352,6 +352,7 @@ PlotModuleUI <- function(id,
         shiny::tags$head(shiny::tags$style(modalbody.style)),
         shiny::tags$head(shiny::tags$style(modalcontent.style)),
         shiny::tags$head(shiny::tags$style(modalfooter.none)),
+        shiny::tags$head(shiny::tags$style(".dropdown-menu:not(.dropdown-menu-body) { display: none; }")),
         shiny::tags$script(src = "dropdown-helper.js")
       )
     ),

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -136,6 +136,7 @@ TableModuleUI <- function(id,
       ),
       shiny::tagList(
         shiny::tags$head(shiny::tags$style(modalfooter.none)),
+        
         shiny::tags$script(src = "dropdown-helper.js")
       )
     ),


### PR DESCRIPTION
**summary:**
this PR fixed the card drop downs being cropped inside cards and triggering scroll x and y bars.

**approach:**
remove html from cards and insert at the bottom of DOM

**future improvements:**
remove flickering caused by some of the dropdowns being active