### PR TITLE
Fix #677: Clustered Heatmap figure is cropped when downloaded

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -269,7 +269,7 @@ clustering_plot_splitmap_server <- function(id,
       obj2 <- plt %>% iheatmapr::to_plotly_list()
       plt <- plotly::as_widget(obj2) %>%
         plotly::layout(
-          margin = list(l = 0, r = 0, t = 0, b = 0)
+          margin = list(l = 5, r = 5, t = 5, b = 5)
         )
 
       return(plt)

--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -269,7 +269,7 @@ clustering_plot_splitmap_server <- function(id,
       obj2 <- plt %>% iheatmapr::to_plotly_list()
       plt <- plotly::as_widget(obj2) %>%
         plotly::layout(
-          margin = list(l = 5, r = 5, t = 5, b = 5)
+          margin = list(l = 10, r = 5, t = 5, b = 5)
         )
 
       return(plt)


### PR DESCRIPTION
This closes #677 

## Description
Added margins. @mauromiguelm feel free to modify it before merging if required.