### PR TITLE
Refactor gene name assignment in board.pathway (wikipathways and reactome)

### DIFF
--- a/components/board.pathway/R/pathway_plot_reactome_graph.R
+++ b/components/board.pathway/R/pathway_plot_reactome_graph.R
@@ -88,10 +88,7 @@ functional_plot_reactome_graph_server <- function(id,
         fc <- pgx$gx.meta$meta[[comparison]]$meta.fx
         pp <- rownames(pgx$gx.meta$meta[[comparison]])
 
-        if ("human_ortholog" %in% colnames(pgx$genes) && sum(pp %in% pgx$genes$symbol) > 100) {
-          names(fc) <- pgx$genes[pp, "human_ortholog"]
-        } else if ("human_ortholog" %in% colnames(pgx$genes) && sum(pp %in% pgx$genes$feature) > 100) {
-          pp <- pgx$genes[pp, "feature"]
+        if (pgx$organism != "Human") {
           names(fc) <- pgx$genes[pp, "human_ortholog"]
         } else {
           names(fc) <- pgx$genes[pp, "symbol"]

--- a/components/board.pathway/R/pathway_plot_wikipathway_graph.R
+++ b/components/board.pathway/R/pathway_plot_wikipathway_graph.R
@@ -93,10 +93,8 @@ functional_plot_wikipathway_graph_server <- function(id,
         pp <- rownames(pgx$gx.meta$meta[[comparison]])
 
         # Rename to human orthologs for non-human species and sort
-        if ("human_ortholog" %in% colnames(pgx$genes) && sum(pp %in% pgx$genes$symbol) > 100) {
-          names(fc) <- pgx$genes[pp, "human_ortholog"]
-        } else if ("human_ortholog" %in% colnames(pgx$genes) && sum(pp %in% pgx$genes$feature) > 100) {
-          pp <- pgx$genes[pp, "feature"]
+        
+        if (pgx$organism != "Human") {
           names(fc) <- pgx$genes[pp, "human_ortholog"]
         } else {
           names(fc) <- pgx$genes[pp, "symbol"]
@@ -110,7 +108,6 @@ functional_plot_wikipathway_graph_server <- function(id,
           return(NULL.IMG)
         }
         sel.row <- as.integer(sel.row)
-        pathway.id <- "WP179"
         pathway.name <- pw.genes <- "x"
         if (is.null(sel.row) || length(sel.row) == 0) {
           return(NULL.IMG)


### PR DESCRIPTION
This pull request refactors the gene name assignment in the pathway_plot_reactome_graph.R and pathway_plot_wikipathway_graph.R files to correctly handle human and non-human species. The changes ensure that the gene names are assigned based on the organism specified in the pgx object, improving the accuracy of the plots.