### PR TITLE
Fix #559: Uploaded pgx files dont appear immediately in data loading table if they are loaded

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -104,8 +104,7 @@ UploadBoard <- function(id,
 
       load_my_dataset <- function() {
         if (input$confirmload) {
-          bigdash.selectTab(session, selected = "load-tab")
-          load_uploaded_data(new_pgx$name)
+          load_uploaded_data(new_pgx$name) 
         }
       }
 


### PR DESCRIPTION
This closes #559 

## Description
Selecting the tab and immediately afterwards loading the data made the reactivity not work. That is why selecting "Stay here." worked ok.

Just loading directly the data fixes the issue.

Please @ncullen93 double check and merge.