### PR TITLE
add scale per method option, set default=TRUE

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -12,12 +12,20 @@ enrichment_plot_volcanoall_ui <- function(
     width) {
   ns <- shiny::NS(id)
 
+  plot_options <- shiny::tagList(
+    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", TRUE),
+      "Scale the volcano plots individually per method..",
+      placement = "right", options = list(container = "body")
+    )
+  )
+
   PlotModuleUI(
     ns("plot"),
     plotlib = "grid",
     title = title,
-    caption = caption,
     info.text = info.text,
+    caption = caption,
+    options = plot_options,
     height = height,
     width = width,
     download.fmt = c("png", "pdf")
@@ -108,7 +116,10 @@ enrichment_plot_volcanoall_server <- function(id,
 
           xy <- cbind(x = fc, y = -log10(qv))
           tt <- names(F)[i]
-          #
+          ymax1 <- ymax
+          if (input$scale_per_method) {
+            ymax1 <- 1.2 * quantile(xy[, 2], probs = 0.999, na.rm = TRUE)[1] ## y-axis
+          }
 
           plt[[i]] <- playbase::pgx.scatterPlotXY.GGPLOT(
             xy,
@@ -121,7 +132,7 @@ enrichment_plot_volcanoall_server <- function(id,
             hilight = NULL,
             hilight2 = NULL,
             xlim = xmax * c(-1, 1),
-            ylim = c(0, ymax),
+            ylim = c(0, ymax1),
             xlab = "difference  (log2FC)",
             ylab = "significance  (-log10q)",
             hilight.lwd = 0,

--- a/components/board.enrichment/R/enrichment_plot_volcanomethods.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanomethods.R
@@ -14,7 +14,7 @@ enrichment_plot_volcanomethods_ui <- function(
 
 
   plot_options <- shiny::tagList(
-    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", FALSE),
+    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", TRUE),
       "Scale the volcano plots individually per method..",
       placement = "right", options = list(container = "body")
     )
@@ -98,8 +98,6 @@ enrichment_plot_volcanomethods_server <- function(id,
 
           xy <- cbind(x = fc, y = -log10(qv))
           tt <- colnames(Q)[i]
-          #
-
           ymax1 <- ymax
           if (input$scale_per_method) {
             ymax1 <- 1.2 * quantile(xy[, 2], probs = 0.999, na.rm = TRUE)[1] ## y-axis

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -133,6 +133,8 @@ expression_plot_volcanoAll_server <- function(id,
           xy <- data.frame(x = fx, y = -log10(qval))
           is.sig1 <- factor(is.sig, levels = c(FALSE, TRUE))
           ymax1 <- ymax
+          xmax <- max(1, 1.2 * quantile(abs(unlist(pd[["F"]])), probs = 0.999, na.rm = TRUE)[1]) ## x-axis
+
           if (input$scale_per_method) {
             ymax1 <- 1.2 * quantile(xy[, 2], probs = 0.999, na.rm = TRUE)[1] ## y-axis
           }

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -24,7 +24,7 @@ expression_plot_volcanoMethods_ui <- function(
   ns <- shiny::NS(id)
 
   plot_options <- shiny::tagList(
-    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", FALSE),
+    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", TRUE),
       "Scale the volcano plots individually per method..",
       placement = "right", options = list(container = "body")
     )


### PR DESCRIPTION
Add some minor changes addressing #613. Basically I added:

```r
  plot_options <- shiny::tagList(
    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", TRUE),
      "Scale the volcano plots individually per method..",
      placement = "right", options = list(container = "body")
    )
  )
```

and 

```r
          if (input$scale_per_method) {
            ymax1 <- 1.2 * quantile(xy[, 2], probs = 0.999, na.rm = TRUE)[1] ## y-axis
          }
```

To the files `enrichment_plot_volcanoall.R`, `enrichment_plot_volcanomethods.R`, `expression_plot_volcanoAll.R`, and `expression_plot_volcanoMethods.R`. 

I would like to note that there is space for improvement as the plot re-renders each time that the user expands the options panel, regardless of whether they click or not on the option. Any suggestions will be welcomed. 

I set @mauromiguelm as reviewer since you opened the issue.