### PR TITLE
Fix #816: remove "new text" label for no labels display

### DIFF
--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -172,7 +172,10 @@ FeatureMapBoard <- function(id, pgx) {
       }
 
       if (length(hilight) > 0.33 * length(var)) hilight <- hilight2
-
+      if (length(hilight) == 0) {
+        hilight <- NULL
+        hilight2 <- NULL
+      }
       cexlab <- ifelse(length(hilight2) <= 20, 1, 0.85)
       cexlab <- ifelse(length(hilight2) <= 8, 1.15, cexlab)
       opacity <- ifelse(length(hilight2) > 0, 0.4, 0.90)


### PR DESCRIPTION
This closes #816 

## Description
When `nr labels:` is set to 0, pass `NULL` to the highlight arguments of the plot function. This ensures that the "new text" label is not displayed.

![image](https://github.com/bigomics/omicsplayground/assets/10220503/a24bdfae-3274-45f7-8edb-9ddae254bfdc)
