### PR TITLE
Fix #649: Enrichment analysis has first column truncated

### DIFF
--- a/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
+++ b/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
@@ -38,6 +38,7 @@ enrichment_table_enrichment_analysis_server <- function(id,
 
     table_data <- shiny::reactive({
       rpt <- getFilteredGeneSetTable()
+      if (!("GS" %in% colnames(rpt))) rpt <- cbind(GS = rownames(rpt), rpt)
       rpt
     })
 
@@ -51,7 +52,6 @@ enrichment_table_enrichment_analysis_server <- function(id,
         return(NULL)
       }
 
-      if (!("GS" %in% colnames(rpt))) rpt <- cbind(GS = rownames(rpt), rpt)
       if ("GS" %in% colnames(rpt)) rpt$GS <- playbase::shortstring(rpt$GS, 72)
       if ("size" %in% colnames(rpt)) rpt$size <- as.integer(rpt$size)
 


### PR DESCRIPTION
This closes #649 

## Description
The handling of the rownames was being made inside the table render function and not on the `table_data` generator. Moved one line to achieve that and have the actual geneset names on the downloaded csv.