### PR TITLE
Add condition to enable/disable run button based on levels of pgx_predicted [stable branch] 

### DIFF
--- a/components/board.biomarker/R/biomarker_server.R
+++ b/components/board.biomarker/R/biomarker_server.R
@@ -99,17 +99,15 @@ BiomarkerBoard <- function(id, pgx) {
     # if the pdx_predicted overlaps with the pdx_samplefilter variable
     shiny::observeEvent(input$pdx_samplefilter, {
       shiny::req(pgx$Y)
-      if (!is.null(input$pdx_samplefilter)) {
-        # Get the variable name for each pdx_samplefilter
-        col_filter <- data.table::tstrsplit(input$pdx_samplefilter, "=", keep = 1)[[1]]
-      } else {
-        col_filter <- 1
-      }
-      if (!input$pdx_predicted %in% col_filter) {
+      
+      levels_filtered <- unique(pgx$Y[selected_samples(),input$pdx_predicted])
+
+      if(length(levels_filtered) > 1) {
         shinyjs::enable("pdx_runbutton")
       } else {
         shinyjs::disable("pdx_runbutton")
       }
+
     })
 
     calcVariableImportance <- shiny::eventReactive(input$pdx_runbutton, {


### PR DESCRIPTION
Previously, the compute button in the Biomarker Board was not correctly disabled and enabled, as it would disable if predicted matched filter samples, regardless of the number of levels in the pgx_predicted variable. This pull request adds a condition to enable the run button only if pgx_predicted has more than one level. If pgx_predicted has only one level, the run button will be disabled.