### PR TITLE
Fix #607 - gene methods and gene set methods fails when there is only one sample in a group

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -491,8 +491,8 @@ upload_module_computepgx_server <- function(
         shinyalert::shinyalert(
           title = "Crunching your data!",
           text = "Your dataset will be computed in the background. 
-                  You can continue to play with a different dataset in the meantime. 
-                  When it is ready, it will appear in your dataset library.",
+          You can continue to play with a different dataset in the meantime. 
+          When it is ready, it will appear in your dataset library.",
           type = "info",
           timer = 60000
         )

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -238,7 +238,9 @@ upload_module_computepgx_server <- function(
           ) ## end of conditional panel
         ) ## end of fill Col
       })
-      shiny::outputOptions(output, "UI", suspendWhenHidden = FALSE) ## important!!!
+      shiny::outputOptions(output,
+                           "UI",
+                           suspendWhenHidden = FALSE) ## important!!!
 
       shiny::observeEvent(enable_button(), {
         if (!enable_button()) {
@@ -252,67 +254,39 @@ upload_module_computepgx_server <- function(
         meta <- metaRT()
 
         if (!is.null(meta[["name"]])) {
-          shiny::updateTextInput(session, "upload_name", value = meta[["name"]])
+          shiny::updateTextInput(session,
+                                 "upload_name",
+                                 value = meta[["name"]])
         }
         if (!is.null(meta[["description"]])) {
-          shiny::updateTextAreaInput(session, "upload_description", value = meta[["description"]])
+          shiny::updateTextAreaInput(session,
+                                     "upload_description",
+                                     value = meta[["description"]])
         }
       })
 
-      # shiny::observeEvent(input$options, {
-
-      #   contrasts.update <- as.data.frame(contrasts.updated())
-      #   contrasts <- as.matrix(contrastsRT())
-      #   samples <- samplesRT()
-
-      #   group.count <- list()
-      #   sample_1 <- list()
-      #   sample_2 <- list()
-
-      #   for (i in 1:dim(contrasts.update)[2]){
-      #     sample_1[[i]] <- sum(contrasts.update[i] == 1)
-      #     sample_2[[i]] <- sum(contrasts.update[i] == -1)
-      #   }
-
-      #   if (sum(sample_1 == 1) >= 1 || sum(sample_2 == 1) >= 1) {
-      #   shinyalert::shinyalert(
-      #     title = "WARNING",
-      #     text = "There are cases where there is only one samples in a group. Some of the gene tests and enrichment methods are disabled.",
-      #     type = "warning"
-      #   )
-      #   shiny::updateCheckboxGroupInput(session, "gene_methods", choices = DISABLED.GENE_METHODS)
-      #   shiny::updateCheckboxGroupInput(session, "gset_methods", choices = DISABLED.GENESET_METHODS)
-      #   }
-      # })
-
-      ##      shiny::observeEvent(input$options | input$compute, {
-      shiny::observeEvent( contrastsRT(), {
-##        if(is.null(input$compute) || input$compute==0) return(NULL)
-            
-##        contrasts.update <- as.data.frame(contrasts.updated())
-        contrasts <- as.data.frame(contrastsRT())            
-        # print(contrasts.update)
-        # write.csv(contrasts.update, file.path(raw_dir(), "contrasts_contrasts.csv"), row.names = TRUE)
-#        has_one <- c()
-#        for (i in colnames(contrasts)){
-##            group.count <- contrasts.update %>% dplyr::count(contrasts.update[i])
-##            has_one[i] <- any(group.count[1:nrow(group.count)-1,]['n'] == 1 )
-#            has_one[i] <- any(table(contrast[,i])==1)
-#        }
-        has_one <- apply(contrasts, 2, function(x) any(table(x)==1))
-        
-        if (any(has_one)){
+      shiny::observeEvent(contrastsRT(), {
+        contrasts <- as.data.frame(contrastsRT())
+        has_one <- apply(contrasts, 2, function(x) any(table(x) == 1))
+        if (any(has_one)) {
           shinyalert::shinyalert(
             title = "WARNING",
-            text = "There are cases where there is only one samples in a group. Some of the gene tests and enrichment methods are disabled.",
+            text = "There are cases where there is only one samples in a group. 
+                    Some of the gene tests and enrichment 
+                    methods are disabled.",
             type = "warning"
           )
-          shiny::updateCheckboxGroupInput(session, "gene_methods", choices = ONESAMPLE.GENE_METHODS, sel="ttest")
-          shiny::updateCheckboxGroupInput(session, "gset_methods", choices = ONESAMPLE.GENESET_METHODS,
-                                          sel=c("fisher","fgsea","gsva"))
+          shiny::updateCheckboxGroupInput(
+                                          session,
+                                          "gene_methods",
+                                          choices = ONESAMPLE.GENE_METHODS,
+                                          sel = "ttest")
+          shiny::updateCheckboxGroupInput(session,
+                                          "gset_methods",
+                                          choices = ONESAMPLE.GENESET_METHODS,
+                                          sel = c("fisher", "fgsea", "gsva"))
         }
       })
-
 
       ## ------------------------------------------------------------------
       ## After confirmation is received, start computing the PGX
@@ -530,7 +504,9 @@ upload_module_computepgx_server <- function(
         # Start the process and store it in the reactive value
         shinyalert::shinyalert(
           title = "Crunching your data!",
-          text = "Your dataset will be computed in the background. You can continue to play with a different dataset in the meantime. When it is ready, it will appear in your dataset library.",
+          text = "Your dataset will be computed in the background. 
+                  You can continue to play with a different dataset in the meantime. 
+                  When it is ready, it will appear in your dataset library.",
           type = "info",
           timer = 60000
         )

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -27,7 +27,6 @@ upload_module_computepgx_server <- function(
     batchRT,
     metaRT,
     lib.dir,
-    contrasts.updated,
     auth,
     enable_button = TRUE,
     alertready = TRUE,

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -36,19 +36,6 @@ upload_module_computepgx_server <- function(
     function(input, output, session) {
       ns <- session$ns
 
-      
-
-      # samples <- samplesRT()
-      # sample.count <- any(dplyr::count(samples, group)['n'] < 2)
-        
-      # if (sample.count) {
-      #     shinyalert::shinyalert(
-      #     title = "WARNING",
-      #     text = "There are one or more cases where there are less than two samples in a Group",
-      #     type = "error"
-      #   )
-      # }
-      
       ## statistical method for GENE level testing
       GENETEST.METHODS <- c(
         "ttest", "ttest.welch", "voom.limma", "trend.limma", "notrend.limma",
@@ -289,7 +276,7 @@ upload_module_computepgx_server <- function(
 
       ## ------------------------------------------------------------------
       ## After confirmation is received, start computing the PGX
-      ## object from the uploaded samplesRT()files
+      ## object from the uploaded files
       ## ------------------------------------------------------------------
 
       # Define a reactive value to store the process object

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -250,10 +250,11 @@ upload_module_computepgx_server <- function(
                                      value = meta[["description"]])
         }
       })
-
+        
       shiny::observeEvent(contrastsRT(), {
         contrasts <- as.data.frame(contrastsRT())
         has_one <- apply(contrasts, 2, function(x) any(table(x) == 1))
+
         if (any(has_one)) {
           shinyalert::shinyalert(
             title = "WARNING",
@@ -271,7 +272,7 @@ upload_module_computepgx_server <- function(
                                           "gset_methods",
                                           choices = ONESAMPLE.GENESET_METHODS,
                                           sel = c("fisher", "fgsea", "gsva"))
-        }
+          }
       })
 
       ## ------------------------------------------------------------------

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -668,7 +668,7 @@ UploadBoard <- function(id,
       ## so replace the uploaded reactive values.
       modct <- modified_ct()
       uploaded$contrasts.csv <- modct$contr
-      uploaded$CONTRASTS_check <- modct$contr
+##      uploaded$CONTRASTS_check <- modct$contr
       if (!is.null(raw_dir()) && dir.exists(raw_dir())) {
         write.csv(modct$contr, file.path(raw_dir(), "user_contrasts.csv"), row.names = TRUE)
       }
@@ -693,7 +693,7 @@ UploadBoard <- function(id,
       batchRT = batch_vectors,
       metaRT = shiny::reactive(uploaded$meta),
       enable_button = upload_ok,
-      contrasts.updated = shiny::reactive(uploaded$CONTRASTS_check),
+ ##     contrasts.updated = shiny::reactive(uploaded$CONTRASTS_check),
       alertready = FALSE,
       lib.dir = FILES,
       auth = auth,

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -668,6 +668,7 @@ UploadBoard <- function(id,
       ## so replace the uploaded reactive values.
       modct <- modified_ct()
       uploaded$contrasts.csv <- modct$contr
+      uploaded$CONTRASTS_check <- modct$contr
       if (!is.null(raw_dir()) && dir.exists(raw_dir())) {
         write.csv(modct$contr, file.path(raw_dir(), "user_contrasts.csv"), row.names = TRUE)
       }
@@ -692,6 +693,7 @@ UploadBoard <- function(id,
       batchRT = batch_vectors,
       metaRT = shiny::reactive(uploaded$meta),
       enable_button = upload_ok,
+      contrasts.updated = shiny::reactive(uploaded$CONTRASTS_check),
       alertready = FALSE,
       lib.dir = FILES,
       auth = auth,

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -668,7 +668,6 @@ UploadBoard <- function(id,
       ## so replace the uploaded reactive values.
       modct <- modified_ct()
       uploaded$contrasts.csv <- modct$contr
-##      uploaded$CONTRASTS_check <- modct$contr
       if (!is.null(raw_dir()) && dir.exists(raw_dir())) {
         write.csv(modct$contr, file.path(raw_dir(), "user_contrasts.csv"), row.names = TRUE)
       }
@@ -693,7 +692,6 @@ UploadBoard <- function(id,
       batchRT = batch_vectors,
       metaRT = shiny::reactive(uploaded$meta),
       enable_button = upload_ok,
- ##     contrasts.updated = shiny::reactive(uploaded$CONTRASTS_check),
       alertready = FALSE,
       lib.dir = FILES,
       auth = auth,


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->
  
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
So far, added an observe event to the contrasts file and warn the users when there is only one sample in a group. 

![Screenshot from 2023-08-04 15-25-46](https://github.com/bigomics/omicsplayground/assets/56559132/b0bc46b1-8311-4def-9c0a-4f3829edd9e8)

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->