### PR TITLE
remove html tags from tooltips

### DIFF
--- a/components/board.enrichment/R/enrichment_ui.R
+++ b/components/board.enrichment/R/enrichment_ui.R
@@ -44,7 +44,7 @@ EnrichmentInputs <- function(id) {
           placement = "right", options = list(container = "body")
         ),
         withTooltip(shiny::checkboxInput(ns("gs_top10"), "top 10 gene sets", FALSE),
-          "Display only top 10 differentially enirhced gene sets (positively and negatively) in the <b>enrihcment analysis</b> table.",
+          "Display only top 10 differentially enirhced gene sets (positively and negatively) in the enrihcment analysis table.",
           placement = "top", options = list(container = "body")
         ),
       )

--- a/components/board.upload/R/upload_module_batchcorrect.R
+++ b/components/board.upload/R/upload_module_batchcorrect.R
@@ -191,7 +191,7 @@ upload_module_batchcorrect_server <- function(id, X, pheno, is.count = FALSE, he
             shiny::selectInput(ns("bc_modelpar"), "Model parameters:", pheno.par,
               selected = sel.par, multiple = TRUE
             ),
-            "Please specify <b>all</b> your model parameters. These are the parameters of interest that will determine your groupings.",
+            "Please specify all your model parameters. These are the parameters of interest that will determine your groupings.",
             placement = "top", options = list(container = "body")
           ),
           withTooltip(
@@ -208,7 +208,7 @@ upload_module_batchcorrect_server <- function(id, X, pheno, is.count = FALSE, he
               selected = bc.selected,
               inline = FALSE
             ),
-            "Unsupervised correction methods. Correction will be performed additional to the (supervised) corrections above. <b>PCA</b> iteratively corrects low rank PC components not correlated to any model parameters; <b>SVA</b> applies surrogate variable analysis (Leek et al.); <b>NNM</b> applies nearest neighbour matching, a quasi-pairing approach for incomplete matched data (unpublished).",
+            "Unsupervised correction methods. Correction will be performed additional to the (supervised) corrections above. PCA iteratively corrects low rank PC components not correlated to any model parameters; SVA applies surrogate variable analysis (Leek et al.); NNM applies nearest neighbour matching, a quasi-pairing approach for incomplete matched data (unpublished).",
             placement = "left", options = list(container = "body")
           ),
           withTooltip(


### PR DESCRIPTION
Fixes https://github.com/bigomics/omicsplayground/issues/670

HTML tags dont belong in tooltips.. text only. That is the easiest solution. It was only a "< b >" (bold) tag used in a couple places -- we can go without bolding a few words in tooltips compared to the work it may take to implement html tags in tooltips.