### PR TITLE
feat: remove `fluctuator` dependency

### DIFF
--- a/components/board.pathway/R/fun_wikipathview.R
+++ b/components/board.pathway/R/fun_wikipathview.R
@@ -2,7 +2,6 @@
 
 wikipathview <- function(wp, val) {
   require(xml2)
-  require(fluctuator)
 
   url <- paste0("https://www.wikipathways.org/wikipathways-assets/pathways/", wp, "/", wp, ".svg")
   destfile <- tempfile(fileext = ".svg")
@@ -77,7 +76,5 @@ wikipathview <- function(wp, val) {
   # Write the lines back to the file
   writeLines(lines, destfile)
 
-  svg <- fluctuator::read_svg(destfile)
-
-  return(svg)
+  return(destfile)
 }

--- a/components/board.pathway/R/functional_plot_wikipathway_graph.R
+++ b/components/board.pathway/R/functional_plot_wikipathway_graph.R
@@ -125,19 +125,17 @@ functional_plot_wikipathway_graph_server <- function(id,
           progress$set(message = "Rendering pathway...", value = 0.33)
         }
 
-        tmpfile <- paste0(tempfile(), ".svg")
         svg <- wikipathview(wp = pathway.id, val = fc)
         if (is.null(svg)) {
           return(NULL)
         }
-        fluctuator::write_svg(svg, file = tmpfile)
         list(
-          src = normalizePath(tmpfile),
+          src = normalizePath(svg),
           contentType = "image/svg+xml",
           width = "100%", height = "100%", ## actual size: 1040x800
           alt = "wikipathway SVG"
         )
-      })
+      }) 
 
       plot_RENDER <- function() {
         img <- getPathwayImage()

--- a/dev/requirements.R
+++ b/dev/requirements.R
@@ -173,7 +173,6 @@ install.github('bigomics/bigdash', force=TRUE)
 install.github('bigomics/bigLoaders')
 install.github('bigomics/PCSF', force=TRUE)
 install.github('bigomics/shinyChatR')
-install.github('m-jahn/fluctuator')
 install.github('ropensci/iheatmapr')
 
 ##---------------------------------------------------------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,6 @@ ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 #------------------------------------------------------------
 WORKDIR /
 #RUN pip3 install umap-learn
-#RUN R -e "devtools::install_github('m-jahn/fluctuator')"
 RUN R -e "devtools::install_github('bigomics/shinyChatR')"
 RUN R -e "devtools::install_github('JohnCoene/bsutils')"
 RUN R -e "devtools::install_github('ropensci/iheatmapr')"


### PR DESCRIPTION
## Description
With the upgrade of WikiPathway plots the `fluctuator` package was not really required at all. However, there were still some traces of it left.

Removed them to have one less dependency.