### PR TITLE
Fix #766: do not allow slash ("/") in dataset name

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -377,6 +377,15 @@ upload_module_computepgx_server <- function(
           )
           return(NULL)
         }
+        if (!isValidFileName(input$upload_name)) {
+          message("[ComputePgxServer:input$compute] WARNING:: Invalid name")
+          shinyalert::shinyalert(
+            title = "Invalid name",
+            text = "Please remove any slashes (/) from the name",
+            type = "error"
+          )
+          return(NULL)
+        }
 
         max.datasets <- as.integer(auth$options$MAX_DATASETS)
         pgxdir <- auth$user_dir

--- a/components/board.upload/R/upload_utils.R
+++ b/components/board.upload/R/upload_utils.R
@@ -192,3 +192,14 @@ sendSuccessMessageToUser <- function(user_email, pgx_name, path_to_creds = "gmai
     credentials = blastula::creds_file(path_to_creds)
   )
 }
+
+isValidFileName <- function(name) {
+  if (name == "") {
+    return(FALSE)
+  }
+  pattern <- "/"
+  if (grepl(pattern, name)) {
+    return(FALSE)
+  }
+  return(TRUE)
+}


### PR DESCRIPTION
This closes #766 

## Description
Pass a regex on the name field, if not passed display error message:

![image](https://github.com/bigomics/omicsplayground/assets/10220503/f858d081-83fd-4e4f-a691-0a4d3a39fb4c)
