### PR TITLE
Add option to select contrasts in activation map/wikipathways

### DIFF
--- a/components/board.pathway/R/pathway_plot_go_actmap.R
+++ b/components/board.pathway/R/pathway_plot_go_actmap.R
@@ -38,6 +38,12 @@ functional_plot_go_actmap_ui <- function(
         FALSE
       ),
       "Click to rotate the activation matrix."
+    ),
+    shiny::selectInput(
+      ns("selected_contrasts"),
+      "Select comparisons:",
+      choices = NULL,
+      multiple = TRUE
     )
   )
 
@@ -66,13 +72,34 @@ functional_plot_go_actmap_server <- function(id,
                                              watermark = FALSE) {
   moduleServer(
     id, function(input, output, session) {
+      shiny::observe({
+        shiny::req(pgx$X)
+        ct <- colnames(pgx$model.parameters$contr.matrix)
+        ct <- sort(ct)
+        selected_ct <- head(ct, 7)
+        shiny::updateSelectInput(
+          session,
+          "selected_contrasts",
+          choices = ct,
+          selected = selected_ct)
+      })
+      
+      
       plotGOactmap <- function(score, go, normalize, rotate, maxterm, maxfc,
                                tl.cex = 0.85, row.nchar = 60) {
         rownames(score) <- igraph::V(go)[rownames(score)]$Term
-
+        
         ## avoid errors!!!
         score[is.na(score) | is.infinite(score)] <- 0
         score[is.na(score)] <- 0
+
+        shiny::validate(
+          shiny::need(
+            !is.null(input$selected_contrasts),
+            "Please select at least one comparison."
+          )
+        )
+        score <- score[,input$selected_contrasts, drop = FALSE]
 
         ## reduce score matrix
         score <- score[head(order(-rowSums(score**2, na.rm = TRUE)), maxterm), , drop = FALSE] ## max number terms

--- a/components/board.pathway/R/pathway_plot_reactome_actmap.R
+++ b/components/board.pathway/R/pathway_plot_reactome_actmap.R
@@ -37,6 +37,12 @@ functional_plot_reactome_actmap_ui <- function(
         FALSE
       ),
       "Click to rotate the activation matrix."
+    ),
+    shiny::selectInput(
+      ns("selected_contrasts"),
+      "Select comparisons:",
+      choices = NULL,
+      multiple = TRUE
     )
   )
 
@@ -62,15 +68,36 @@ functional_plot_reactome_actmap_ui <- function(
 #' @export
 functional_plot_reactome_actmap_server <- function(id,
                                                    r_meta,
+                                                   pgx,
                                                    getReactomeTable,
                                                    plotActivationMatrix,
                                                    watermark = FALSE) {
   moduleServer(
     id, function(input, output, session) {
+
+      shiny::observe({
+        shiny::req(pgx$X)
+        ct <- colnames(pgx$model.parameters$contr.matrix)
+        ct <- sort(ct)
+        selected_ct <- head(ct, 7)
+        shiny::updateSelectInput(
+          session,
+          "selected_contrasts",
+          choices = ct,
+          selected = selected_ct)
+      })
       plot_data <- shiny::reactive({
         df <- getReactomeTable()
         meta <- r_meta()
         shiny::req(df, meta)
+
+        shiny::validate(
+          shiny::need(
+            !is.null(input$selected_contrasts),
+            message = "Please select at least one comparison."
+          )
+        )
+        meta <- meta[input$selected_contrasts]
         res <- list(
           df = df,
           meta = meta

--- a/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
+++ b/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
@@ -78,12 +78,12 @@ functional_plot_wikipathway_actmap_server <- function(id,
         shiny::req(pgx$X)
         ct <- colnames(pgx$model.parameters$contr.matrix)
         ct <- sort(ct)
-        ct <- c("<all>", ct)
+        selected_ct <- head(ct, 7)
         shiny::updateSelectInput(
           session,
           "selected_contrasts",
           choices = ct,
-          selected = ct[1])
+          selected = selected_ct)
       })
       plot_data <- shiny::reactive({
         df <- getWikiPathwayTable()
@@ -96,9 +96,9 @@ functional_plot_wikipathway_actmap_server <- function(id,
             "Please select a comparison in plot options."
           )
         )
-        if(!"<all>" %in% input$selected_contrasts) {
-          meta <- meta[input$selected_contrasts]
-        }
+        
+        meta <- meta[input$selected_contrasts]
+        
         res <- list(
           df = df,
           meta = meta

--- a/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
+++ b/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
@@ -37,6 +37,12 @@ functional_plot_wikipathway_actmap_ui <- function(
         FALSE
       ),
       "Click to rotate the activation matrix."
+    ),
+    shiny::selectInput(
+      ns("selected_contrasts"),
+      "Select comparisons:",
+      choices = NULL,
+      multiple = TRUE
     )
   )
 
@@ -68,10 +74,31 @@ functional_plot_wikipathway_actmap_server <- function(id,
                                                       watermark = FALSE) {
   moduleServer(
     id, function(input, output, session) {
+      shiny::observe({
+        shiny::req(pgx$X)
+        ct <- colnames(pgx$model.parameters$contr.matrix)
+        ct <- sort(ct)
+        ct <- c("<all>", ct)
+        shiny::updateSelectInput(
+          session,
+          "selected_contrasts",
+          choices = ct,
+          selected = ct[1])
+      })
       plot_data <- shiny::reactive({
         df <- getWikiPathwayTable()
         meta <- pgx$gset.meta$meta
         shiny::req(df, pgx$X, meta)
+        
+        shiny::validate(
+          need(
+            !is.null(input$selected_contrasts),
+            "Please select a comparison in plot options."
+          )
+        )
+        if(!"<all>" %in% input$selected_contrasts) {
+          meta <- meta[input$selected_contrasts]
+        }
         res <- list(
           df = df,
           meta = meta

--- a/components/board.pathway/R/pathway_server.R
+++ b/components/board.pathway/R/pathway_server.R
@@ -214,6 +214,7 @@ PathwayBoard <- function(id, pgx, selected_gsetmethods = reactive(colnames(pgx$g
       "reactome_actmap",
       reactive(pgx$gset.meta$meta),
       getReactomeTable,
+      pgx = pgx,
       plotActivationMatrix,
       WATERMARK
     )


### PR DESCRIPTION
This pull request adds a new feature that allows users to select specific contrasts in the activation map for wikipathways, reactome and GO. Users can now choose the comparisons they want to visualize, providing more flexibility and customization options.

Another option is to select <all>, but that has several problems:

- Some datasets have too many options, and <all> contrasts at once will clutter the activation matrix;
-  PR implementation uses the same logic as in board.clustering, which is nice for the user to have the same UI for contrasts across entire platform;
- PR implementation indirectly tells the user there is a settings bar for contrasts, as some contrasts are not shown in plot. For large number of contrasts, option <all> might induce some users to miss the plot settings;

https://github.com/bigomics/omicsplayground/assets/28757711/68a71972-c12f-4bfd-939b-ef99a37dbb04

