### PR TITLE
Fix #754: Clustering > Samples > Level: Geneset Heatmap hover no row info

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -258,6 +258,7 @@ clustering_plot_splitmap_server <- function(id,
         tooltips <- sapply(aa, function(x) {
           playbase::breakstring2(x, 50, brk = "<br>")
         })
+        names(tooltips) <- rownames(X)
       }
       shiny::showNotification("Rendering iHeatmap...")
 


### PR DESCRIPTION
This closes #754 

## Description
`playbase::pgx.splitHeatmapFromMatrix` compares the tooltip names with the actual rownames of X, therefore the `tooltips` object needs to be properly named.