### PR TITLE
stable: Set default value of "show others" input to FALSE

### DIFF
--- a/components/board.expression/R/expression_plot_barplot.R
+++ b/components/board.expression/R/expression_plot_barplot.R
@@ -32,7 +32,7 @@ expression_plot_barplot_ui <- function(
       "Show logarithmic (log2CPM) expression values.",
       placement = "right", options = list(container = "body")
     ),
-    withTooltip(shiny::checkboxInput(ns("barplot_showothers"), "show others", TRUE),
+    withTooltip(shiny::checkboxInput(ns("barplot_showothers"), "show others", FALSE),
       "Show the 'others' class (if any)",
       placement = "right", options = list(container = "body")
     )

--- a/components/board.expression/R/expression_plot_topgenes.R
+++ b/components/board.expression/R/expression_plot_topgenes.R
@@ -32,7 +32,7 @@ expression_plot_topgenes_ui <- function(
       "Group samples by phenotype",
       placement = "right", options = list(container = "body")
     ),
-    withTooltip(shiny::checkboxInput(ns("gx_showothers"), "show others", TRUE),
+    withTooltip(shiny::checkboxInput(ns("gx_showothers"), "show others", FALSE),
       "Show the 'others' class (if any)",
       placement = "right", options = list(container = "body")
     )


### PR DESCRIPTION
This pull request updates the default value of the "show others" input to FALSE in the `expression_plot_barplot_ui` and `expression_plot_topgenes_ui` functions. This change ensures that the "show others" class is not displayed by default, which makes the plot simpler to read.