### PR TITLE
remove Keyword option under word cloud

### DIFF
--- a/components/board.wordcloud/R/wordcloud_plot_enrichment.R
+++ b/components/board.wordcloud/R/wordcloud_plot_enrichment.R
@@ -9,14 +9,8 @@ wordcloud_plot_enrichment_ui <- function(
     info.text,
     caption,
     height) {
+      
   ns <- shiny::NS(id)
-
-  gseaplots_opts <- shiny::tagList(
-    withTooltip(shiny::textInput(ns("gseaplots_keywords"), "Keyword:", "cell cycle"),
-      "Paste a keyword such as 'apoptosis', 'replication' or 'cell cycle'.",
-      placement = "top", options = list(container = "body")
-    )
-  )
 
   PlotModuleUI(
     ns("plot"),
@@ -24,7 +18,6 @@ wordcloud_plot_enrichment_ui <- function(
     label = "a",
     info.text = info.text,
     caption = caption,
-    options = gseaplots_opts,
     height = height,
     download.fmt = c("png", "pdf")
   )
@@ -43,10 +36,6 @@ wordcloud_plot_enrichment_server <- function(id,
       shiny::req(res, topFreq)
 
       S <- res$S ## geneset expressions
-      keyword <- "ribosomal"
-      keyword <- "lipid"
-      keyword <- "apoptosis"
-      keyword <- "cell.cycle"
 
       sel.row <- wordcloud_enrichmentTable$rows_selected()
       shiny::req(sel.row)


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->
  
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keyword option under the word cloud serves no purpose since the keywords are updated based on the row selected from the enrichment table. 

So, keyword input is removed from the Enrichment plot. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->