### PR TITLE
Fix #734: Clustering > Samples not working after a dataset change

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -252,6 +252,7 @@ ClusteringBoard <- function(id, pgx) {
       input$hm_samplefilter,
       input$hm_filterXY,
       input$hm_filterMitoRibo,
+      pgx$X,
       ## input$hm_group,
       splitmap$hm_ntop()
     )


### PR DESCRIPTION
This closes #734 

## Description
Needed an extra `bindEvent` on `getFilteredMatrix` so it gets recomputed after a dataset change.