### PR TITLE
Tab Signature Clustering now responds to comparison input changes

### DIFF
--- a/components/board.intersection/R/intersection_plot_contrast_correlation.R
+++ b/components/board.intersection/R/intersection_plot_contrast_correlation.R
@@ -57,12 +57,17 @@ contrast_correlation_server <- function(id,
       if (is.null(res)) {
         return(NULL)
       }
-      if (NCOL(res$fc) < 2) {
-        return(NULL)
-      }
 
-      fc0 <- res$fc
-      qv0 <- res$qv
+      fc0 <- res$fc[, input_comparisons(), drop = FALSE]
+      qv0 <- res$qv[, input_comparisons(), drop = FALSE]
+
+      # module can only run with at least two comparisons
+      validate(
+        need(
+          dim(fc0)[2] >= 2,
+          "Less than 2 comparisons selected. Please select at least 2 comparison on the settings sidebar."
+        )
+      )
 
       ntop <- 2000
       ntop <- input$ctcorrplot_ntop
@@ -71,10 +76,6 @@ contrast_correlation_server <- function(id,
 
       allfc <- input$ctcorrplot_allfc
       if (!allfc) {
-        comp <- input_comparisons()
-        if (length(comp) < 2) {
-          return(NULL)
-        }
         kk <- match(comp, colnames(fc0))
         fc0 <- fc0[, kk, drop = FALSE]
       }

--- a/components/board.intersection/R/intersection_plot_foldchange_heatmap.R
+++ b/components/board.intersection/R/intersection_plot_foldchange_heatmap.R
@@ -51,6 +51,7 @@ foldchange_heatmap_server <- function(id,
                                       getActiveFoldChangeMatrix,
                                       pgx,
                                       level,
+                                      input_comparisons,
                                       watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     plot_data <- shiny::reactive({
@@ -60,11 +61,21 @@ foldchange_heatmap_server <- function(id,
         F <- getActiveFoldChangeMatrix()$fc
       }
 
-      F <- F[order(-rowMeans(F**2)), ]
-      F <- F[order(-abs(rowMeans(F))), ]
+      F <- F[, input_comparisons(), drop = FALSE]
+      
+      # check that dim(F)[2] >0, in case user has not selected any comparisons
+      validate(
+        need(
+          dim(F)[2] > 0,
+          "No comparisons selected. Please select a comparison on the settings sidebar."
+        )
+      )
+
+      F <- F[order(-rowMeans(F**2)), , drop = FALSE]
+      F <- F[order(-abs(rowMeans(F))), ,drop = FALSE]
 
       F1 <- head(F, 80)
-      F1 <- F1[order(rowMeans(F1)), ]
+      F1 <- F1[order(rowMeans(F1)), , drop = FALSE]
       F1
     })
 

--- a/components/board.intersection/R/intersection_server.R
+++ b/components/board.intersection/R/intersection_server.R
@@ -307,6 +307,7 @@ IntersectionBoard <- function(
       getFoldChangeMatrix = getFoldChangeMatrix,
       getActiveFoldChangeMatrix = getActiveFoldChangeMatrix,
       pgx = pgx,
+      input_comparisons = input_comparisons,
       level = input$level,
       watermark = WATERMARK
     )


### PR DESCRIPTION
- signature clustering not responds to contrast inputs, similar to pairwise comparison tab on the same board.

this fixes #753 


