### PR TITLE
fix: FC-FC scatter for multiple contrasts

### DIFF
--- a/components/board.compare/R/compare_plot_cum_fc1.R
+++ b/components/board.compare/R/compare_plot_cum_fc1.R
@@ -75,7 +75,7 @@ compare_plot_cum_fc1_server <- function(id,
           x = "x",
           y = ycols,
           fillcolor = fillcolor,
-          yaxistitle = "Foldchange  (log2FC)",
+          yaxistitle = "log2FC",
           xaxistitle = "",
           title = "",
           grouped = FALSE
@@ -90,7 +90,7 @@ compare_plot_cum_fc1_server <- function(id,
       func = cumfcplot.RENDER,
       csvFunc = cum_fc,
       res = c(80, 98), ## resolution of plots
-      pdf.width = 6, pdf.height = 6,
+      pdf.width = 10, pdf.height = 6,
       add.watermark = watermark
     )
   }) ## end of moduleServer

--- a/components/board.compare/R/compare_plot_cum_fc1.R
+++ b/components/board.compare/R/compare_plot_cum_fc1.R
@@ -20,7 +20,7 @@ compare_plot_cum_fc1_ui <- function(id,
   info_text <- "Barplot showing the cumulative fold changes on dataset 1"
 
   PlotModuleUI(ns("plot"),
-    title = "Cumulative foldchange",
+    title = "Foldchange (Dataset 1)",
     plotlib = "plotly",
     label = label,
     info.text = info_text,
@@ -75,9 +75,9 @@ compare_plot_cum_fc1_server <- function(id,
           x = "x",
           y = ycols,
           fillcolor = fillcolor,
-          yaxistitle = "Cumulative foldchange",
-          xaxistitle = "Genes",
-          title = "Dataset 1",
+          yaxistitle = "Foldchange  (log2FC)",
+          xaxistitle = "",
+          title = "",
           grouped = FALSE
         )
       )

--- a/components/board.compare/R/compare_plot_cum_fc2.R
+++ b/components/board.compare/R/compare_plot_cum_fc2.R
@@ -17,10 +17,10 @@ compare_plot_cum_fc2_ui <- function(id,
                                     width,
                                     label) {
   ns <- shiny::NS(id)
-  info_text <- "Barplot showing the cumulative fold changes on dataset 2"
+  info_text <- "Barplot showing the fold changes on dataset 2"
 
   PlotModuleUI(ns("plot"),
-    title = "Cumulative foldchange",
+    title = "Foldchange (Dataset 2)",
     plotlib = "plotly",
     label = label,
     info.text = info_text,
@@ -72,9 +72,9 @@ compare_plot_cum_fc2_server <- function(id,
           x = "x",
           y = ycols,
           fillcolor = fillcolor,
-          yaxistitle = "Cumulative foldchange",
-          xaxistitle = "Genes",
-          title = "Dataset 2",
+          yaxistitle = "Foldchange  (log2FC)",
+          xaxistitle = "",
+          title = "",
           grouped = FALSE
         )
       )

--- a/components/board.compare/R/compare_plot_cum_fc2.R
+++ b/components/board.compare/R/compare_plot_cum_fc2.R
@@ -72,7 +72,7 @@ compare_plot_cum_fc2_server <- function(id,
           x = "x",
           y = ycols,
           fillcolor = fillcolor,
-          yaxistitle = "Foldchange  (log2FC)",
+          yaxistitle = "log2FC",
           xaxistitle = "",
           title = "",
           grouped = FALSE
@@ -87,7 +87,7 @@ compare_plot_cum_fc2_server <- function(id,
       func = cumfcplot.RENDER,
       csvFunc = cum_fc,
       res = c(80, 98), ## resolution of plots
-      pdf.width = 6, pdf.height = 6,
+      pdf.width = 10, pdf.height = 6,
       add.watermark = watermark
     )
   }) ## end of moduleServer


### PR DESCRIPTION
Problem: For multiple contrasts in dataset1 and/or dataset2, the scatterplots are all the same and the xlab and ylab are wrong.

Fixed: order of plots not correct for subplots layout. Use of tilde (~) not correct when using arrays for x and y. 

Before:
![image](https://github.com/bigomics/omicsplayground/assets/19613146/be0f20e8-e185-442d-8e20-4e15d112c4ef)

After:
![image](https://github.com/bigomics/omicsplayground/assets/19613146/3114b08d-bd71-4ee8-865c-0588a1c07adc)
