### PR TITLE
Fix input_genelistUP bug in signature_server.R

### DIFF
--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -93,6 +93,7 @@ SignatureBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$g
 
     input_genelistUP <- shiny::reactive({
       shiny::req(input$genelistUP)
+
       gg <- input$genelistUP
       gg <- strsplit(as.character(gg), split = "[, \n\t]")[[1]]
       if (length(gg) == 1 && gg[1] != "") gg <- c(gg, gg) ## hack to allow single gene....
@@ -106,7 +107,6 @@ SignatureBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$g
 
       ## Get current selection of markers/genes
       type <- input$type
-
       level <- "gene"
       features <- toupper(pgx$genes$gene_name)
       xfeatures <- toupper(pgx$genes[rownames(pgx$X), "gene_name"])
@@ -137,7 +137,7 @@ SignatureBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$g
         names(fx) <- rownames(pgx$gx.meta$meta[[contr]])
         probes <- rownames(pgx$gx.meta$meta[[contr]])
 
-        match_input_genes <- all(input_genelistUP() %in% probes)
+        match_input_genes <- !all(input_genelistUP() %in% probes)
 
         if (match_input_genes == FALSE) {
           # use human ortholog in case no matched found in proves


### PR DESCRIPTION
This pull request fixes a bug in the `signature_server.R` file where the `input_genelistUP` function was not working correctly. The bug caused an incorrect match of input genes with probes, resulting in unexpected behavior. The fix ensures that the correct matching is performed.