### PR TITLE
hotfix: reset download counter

### DIFF
--- a/components/modules/AuthenticationModule.R
+++ b/components/modules/AuthenticationModule.R
@@ -903,6 +903,8 @@ LoginCodeAuthenticationModule <- function(id,
       updateTextInput(session, "login_email", value = "")
       updateTextInput(session, "login_password", value = "")
 
+      PLOT_DOWNLOAD_LOGGER <<- reactiveValues(log = list(), str = "")
+
       shiny::showModal(login_modal)
     }
 


### PR DESCRIPTION
Avoids double counting plot downloads from sessions that do not fully disconnected.