### PR TITLE
Fix #620: improve pgx computation spinner

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -146,6 +146,7 @@ app_server <- function(input, output, session) {
       pgx_dir = PGX.DIR,
       pgx = PGX,
       auth = auth,
+      nav = reactive(input$nav),
       reload_pgxdir = reload_pgxdir,
       load_uploaded_data = load_uploaded_data
     )
@@ -443,10 +444,15 @@ app_server <- function(input, output, session) {
     user
   })
 
+  welcome_detector <- reactiveVal(NULL)
+  observeEvent(input$nav, {
+    welcome_detector(input$nav == "welcome-tab")
+  })
+
   output$current_dataset <- shiny::renderText({
     shiny::req(auth$logged)
     has.pgx <- !is.null(PGX$name) && length(PGX$name) > 0
-    nav.welcome <- input$nav == "welcome-tab"
+    nav.welcome <- welcome_detector()
 
     if (isTRUE(auth$logged) && has.pgx && !nav.welcome) {
       ## trigger on change of dataset

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -146,7 +146,6 @@ app_server <- function(input, output, session) {
       pgx_dir = PGX.DIR,
       pgx = PGX,
       auth = auth,
-      nav = reactive(input$nav),
       reload_pgxdir = reload_pgxdir,
       load_uploaded_data = load_uploaded_data
     )

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -31,6 +31,7 @@ upload_module_computepgx_server <- function(
     create_raw_dir,
     enable_button = TRUE,
     alertready = TRUE,
+    nav,
     height = 720) {
   shiny::moduleServer(
     id,
@@ -725,7 +726,7 @@ upload_module_computepgx_server <- function(
       ## what does this do???
       observe(check_process_status())
 
-      observe({
+      observeEvent(c(process_counter(), nav()), {
         if (process_counter() > 0) {
           shiny::insertUI(
             selector = "#current_dataset",

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -726,15 +726,18 @@ upload_module_computepgx_server <- function(
       ## what does this do???
       observe(check_process_status())
 
-      observeEvent(c(process_counter(), nav()), {
+      observe({
+        
         if (process_counter() > 0) {
           shiny::insertUI(
             selector = "#current_dataset",
-            where = "beforeEnd",
-            ui = loading_spinner("Computation in progress...")
+            where = "beforeBegin",
+            ui = loading_spinner("Computation in progress..."),
+            session = session
           )
         } else if (process_counter() == 0) {
-          shiny::removeUI(selector = "#current_dataset > #spinner-container")
+          # remove UI with JS, had problems with shiny::removeUI
+          shinyjs::runjs("document.querySelector('.current-dataset #spinner-container').remove();")
         }
 
         MAX_DS_PROCESS <- 1

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -31,7 +31,6 @@ upload_module_computepgx_server <- function(
     create_raw_dir,
     enable_button = TRUE,
     alertready = TRUE,
-    nav,
     height = 720) {
   shiny::moduleServer(
     id,

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -7,6 +7,7 @@ UploadBoard <- function(id,
                         pgx_dir,
                         pgx,
                         auth,
+                        nav,
                         reload_pgxdir,
                         load_uploaded_data) {
   moduleServer(id, function(input, output, session) {
@@ -696,6 +697,7 @@ UploadBoard <- function(id,
       lib.dir = FILES,
       auth = auth,
       create_raw_dir = create_raw_dir,
+      nav = nav,
       height = height
     )
 

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -7,7 +7,6 @@ UploadBoard <- function(id,
                         pgx_dir,
                         pgx,
                         auth,
-                        nav,
                         reload_pgxdir,
                         load_uploaded_data) {
   moduleServer(id, function(input, output, session) {
@@ -697,7 +696,6 @@ UploadBoard <- function(id,
       lib.dir = FILES,
       auth = auth,
       create_raw_dir = create_raw_dir,
-      nav = nav,
       height = height
     )
 


### PR DESCRIPTION
This closes #620 + header refresh (still not tracked on issues, only commented on #620 discussion by @mauromiguelm)

## Description
### Header refresh
The header refresh was being triggered by [this line](https://github.com/bigomics/omicsplayground/compare/fix-%23620?expand=1#diff-a03e6d6a363b07de38c96f79f8b756c0326a33d8ad73ab1033b705d344830b1cL449) (reactivity). Moved the call to a reactive value so that the header only is refreshed when we intend it to.
### #620 fix
The spinner itself (IMHO) is pretty ok, I don't really think we have to make it more visible or move it somewhere else. However we kept loosing it on header refresh, which is fixed by this PR. Another edge case that made it disappear :

1. Creating compute job
2. Loading dataset

On this case the header does indeed have to be refreshed to display the loaded dataset name, by sharing the `input$nav` from the server to `upload_module_computepgx.R` I trigger [this code](https://github.com/bigomics/omicsplayground/compare/fix-%23620?expand=1#diff-d2a224220950205ab698eac5e55a59807e45eaafad1db8ae096d59d4316fc5e2R729-R746) at each tab change, therefore we will always display properly if a compute job is running.