### PR TITLE
Fix #697: ssue with "Compare datasets" in V3

### DIFF
--- a/components/board.compare/R/compare_server.R
+++ b/components/board.compare/R/compare_server.R
@@ -106,13 +106,6 @@ CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "min
       comparisons2 <- names(pgx$gx.meta$meta)
       sel2 <- tail(head(comparisons2, 2), 1)
       shiny::updateSelectInput(session, "contrast2", choices = comparisons2, selected = sel2)
-      # Save on the server the new `contrast2` input value.
-      # `updateSelectInput` sends message to browser, but the `input$contrast2` value
-      # is not updated on the server instantanely, this creates an issue
-      # on the `getOmicsScoreTable` reactive when triggered by a change in dataset
-      # that makes `input$contrast2` to be outdated and crash the application.
-      updated_contrast2 <- reactiveVal()
-      updated_contrast2(sel2)
       pgx
     })
 
@@ -121,17 +114,15 @@ CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "min
       shiny::req(dataset2())
       shiny::req(input$contrast1)
       shiny::req(input$contrast2)
+      shiny::req(
+        input$contrast2 %in% colnames(playbase::pgx.getMetaMatrix(dataset2())$fc)
+      )
 
       pgx1 <- pgx
       pgx2 <- dataset2()
 
       ct1 <- input$contrast1
       ct2 <- input$contrast2
-      # This is just useful when there's a change in dataset2
-      # read comment on dataset2 reactive for info
-      if(updated_contrast2() != ct2) {
-        ct2 <- updated_contrast2()
-      }
 
       F1 <- playbase::pgx.getMetaMatrix(pgx1)$fc[, ct1, drop = FALSE]
       F2 <- playbase::pgx.getMetaMatrix(pgx2)$fc[, ct2, drop = FALSE]

--- a/components/board.compare/R/compare_server.R
+++ b/components/board.compare/R/compare_server.R
@@ -106,6 +106,13 @@ CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "min
       comparisons2 <- names(pgx$gx.meta$meta)
       sel2 <- tail(head(comparisons2, 2), 1)
       shiny::updateSelectInput(session, "contrast2", choices = comparisons2, selected = sel2)
+      # Save on the server the new `contrast2` input value.
+      # `updateSelectInput` sends message to browser, but the `input$contrast2` value
+      # is not updated on the server instantanely, this creates an issue
+      # on the `getOmicsScoreTable` reactive when triggered by a change in dataset
+      # that makes `input$contrast2` to be outdated and crash the application.
+      updated_contrast2 <- reactiveVal()
+      updated_contrast2(sel2)
       pgx
     })
 
@@ -120,6 +127,11 @@ CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "min
 
       ct1 <- input$contrast1
       ct2 <- input$contrast2
+      # This is just useful when there's a change in dataset2
+      # read comment on dataset2 reactive for info
+      if(updated_contrast2() != ct2) {
+        ct2 <- updated_contrast2()
+      }
 
       F1 <- playbase::pgx.getMetaMatrix(pgx1)$fc[, ct1, drop = FALSE]
       F2 <- playbase::pgx.getMetaMatrix(pgx2)$fc[, ct2, drop = FALSE]


### PR DESCRIPTION
This closes #697 

## Description
The bug arises from the use of `shiny::updateSelectInput`, this updates the browser but it does not immediately have effect on the `input$X` value on the server. 

Therefore, when the user changed `dataset2`, the server was trying to access the contrast that was previously selected which crashed the application.

To solve it I added a new `shiny::req` that makes sure that the selected contrast is actually present on the data.