### PR TITLE
recode: give plot/table output unique name using ns()

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -399,19 +399,10 @@ PlotModuleServer <- function(id,
   moduleServer(
     id,
     function(input, output, session) {
+
       ns <- session$ns
-
-      filename <- ns("title")
-      stopwords <- c("-title", "-pltmod-title", "-plot-title", "-pltsrv-title", "-plotmodule-title")
-      x <- unlist(strsplit(filename, "-"))
-      x <- x[!x %in% stopwords]
-      filename <- paste(x, collapse = "-")
-
-      # replace empty spaces of title with underscore
-      filename <- gsub(" ", "_", filename)
-      # all caps down
-      filename <- tolower(filename)
-
+      filename <- sub("-$","",ns(''))  ## filename root
+      
       observeEvent(input$downloadOption,
         {
           if (!input$downloadOption %in% c("pdf", "png")) {
@@ -504,14 +495,13 @@ PlotModuleServer <- function(id,
       do.png <- "png" %in% download.fmt
       do.html <- "html" %in% download.fmt
       do.obj <- "obj" %in% download.fmt
-
       do.csv <- !is.null(csvFunc)
 
       PNGFILE <- PDFFILE <- HTMLFILE <- CSVFILE <- NULL
-      if (do.pdf) PDFFILE <- paste0(gsub("file", filename, tempfile()), ".pdf")
-      if (do.png) PNGFILE <- paste0(gsub("file", filename, tempfile()), ".png")
-      if (do.csv) CSVFILE <- paste0(gsub("file", filename, tempfile()), ".csv")
-      HTMLFILE <- paste0(gsub("file", filename, tempfile()), ".html") ## tempory for webshot
+      if (do.pdf) PDFFILE <- paste0(gsub("file", "plot", tempfile()), ".pdf")
+      if (do.png) PNGFILE <- paste0(gsub("file", "plot", tempfile()), ".png")
+      if (do.csv) CSVFILE <- paste0(gsub("file", "data", tempfile()), ".csv")
+      HTMLFILE <- paste0(tempfile(), ".html") ## tempory for webshot
       HTMLFILE
       unlink(HTMLFILE)
 

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -157,22 +157,13 @@ TableModuleServer <- function(id,
                               height = c(640, 800),
                               width = c("auto", 1400),
                               selector = c("none", "single", "multi", "key")[1],
-                              filename = "data.csv") {
+                              filename = "table.csv") {
   moduleServer(
     id,
     function(input, output, session) {
       ns <- session$ns
-      filename <- ns("title")
-      # stopwords = ['-title', '-pltmod-title', '-plot-title', '-pltsrv-title', '-plotmodule-title']
-      # x <- unlist(strsplit(filename, "-"))
-      # x <- x[!x %in% stopwords]
-      # filename <- paste(x, collapse = "-")
-      # print(filename)
-      filename <- vapply(strsplit(filename, "-"), function(x) { # remove uninformative information.
-        paste(x[seq.int(2)], collapse = "-")
-      }, character(1L))
-      filename <- paste0(filename, ".csv")
-
+      filename <- paste0(sub(".csv$","",ns(filename)),".csv")
+      
       if (is.null(func2)) func2 <- func
 
       # Downloader


### PR DESCRIPTION
Recoding to give unique file names to plot/table output using namespace ns() function. 

This solves issue #632
Related to commit 5bcbe56  and branch fix-#632-Custom_name_plots