### PR TITLE
Scm recompute feature

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -128,6 +128,7 @@ app_server <- function(input, output, session) {
   shinyjs::runjs("sidebarClose()")
 
   ## Modules needed from the start
+  recompute_pgx <- reactiveVal(NULL)
   env$load <- LoadingBoard(
     id = "load",
     pgx = PGX,
@@ -136,18 +137,21 @@ app_server <- function(input, output, session) {
     load_example = load_example,
     reload_pgxdir = reload_pgxdir,
     current_page = reactive(input$nav),
-    load_uploaded_data = load_uploaded_data
+    load_uploaded_data = load_uploaded_data,
+    recompute_pgx = recompute_pgx
   )
 
   ## Modules needed from the start
   if (opt$ENABLE_UPLOAD) {
+
     UploadBoard(
       id = "upload",
       pgx_dir = PGX.DIR,
       pgx = PGX,
       auth = auth,
       reload_pgxdir = reload_pgxdir,
-      load_uploaded_data = load_uploaded_data
+      load_uploaded_data = load_uploaded_data,
+      recompute_pgx = recompute_pgx
     )
   }
 

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -152,7 +152,7 @@ app_server <- function(input, output, session) {
       reload_pgxdir = reload_pgxdir,
       load_uploaded_data = load_uploaded_data,
       recompute_pgx = recompute_pgx
-    )
+      )
   }
 
   ## Chatbox

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -128,8 +128,8 @@ app_server <- function(input, output, session) {
   shinyjs::runjs("sidebarClose()")
 
   ## Modules needed from the start
-  recompute_pgx <- reactiveVal(NULL)
-  recompute_info <- reactiveVal(NULL)
+  recompute_pgx <- shiny::reactiveVal(NULL)
+  recompute_info <- shiny::reactiveVal(NULL)
   env$load <- LoadingBoard(
     id = "load",
     pgx = PGX,

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -129,6 +129,7 @@ app_server <- function(input, output, session) {
 
   ## Modules needed from the start
   recompute_pgx <- reactiveVal(NULL)
+  recompute_info <- reactiveVal(NULL)
   env$load <- LoadingBoard(
     id = "load",
     pgx = PGX,
@@ -151,7 +152,8 @@ app_server <- function(input, output, session) {
       auth = auth,
       reload_pgxdir = reload_pgxdir,
       load_uploaded_data = load_uploaded_data,
-      recompute_pgx = recompute_pgx
+      recompute_pgx = recompute_pgx,
+      recompute_info = recompute_info
       )
   }
 

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -15,9 +15,12 @@ LoadingBoard <- function(id,
                          load_example,
                          reload_pgxdir,
                          current_page,
-                         load_uploaded_data) {
+                         load_uploaded_data,
+                         recompute_pgx) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
+
+
 
     reload_pgxdir_public <- reactiveVal(0)
     refresh_shared <- reactiveVal(0)
@@ -175,7 +178,8 @@ LoadingBoard <- function(id,
       loadPGX = loadPGX,
       refresh_shared = refresh_shared,
       reload_pgxdir_public = reload_pgxdir_public,
-      reload_pgxdir = reload_pgxdir
+      reload_pgxdir = reload_pgxdir,
+      recompute_pgx = recompute_pgx
     )
 
     loading_tsne_server(

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -16,7 +16,8 @@ LoadingBoard <- function(id,
                          reload_pgxdir,
                          current_page,
                          load_uploaded_data,
-                         recompute_pgx) {
+                         recompute_pgx
+                         ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
 

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -551,13 +551,41 @@ loading_table_datasets_server <- function(id,
       {
         shinyjs::click(id = "recompute_pgx_btn")
       }
-      print("Just to be sure we are here")
-      #updateTabsetPanel(session, "tabset_b", selected = "B1")
 
-      updateTabsetPanel(session, "upload",selected = "makecontrast")
-      
-      #shinyjs::runjs("$('a[data-value=\"Comparisons\"]').tab('show')")
-      #shinyjs::runjs("$('div[data-value=\"Comparisons\"]').addClass('tab-pane active show')")
+      shinyalert::shinyalert(
+                    title = "Recompute",
+                    text = "Recomputing your data will remove the current contrasts",
+                    confirmButtonText = "OK", 
+                    cancelButtonText = "Cancel",
+                    callbackR = function() {
+
+                        # Load PGX 
+                        sel <- row_idx <- as.numeric(stringr::str_split(input$recompute_pgx, "_row_")[[1]][2])
+                        df <- getFilteredPGXINFO()
+                        pgxfile <- as.character(df$dataset[sel])
+                        pgxfile <- paste0(sub("[.]pgx$", "", pgxfile), ".pgx")
+                        pgx <- loadPGX(pgxfile)
+                        load_uploaded_data <- reactiveVal(NULL)
+                        reload_pgxdir <- reactiveVal(0)
+
+                        UploadBoard(
+                          id = "upload",
+                          pgx_dir = auth$user_dir,
+                          pgx = pgx,
+                          auth = auth,
+                          reload_pgxdir = reload_pgxdir,
+                          load_uploaded_data = load_uploaded_data,
+                          recompute_pgx = TRUE
+                        )
+
+                        bigdash.selectTab(session, "upload-tab")
+                        shinyjs::runjs('$("[data-value=\'Upload\']").click();') # Should be Comparisons?
+
+                        return(0)
+               }
+                  ) 
+
+
     })
 
     ## ---------------- DOWNLOAD PGX FILE ----------------

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -71,7 +71,8 @@ loading_table_datasets_server <- function(id,
                                           refresh_shared,
                                           reload_pgxdir_public,
                                           reload_pgxdir,
-                                          recompute_pgx) {
+                                          recompute_pgx
+                                          ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -550,17 +551,16 @@ loading_table_datasets_server <- function(id,
     )
     ## ---------------- RECOMPUTE PGX -------------------
     shiny::observeEvent(input$recompute_pgx, {
-      #{
-      #  shinyjs::click(id = "recompute_pgx_btn")
-      #}
 
       shinyalert::shinyalert(
                     title = "Recompute",
                     text = "Recomputing your data will remove the current contrasts",
-                    confirmButtonText = "OK",
+                    showCancelButton = TRUE,
                     cancelButtonText = "Cancel",
-                    callbackR = function() {
+                    confirmButtonText = "OK",
+                    callbackR = function(x) {
 
+                      if (x) {
                         # Load PGX
                         sel <- row_idx <- as.numeric(stringr::str_split(input$recompute_pgx, "_row_")[[1]][2])
                         df <- getFilteredPGXINFO()
@@ -570,12 +570,15 @@ loading_table_datasets_server <- function(id,
                         load_uploaded_data <- reactiveVal(NULL)
                         reload_pgxdir <- reactiveVal(0)
                         recompute_pgx(pgx)
-                        print('SETTING THE RECOMPUTE PGX')
 
                         bigdash.selectTab(session, "upload-tab")
                         shinyjs::runjs('$("[data-value=\'Upload\']").click();') # Should be Comparisons?
 
                         return(0)
+                        } else {
+                          return(0)
+                        }
+
                }
                   )
 

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -563,12 +563,12 @@ loading_table_datasets_server <- function(id,
                       if (x) {
                         # Load PGX
                         sel <- row_idx <- as.numeric(stringr::str_split(input$recompute_pgx, "_row_")[[1]][2])
-                        df <- getFilteredPGXINFO()
+                        df <- playbase::getFilteredPGXINFO()
                         pgxfile <- as.character(df$dataset[sel])
                         pgxfile <- paste0(sub("[.]pgx$", "", pgxfile), ".pgx")
-                        pgx <- loadPGX(pgxfile)
-                        load_uploaded_data <- reactiveVal(NULL)
-                        reload_pgxdir <- reactiveVal(0)
+                        pgx <- playbase::loadPGX(pgxfile)
+                        load_uploaded_data <- shiny::reactiveVal(NULL)
+                        reload_pgxdir <- shiny::reactiveVal(0)
                         recompute_pgx(pgx)
 
                         bigdash.selectTab(session, "upload-tab")

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -331,9 +331,9 @@ loading_table_datasets_server <- function(id,
         )
         recompute_pgx_menuitem <- shiny::actionButton(
           ns(paste0("recompute_pgx_row_", i)),
-          label = "Recompute dataset",
-          icon = shiny::icon("trash"), # TODO: change icon
-          class = "btn btn-outline-info",
+          label = "Reanalyse",
+          icon = shiny::icon("gears"), 
+          class = "btn btn-outline-dark",
           style = "border: none;",
           width = "100%",
           onclick = paste0('Shiny.onInputChange(\"', ns("recompute_pgx"), '\",this.id,{priority: "event"});')
@@ -353,10 +353,10 @@ loading_table_datasets_server <- function(id,
                 width = "100%",
                 onclick = paste0('Shiny.onInputChange(\"', ns("download_zip"), '\",this.id,{priority: "event"})')
               ),
+              recompute_pgx_menuitem,
               share_public_menuitem,
               share_dataset_menuitem,
-              delete_pgx_menuitem,
-              recompute_pgx_menuitem
+              delete_pgx_menuitem
             )
           ),
           size = "sm",

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -70,7 +70,8 @@ loading_table_datasets_server <- function(id,
                                           loadPGX,
                                           refresh_shared,
                                           reload_pgxdir_public,
-                                          reload_pgxdir) {
+                                          reload_pgxdir,
+                                          recompute_pgx) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -375,6 +376,7 @@ loading_table_datasets_server <- function(id,
         ignoreInit = TRUE
       )
 
+
       DT::datatable(
         df,
         class = "compact hover",
@@ -546,20 +548,20 @@ loading_table_datasets_server <- function(id,
         gc()
       }
     )
-    ## ---------------- RECOMPUTE PGX -------------------  
+    ## ---------------- RECOMPUTE PGX -------------------
     shiny::observeEvent(input$recompute_pgx, {
-      {
-        shinyjs::click(id = "recompute_pgx_btn")
-      }
+      #{
+      #  shinyjs::click(id = "recompute_pgx_btn")
+      #}
 
       shinyalert::shinyalert(
                     title = "Recompute",
                     text = "Recomputing your data will remove the current contrasts",
-                    confirmButtonText = "OK", 
+                    confirmButtonText = "OK",
                     cancelButtonText = "Cancel",
                     callbackR = function() {
 
-                        # Load PGX 
+                        # Load PGX
                         sel <- row_idx <- as.numeric(stringr::str_split(input$recompute_pgx, "_row_")[[1]][2])
                         df <- getFilteredPGXINFO()
                         pgxfile <- as.character(df$dataset[sel])
@@ -567,23 +569,15 @@ loading_table_datasets_server <- function(id,
                         pgx <- loadPGX(pgxfile)
                         load_uploaded_data <- reactiveVal(NULL)
                         reload_pgxdir <- reactiveVal(0)
-
-                        UploadBoard(
-                          id = "upload",
-                          pgx_dir = auth$user_dir,
-                          pgx = pgx,
-                          auth = auth,
-                          reload_pgxdir = reload_pgxdir,
-                          load_uploaded_data = load_uploaded_data,
-                          recompute_pgx = TRUE
-                        )
+                        recompute_pgx(pgx)
+                        print('SETTING THE RECOMPUTE PGX')
 
                         bigdash.selectTab(session, "upload-tab")
                         shinyjs::runjs('$("[data-value=\'Upload\']").click();') # Should be Comparisons?
 
                         return(0)
                }
-                  ) 
+                  )
 
 
     })

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -44,6 +44,12 @@ loading_table_datasets_ui <- function(
         icon = NULL,
         width = "0%"
       ),
+      shiny::downloadLink(
+        ns("recompute_pgx_btn"),
+        label = "",
+        icon = NULL,
+        width = "0%"
+      ),
       shiny::actionButton(
         ns("loadbutton"),
         label = "Load dataset",
@@ -313,18 +319,24 @@ loading_table_datasets_server <- function(id,
         }
 
         ## instead of disabling we grey out and have a popup message
-        ##        if(enable_delete) {
-        if (TRUE) {
-          delete_pgx_menuitem <- shiny::actionButton(
-            ns(paste0("delete_dataset_row_", i)),
-            label = "Delete dataset",
-            icon = shiny::icon("trash"),
-            class = "btn btn-outline-danger",
-            style = "border: none;",
-            width = "100%",
-            onclick = paste0('Shiny.onInputChange(\"', ns("delete_pgx"), '\",this.id,{priority: "event"});')
-          )
-        }
+        delete_pgx_menuitem <- shiny::actionButton(
+          ns(paste0("delete_dataset_row_", i)),
+          label = "Delete dataset",
+          icon = shiny::icon("trash"),
+          class = "btn btn-outline-danger",
+          style = "border: none;",
+          width = "100%",
+          onclick = paste0('Shiny.onInputChange(\"', ns("delete_pgx"), '\",this.id,{priority: "event"});')
+        )
+        recompute_pgx_menuitem <- shiny::actionButton(
+          ns(paste0("recompute_pgx_row_", i)),
+          label = "Recompute dataset",
+          icon = shiny::icon("trash"), # TODO: change icon
+          class = "btn btn-outline-info",
+          style = "border: none;",
+          width = "100%",
+          onclick = paste0('Shiny.onInputChange(\"', ns("recompute_pgx"), '\",this.id,{priority: "event"});')
+        )
 
         new_menu <- DropdownMenu(
           div(
@@ -342,7 +354,8 @@ loading_table_datasets_server <- function(id,
               ),
               share_public_menuitem,
               share_dataset_menuitem,
-              delete_pgx_menuitem
+              delete_pgx_menuitem,
+              recompute_pgx_menuitem
             )
           ),
           size = "sm",
@@ -533,6 +546,19 @@ loading_table_datasets_server <- function(id,
         gc()
       }
     )
+    ## ---------------- RECOMPUTE PGX -------------------  
+    shiny::observeEvent(input$recompute_pgx, {
+      {
+        shinyjs::click(id = "recompute_pgx_btn")
+      }
+      print("Just to be sure we are here")
+      #updateTabsetPanel(session, "tabset_b", selected = "B1")
+
+      updateTabsetPanel(session, "upload",selected = "makecontrast")
+      
+      #shinyjs::runjs("$('a[data-value=\"Comparisons\"]').tab('show')")
+      #shinyjs::runjs("$('div[data-value=\"Comparisons\"]').addClass('tab-pane active show')")
+    })
 
     ## ---------------- DOWNLOAD PGX FILE ----------------
     observeEvent(input$download_pgx,

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -563,10 +563,10 @@ loading_table_datasets_server <- function(id,
                       if (x) {
                         # Load PGX
                         sel <- row_idx <- as.numeric(stringr::str_split(input$recompute_pgx, "_row_")[[1]][2])
-                        df <- playbase::getFilteredPGXINFO()
+                        df <- getFilteredPGXINFO()
                         pgxfile <- as.character(df$dataset[sel])
                         pgxfile <- paste0(sub("[.]pgx$", "", pgxfile), ".pgx")
-                        pgx <- playbase::loadPGX(pgxfile)
+                        pgx <- loadPGX(pgxfile)
                         load_uploaded_data <- shiny::reactiveVal(NULL)
                         reload_pgxdir <- shiny::reactiveVal(0)
                         recompute_pgx(pgx)

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -31,12 +31,13 @@ upload_module_computepgx_server <- function(
     create_raw_dir,
     enable_button = TRUE,
     alertready = TRUE,
-    height = 720) {
+    height = 720,
+    recompute_pgx
+    ) {
   shiny::moduleServer(
     id,
     function(input, output, session) {
       ns <- session$ns
-
       ## statistical method for GENE level testing
       GENETEST.METHODS <- c(
         "ttest", "ttest.welch", "voom.limma", "trend.limma", "notrend.limma",
@@ -109,7 +110,7 @@ upload_module_computepgx_server <- function(
                   shiny::tags$td("Description"),
                   shiny::tags$td(shiny::div(
                     shiny::textAreaInput(
-                      ns("upload_description"), NULL, ## "Description:",
+                      ns("upload_description"), NULL, 
                       placeholder = "Give a short description of your dataset",
                       height = 100, resize = "none"
                     ),

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -149,8 +149,6 @@ upload_module_computepgx_server <- function(
                       "only.proteincoding",
                       "remove.unknown",
                       "remove.notexpressed"
-                      ## "excl.immuno"
-                      ## "excl.xy"
                     ),
                   choiceNames =
                     c(

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -32,7 +32,7 @@ upload_module_computepgx_server <- function(
     enable_button = TRUE,
     alertready = TRUE,
     height = 720,
-    recompute_pgx
+    recompute_info
     ) {
   shiny::moduleServer(
     id,
@@ -238,11 +238,13 @@ upload_module_computepgx_server <- function(
           shinyjs::enable(ns("compute"))
         }
       })
-
-      shiny::observeEvent(metaRT(), {
+      # Inpute name and description
+      shiny::observeEvent(list(metaRT(), recompute_info()), {
         meta <- metaRT()
-
-        if (!is.null(meta[["name"]])) {
+        pgx_info <- recompute_info()
+        # If the user recomputes, recycle old names/description
+        if (is.null(pgx_info)) {
+          if (!is.null(meta[["name"]])) {
           shiny::updateTextInput(session,
             "upload_name",
             value = meta[["name"]]
@@ -253,6 +255,18 @@ upload_module_computepgx_server <- function(
             "upload_description",
             value = meta[["description"]]
           )
+          }
+          } else {
+
+          shiny::updateTextInput(session,
+            "upload_name",
+            value = gsub(".pgx$", "", pgx_info[["name"]])
+          )
+          shiny::updateTextAreaInput(session,
+            "upload_description",
+            value = pgx_info[["description"]]
+          )
+        
         }
       })
 

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -9,7 +9,8 @@ UploadBoard <- function(id,
                         auth,
                         reload_pgxdir,
                         load_uploaded_data,
-                        recompute_pgx) {
+                        recompute_pgx
+                        ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
 
@@ -138,7 +139,6 @@ UploadBoard <- function(id,
 
     ## Hide/show tabpanels upon available data like a wizard dialog
     shiny::observe({
-      
       has.upload <- Vectorize(function(f) {
         (f %in% names(uploaded) && !is.null(nrow(uploaded[[f]])))
       })
@@ -384,16 +384,12 @@ UploadBoard <- function(id,
       message("[upload_files] done!\n")
     })
 
-    # recompute pgx
+    # In case the user is reanalysing the data, get the info from pgx
     observeEvent(recompute_pgx(), {
       pgx <- recompute_pgx()
       uploaded$samples.csv <- pgx$samples
       uploaded$contrasts.csv <- pgx$contrast
       uploaded$counts.csv <- pgx$counts
-
-      # note from nick: you dont want this -- this will load the pgx and go to viewdata page
-      uploaded[["last_uploaded"]] <- c("contrasts.csv")
-
       corrected_counts <- pgx$counts
     })
 

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -9,7 +9,8 @@ UploadBoard <- function(id,
                         auth,
                         reload_pgxdir,
                         load_uploaded_data,
-                        recompute_pgx
+                        recompute_pgx,
+                        recompute_info
                         ) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
@@ -391,6 +392,8 @@ UploadBoard <- function(id,
       uploaded$contrasts.csv <- pgx$contrast
       uploaded$counts.csv <- pgx$counts
       corrected_counts <- pgx$counts
+      recompute_info(list("name" = pgx$name, "description" = pgx$description))
+
     })
 
 
@@ -707,7 +710,8 @@ UploadBoard <- function(id,
       lib.dir = FILES,
       auth = auth,
       create_raw_dir = create_raw_dir,
-      height = height
+      height = height,
+      recompute_info
     )
 
     uploaded_pgx <- shiny::reactive({

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -9,7 +9,7 @@ UploadBoard <- function(id,
                         auth,
                         reload_pgxdir,
                         load_uploaded_data,
-                        recompute_pgx = FALSE) {
+                        recompute_pgx) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
 
@@ -148,11 +148,11 @@ UploadBoard <- function(id,
       if (all(has.upload(need3))) {
         shiny::showTab("tabs", "Comparisons")
         shiny::showTab("tabs", "Compute")
-        if (recompute_pgx ||input$advanced_mode) {
+        if (input$advanced_mode) {
           shiny::showTab("tabs", "BatchCorrect")
         }
-      } else if (recompute_pgx || all(has.upload(need2))) {
-        if (recompute_pgx || input$advanced_mode) {
+      } else if (all(has.upload(need2))) {
+        if (input$advanced_mode) {
           shiny::showTab("tabs", "BatchCorrect")
         }
         shiny::showTab("tabs", "Comparisons")
@@ -200,7 +200,6 @@ UploadBoard <- function(id,
       raw_dir
     }
 
-    if (!recompute_pgx) {
     shiny::observeEvent(input$upload_files, {
 
       if (is.null(raw_dir())) {
@@ -386,21 +385,25 @@ UploadBoard <- function(id,
       message("[upload_files] done!\n")
     })
 
-        } else {
-        observe({
-        print("Working on it!")
-        print(names(pgx))
-        uploaded$samples.csv <- pgx$samples
-        uploaded$contrasts.csv <- pgx$contrast
-        uploaded$counts.csv <- pgx$counts
-        uploaded$pgx <- pgx
-        uploaded[["last_uploaded"]] <- c("contrasts.csv")
+    # recompute pgx
+    observeEvent(recompute_pgx(), {
+      pgx <- recompute_pgx()
+      print("Working on it!")
+      print(names(pgx))
+      uploaded$samples.csv <- pgx$samples
+      uploaded$contrasts.csv <- pgx$contrast
+      uploaded$counts.csv <- pgx$counts
+      print(pgx$samples)
 
-        #print(uploaded)
-        corrected_counts <- pgx$counts
-        print(names(uploaded))
-        })
-    }
+      # note from nick: you dont want this -- this will load the pgx and go to viewdata page
+      #uploaded$pgx <- pgx
+      uploaded[["last_uploaded"]] <- c("contrasts.csv")
+
+      #print(uploaded)
+      corrected_counts <- pgx$counts
+      print(names(uploaded))
+    })
+
 
     observe({
       print("Working on it from the outside!")

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -138,8 +138,7 @@ UploadBoard <- function(id,
 
     ## Hide/show tabpanels upon available data like a wizard dialog
     shiny::observe({
-      print("From the tab checker")
-      print(names(uploaded))
+      
       has.upload <- Vectorize(function(f) {
         (f %in% names(uploaded) && !is.null(nrow(uploaded[[f]])))
       })
@@ -388,27 +387,14 @@ UploadBoard <- function(id,
     # recompute pgx
     observeEvent(recompute_pgx(), {
       pgx <- recompute_pgx()
-      print("Working on it!")
-      print(names(pgx))
       uploaded$samples.csv <- pgx$samples
       uploaded$contrasts.csv <- pgx$contrast
       uploaded$counts.csv <- pgx$counts
-      print(pgx$samples)
 
       # note from nick: you dont want this -- this will load the pgx and go to viewdata page
-      #uploaded$pgx <- pgx
       uploaded[["last_uploaded"]] <- c("contrasts.csv")
 
-      #print(uploaded)
       corrected_counts <- pgx$counts
-      print(names(uploaded))
-    })
-
-
-    observe({
-      print("Working on it from the outside!")
-      print(names(uploaded))
-
     })
 
 


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->
  
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR includes the following changes:
- Added recompute feature at the data loading board (within the ... menu)
- Added reactive value recompute_info to hold PGX info when recomputing
- Updated observeEvent to watch recompute_info in addition to metaRT()
- Handle recompute case separately:
-- If recomputing, reuse old name/description in the Compute tab
-- Else the user will see the name/description in the Compute tab as usual

### For Testing:
Go to the loading data board, select one of your datasets and click the ... menu. If implemented correctly, you should see the new recompute option. Then, test the option by clicking.


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
This should close: #599 
## Notes
Let me know if you would like me to modify or expand the pull request.
Some things to take on for the future:
- Pre-populate checkboxes with old pgx options
- Block the user to write new pgx name
- Block the user to upload new counts/contrast/sample during recompute.
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->