### PR TITLE
Add user_input_dir parameter to pgx.computePGX function for logging errors in extra modules

### DIFF
--- a/bin/pgxcreate_op.R
+++ b/bin/pgxcreate_op.R
@@ -58,7 +58,8 @@ pgx <- playbase::pgx.computePGX(
   prune.samples = params$prune.samples,  ##
   do.cluster = params$do.cluster,
   pgx.dir = params$pgx.save.folder,
-  libx.dir = params$libx.dir
+  libx.dir = params$libx.dir,
+  user_input_dir = temp_dir
   )
 
 # annotate pgx

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -741,8 +741,11 @@ upload_module_computepgx_server <- function(
           info("[computePGX:on_process_completed] : ERROR: Result file not found")
         }
         ## remove temp dir only if "user_input/raw_" is present in raw_dir
-        if (grepl("raw_", raw_dir)) {
-          unlink(raw_dir, recursive = TRUE)
+        if (grepl("raw_", raw_dir) ) {
+          # check if no ERROR_ files exist in raw_dir
+          if(length(list.files(raw_dir, pattern = "ERROR_")) == 0) {
+            unlink(raw_dir, recursive = TRUE)
+          }
         }
       }
 


### PR DESCRIPTION
requires https://github.com/bigomics/playbase/pull/69

This pull request adds a new parameter, `user_input_dir`, to the `pgx.computePGX` function in order to allow users to specify a custom directory for input files. This parameter provides more flexibility and control over the input data used in the computation of PGX.

Aditionally, we now do not remove temp directory in upload_module_computepgx.R if there are ERROR files inside.

This pull request modifies the `upload_module_computepgx.R` file to prevent the removal of the temporary directory if there are any ERROR files present inside. This change ensures that the temporary directory is only removed when it does not contain any error files, preventing the accidental deletion of pgx with crash logs.


### Example 

These new files will be present in folder USER_INPUT, in the case below connectivity had an error, which previously would crash entire pgx computation.

<img width="582" alt="image" src="https://github.com/bigomics/omicsplayground/assets/28757711/7ccb241c-382e-49ff-b7ef-523c7d8c2ee7">


Fixes https://github.com/bigomics/omicsplayground/issues/741