### PR TITLE
Fix #854: Correct editor source path

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -435,7 +435,7 @@ PlotModuleServer <- function(id,
         cd <- session$clientData
         sprintf(
           "%s/?plotURL=%s//%s:%s%s%s",
-          "editor/index.html",
+          "custom/editor/index.html",
           cd$url_protocol,
           cd$url_hostname,
           cd$url_port,


### PR DESCRIPTION
This closes #854 

## Description
The editor path was incorrect. This problem was introduced with cookies persistent login.