### PR TITLE
Fix #637: Tables downloaded as .htm in production (not locally)

### DIFF
--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -434,3 +434,39 @@ $(document).ready(function() {
 
 
 
+document.addEventListener('shown.bs.popover', function(event) {
+	// Get the popover container (Bootstrap 5 attaches the popover to the body by default)
+	var popover = document.body.querySelector('.popover');
+  
+	if (!popover) {
+	  console.log("Popover not found.");
+	  return;
+	}
+  
+	// Find the download button inside the popover using its class
+	var targetNode = popover.querySelector('.shiny-download-link');
+  
+	if (!targetNode) {
+	  console.log("Download button not found.");
+	  return;
+	}
+  
+	// Options for the observer (which attributes to watch)
+	var config = { attributes: true, attributeFilter: ['href'] };
+  
+	// Callback function to execute when mutations are observed
+	var callback = function(mutationsList, observer) {
+	  for (var mutation of mutationsList) {
+		if (mutation.type === 'attributes' && mutation.attributeName === 'href') {
+		  // Enable the button by removing the "disabled" attribute
+		  $(targetNode).removeClass('disabled');
+		}
+	  }
+	};
+  
+	// Create an observer instance linked to the callback function
+	var observer = new MutationObserver(callback);
+  
+	// Start observing the target node for configured mutations
+	observer.observe(targetNode, config);
+  });

--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -432,7 +432,7 @@ $(document).ready(function() {
 });
 
 
-
+var hrefUpdatedStatus = {};  // Object to track href update status for each popover
 
 document.addEventListener('shown.bs.popover', function(event) {
 	// Get the popover container (Bootstrap 5 attaches the popover to the body by default)
@@ -450,6 +450,21 @@ document.addEventListener('shown.bs.popover', function(event) {
 	  console.log("Download button not found.");
 	  return;
 	}
+
+	// Get the id attribute of the download button
+    var buttonId = targetNode.getAttribute('id');
+    if (!buttonId) {
+        console.log("Download button ID not found.");
+        return;
+    }
+
+	// If href has been updated previously for this popover, always remove the disabled class
+    if (hrefUpdatedStatus[buttonId]) {
+        //$(targetNode).removeClass('disabled');
+		return;
+    } else {
+		$(targetNode).addClass('disabled');
+	}
   
 	// Options for the observer (which attributes to watch)
 	var config = { attributes: true, attributeFilter: ['href'] };
@@ -460,6 +475,8 @@ document.addEventListener('shown.bs.popover', function(event) {
 		if (mutation.type === 'attributes' && mutation.attributeName === 'href') {
 		  // Enable the button by removing the "disabled" attribute
 		  $(targetNode).removeClass('disabled');
+		  // Set the flag to true as href has been updated for this popover
+		  hrefUpdatedStatus[buttonId] = true;
 		}
 	  }
 	};

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -104,12 +104,10 @@ PlotModuleUI <- function(id,
 
   if (cards == FALSE) {
     download_buttons <- div(
-      shinyjs::disabled(
-        shiny::downloadButton(
-          outputId = ns("download"),
-          label = "Download",
-          class = "btn-outline-primary"
-        )
+      shiny::downloadButton(
+        outputId = ns("download"),
+        label = "Download",
+        class = "btn-outline-primary"
       )
     )
   } else {

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -95,13 +95,6 @@ PlotModuleUI <- function(id,
     )
   }
 
-  dload.csv <- dload.pdf <- dload.png <- dload.html <- dload.obj <- NULL
-  if ("pdf" %in% download.fmt) dload.pdf <- shiny::downloadButton(ns("pdf"), "PDF")
-  if ("png" %in% download.fmt) dload.png <- shiny::downloadButton(ns("png"), "PNG")
-  if ("html" %in% download.fmt) dload.html <- shiny::downloadButton(ns("html"), "HTML")
-  if ("csv" %in% download.fmt) dload.csv <- shiny::downloadButton(ns("csv"), "CSV")
-  if ("obj" %in% download.fmt) dload.obj <- shiny::downloadButton(ns("obj"), "obj")
-
   if (cards == FALSE) {
     download_buttons <- div(
       shiny::downloadButton(

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -104,10 +104,12 @@ PlotModuleUI <- function(id,
 
   if (cards == FALSE) {
     download_buttons <- div(
-      shiny::downloadButton(
-        outputId = ns("download"),
-        label = "Download",
-        class = "btn-outline-primary"
+      shinyjs::disabled(
+        shiny::downloadButton(
+          outputId = ns("download"),
+          label = "Download",
+          class = "btn-outline-primary"
+        )
       )
     )
   } else {

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -51,9 +51,11 @@ TableModuleUI <- function(id,
       shiny::hr(),
       div(
         style = "text-align: center;",
-        shiny::downloadButton(
-          outputId = ns("download"),
-          label = "Download",
+        shinyjs::disabled(
+          shiny::downloadButton(
+            outputId = ns("download"),
+            label = "Download",
+          )
         )
       )
     ),

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -51,11 +51,9 @@ TableModuleUI <- function(id,
       shiny::hr(),
       div(
         style = "text-align: center;",
-        shinyjs::disabled(
-          shiny::downloadButton(
-            outputId = ns("download"),
-            label = "Download",
-          )
+        shiny::downloadButton(
+          outputId = ns("download"),
+          label = "Download",
         )
       )
     ),


### PR DESCRIPTION
This closes #637 

## Description
As described on the issue thread, there is an initial link (downloads htm) and a correct one (downloads image/table). As it turns out is not a matter of interacting with other elements of the popover, it just takes some time which seems to be related with client computing browser. 

By disabling the buttons by default and enabling them once the correct href is available, we make sure the download is always reliable.

From my testing it does not affect the usability or experience of the application.