### PR TITLE
Revert "Fix cropped card dropdown"

### DIFF
--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -9,6 +9,46 @@
 # It also has logic implemented so that when clicking a different dropdown item,
 # the active one gets desactivated.
 
+## second version of Carson (see email 9jul23)
+dropdown.jsCode.SAVE <- function(id) {
+  paste0("
+$('#", id, "').on('click', function(){
+  if($('#", id, "').hasClass('active')){
+    $('#", id, "').toggleClass('active');
+    return 0;
+  }
+  $('.dropdown-button.active').toggleClass('active');
+  if(!$('#", id, "').hasClass('active')){
+    $('#", id, "').toggleClass('active');
+  }
+})
+function restoreDropdownMenu() {
+  var menuBody = $('body > .dropdown-menu-body');
+  if (menuBody.length > 0) {
+    menuBody.removeClass('dropdown-menu-body');
+    var id = menuBody.attr('data-toggle-id');
+    $('#' + id).parent().append(menuBody.detach());
+  }
+}
+$('#", id, "').on('shown.bs.dropdown', function () {
+  restoreDropdownMenu();
+  if (!this.id) {
+    console.error('Expected dropdown toggle to have an id attribute');
+  }
+  setTimeout(function() {
+    var menu = $(this).parent().find('.dropdown-menu');
+    menu.addClass('dropdown-menu-body');
+    menu.attr('data-toggle-id', this.id);
+    $('body').append(menu.detach());
+  },1);
+});
+$('#", id, "').on('hidden.bs.dropdown', function () {
+  restoreDropdownMenu();
+});
+") ## end of paste0
+}
+
+## first version of Carson
 dropdown.jsCode <- function(id) {
   paste0("
 $('#", id, "').on('click', function(){
@@ -37,20 +77,12 @@ $('#", id, "').on('shown.bs.dropdown', function () {
   var menu = $(this).parent().find('.dropdown-menu');
   menu.addClass('dropdown-menu-body');
   menu.attr('data-toggle-id', this.id);
-  menu.detach();
-  setTimeout(function() { $('body').append(menu); }, 0);
+  $('body').append(menu.detach());
 });
 $('#", id, "').on('hidden.bs.dropdown', function () {
   restoreDropdownMenu();
 });
 ") ## end of paste0
-}
-
-dropdown.assets <- function(id) {
-  tagList(
-    shiny::singleton(tags$style(HTML(".dropdown-menu:not(.dropdown-menu-body) { display: none; }"))),
-    tags$script(HTML(dropdown.jsCode(id)))
-  )
 }
 
 DropdownMenu <- function(..., size = "default", status = "default", icon = NULL, width = "auto", margin = "10px") {
@@ -87,7 +119,7 @@ DropdownMenu <- function(..., size = "default", status = "default", icon = NULL,
         error = function(w) {}
       )
     ),
-    dropdown.assets(id)
+    tags$script(HTML(dropdown.jsCode(id)))
   )
 }
 
@@ -128,6 +160,6 @@ actionMenu <- function(..., size = "default", status = "default", icon = NULL, m
         error = function(w) {}
       )
     ),
-    dropdown.assets(id)
+    tags$script(HTML(dropdown.jsCode(id)))
   )
 }

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -352,7 +352,6 @@ PlotModuleUI <- function(id,
         shiny::tags$head(shiny::tags$style(modalbody.style)),
         shiny::tags$head(shiny::tags$style(modalcontent.style)),
         shiny::tags$head(shiny::tags$style(modalfooter.none)),
-        shiny::tags$head(shiny::tags$style(".dropdown-menu:not(.dropdown-menu-body) { display: none; }")),
         shiny::tags$script(src = "dropdown-helper.js")
       )
     ),


### PR DESCRIPTION
Reverts bigomics/omicsplayground#570

Seems to interfere with the dropdown (suport, tutorials, user) of the main page. Probably Carson's fix is interfering with general drowdowns not in cards.