### PR TITLE
fix functional clusters annotation mismatch

### DIFF
--- a/components/board.clustering/R/clustering_plot_clustannot.R
+++ b/components/board.clustering/R/clustering_plot_clustannot.R
@@ -134,6 +134,7 @@ clustering_plot_clusterannot_server <- function(id,
             align = "center", showarrow = FALSE
           )
         }
+
         ## NOTE: The same plotly code (originally) as in `plot_clustannot.R`
         ##       -> Seems it uses the function from this file, not the other one
         ## TODO: clean-up; we should stick to the general setup of individual
@@ -145,11 +146,10 @@ clustering_plot_clusterannot_server <- function(id,
             type = "bar",
             orientation = "h",
             hoverinfo = "text",
+            text = colnames(rho)[i],
             hovertemplate = ~ paste0(
-              ## TODO: the cluster ID in the tooltip is assigned wrongly (it's always S4),
-              ##       needs to be fixed (or that information to be removed)
               "Annotation: <b>%{y}</b><br>",
-              "Cluster: <b>", colnames(rho)[i], "</b><br>",
+              "Cluster: <b>%{text}</b><br>",
               "Correlation (R): <b>", sprintf("%1.2f", x), "</b>",
               "<extra></extra>"
             ),


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->
  
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The cluster ID is assigned wrongly (it was always S4). 
Reason for the problem: Instead of adding the text using text or customdata argument in the plotly::plot_ly function, used the text directly from outside the function. That appears to not work. 
Fix: Use the text argument with in the function. Also, customdata argument works. 
 
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" --> #628 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->