### PR TITLE
Fix #699: adjust sample-contrast check for when NA present in single contrast

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -306,7 +306,7 @@ UploadBoard <- function(id,
             }
 
             if (IS_CONTRAST) {
-              df0 <- playbase::read.as_matrix(fn2)
+              df0 <- playbase::read.as_matrix(fn2, skip_row_check = TRUE)
               # save input as raw file in raw_dir
               file.copy(fn2, file.path(raw_dir(), "raw_contrasts.csv"))
 


### PR DESCRIPTION
This closes #699 
## Description
`contrasts.csv` can indeed contain completely NA rows, they should not be removed.

Requires merging and installing https://github.com/bigomics/playbase/pull/60