### PR TITLE
Fix only one sample in all the groups

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -253,7 +253,7 @@ upload_module_computepgx_server <- function(
         
       shiny::observeEvent(contrastsRT(), {
         contrasts <- as.data.frame(contrastsRT())
-        has_one <- apply(contrasts, 2, function(x) any(table(x) == 1))
+        has_one <- apply(contrasts, 2, function(x) all(table(x) == 1))
 
         if (any(has_one)) {
           shinyalert::shinyalert(


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->
  
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
IChange the condition to check if there is one sample in all the groups. 
The previous condition was to check if there is one is one sample in any of the groups.
Since the gset and gene methods works for example data which has one sample on only one of the groups, that condition was wrong. Hence, the change. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->