### PR TITLE
Fix #596: Add tooltips to the accept/cancel and resend/cancel in sharing tab

### DIFF
--- a/components/board.loading/R/loading_module_received.R
+++ b/components/board.loading/R/loading_module_received.R
@@ -40,14 +40,6 @@ upload_module_received_server <- function(id,
         return(pgxfiles)
       })
 
-      makebuttonInputs2 <- function(FUN, len, id, ...) {
-        inputs <- character(length(len))
-        for (i in seq_along(len)) {
-          inputs[i] <- as.character(FUN(paste0(id, len[i]), ...))
-        }
-        inputs
-      }
-
       receivedPGXtable <- shiny::eventReactive(
         c(current_page(), getReceivedFiles()),
         {
@@ -71,7 +63,7 @@ upload_module_received_server <- function(id,
             icon = shiny::icon("check"),
             class = "btn-inline btn-success",
             style = "padding:0px; margin:0px; font-size:85%;",
-
+            tooltip = "Accept dataset",
             ## onclick = paste0('Shiny.onInputChange(\"',ns("accept_pgx"),'\", this.id, {priority: "event"})')
             onclick = paste0('Shiny.onInputChange("', ns("accept_pgx"), '", this.id, {priority: "event"})')
           )
@@ -86,6 +78,7 @@ upload_module_received_server <- function(id,
             icon = shiny::icon("x"),
             class = "btn-inline btn-danger",
             style = "padding:0px; margin:0px; font-size:85%;",
+            tooltip = "Declinie dataset",
             onclick = paste0('Shiny.onInputChange(\"', ns("decline_pgx"), '\", this.id, {priority: "event"})')
           )
 

--- a/components/board.loading/R/loading_module_shared.R
+++ b/components/board.loading/R/loading_module_shared.R
@@ -39,14 +39,6 @@ upload_module_shared_server <- function(id,
         return(pgxfiles)
       })
 
-      makebuttonInputs2 <- function(FUN, len, id, ...) {
-        inputs <- character(length(len))
-        for (i in seq_along(len)) {
-          inputs[i] <- as.character(FUN(paste0(id, len[i]), ...))
-        }
-        inputs
-      }
-
       sharedPGXtable <- shiny::eventReactive(
         c(current_page(), getSharedFiles()),
         {
@@ -66,11 +58,12 @@ upload_module_shared_server <- function(id,
             len = shared_files,
             id = ns("resend_pgx__"),
             label = "",
-            width = "50px",
+            width = "50px", 
             inline = TRUE,
             icon = shiny::icon("repeat"),
             class = "btn-inline btn-success",
             style = "padding:0px; margin:0px; font-size:85%;",
+            tooltip = "Resend this dataset",
             onclick = paste0('Shiny.onInputChange("', ns("resend_pgx"), '", this.id, {priority: "event"})')
           )
 
@@ -84,8 +77,10 @@ upload_module_shared_server <- function(id,
             icon = shiny::icon("x"),
             class = "btn-inline btn-danger",
             style = "padding:0px; margin:0px; font-size:85%;",
+            tooltip = "Cancel this dataset sharing",
             onclick = paste0('Shiny.onInputChange(\"', ns("cancel_pgx"), '\", this.id, {priority: "event"})')
           )
+
 
           df <- data.frame(
             Dataset = shared_pgx,

--- a/components/board.loading/R/loading_utils.R
+++ b/components/board.loading/R/loading_utils.R
@@ -47,3 +47,17 @@ is_valid_email <- function(email) {
   valid_email <- valid_email && !grepl("[*/\\}{]", email) ## no special chars
   return(!is_personal && valid_email)
 }
+
+makebuttonInputs2 <- function(FUN, len, id, tooltip = NULL, ...) {
+        inputs <- character(length(len))
+        for (i in seq_along(len)) {
+          if(is.null(tooltip)){
+            inputs[i] <- as.character(FUN(paste0(id, len[i]), ...))
+          } else {
+            inputs[i] <- as.character(
+              withTooltip(FUN(paste0(id, len[i]), ...), tooltip)
+            )
+          }
+        }
+        inputs
+      }


### PR DESCRIPTION
This closes #596 

## Description
Added tooltip argument to the function that generates the buttons. Please re-do the tooltip writing if not OK