### PR TITLE
Fix #884: BA+volcano, download complete data on csv

### DIFF
--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -212,13 +212,20 @@ expression_plot_maplot_server <- function(id,
       fig
     }
 
+    plot_data_csv <- function(){
+      dt <- plot_data()
+      df <- data.frame(dt$x, dt$y)
+      colnames(df) <- c("x", "y")
+      return(df)
+    }
+
     PlotModuleServer(
       "pltmod",
       plotlib = "plotly",
       func = plotly.RENDER,
       func2 = modal_plotly.RENDER,
       remove_margins = FALSE,
-      csvFunc = plot_data, ##  *** downloadable data as CSV
+      csvFunc = plot_data_csv, ##  *** downloadable data as CSV
       res = c(80, 95), ## resolution of plots
       pdf.width = 6, pdf.height = 6,
       add.watermark = watermark

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -191,13 +191,21 @@ expression_plot_volcano_server <- function(id,
       fig
     }
 
+    plot_data_csv <- function(){
+      dt <- plot_data()
+      df <- data.frame(dt$x, dt$y)
+      colnames(df) <- c("x", "y")
+      rownames(df) <- dt$fc.genes
+      return(df)
+    }
+
     PlotModuleServer(
       "pltmod",
       plotlib = "plotly",
       func = plotly.RENDER,
       func2 = modal_plotly.RENDER,
       remove_margins = FALSE,
-      csvFunc = plot_data, ##  *** downloadable data as CSV
+      csvFunc = plot_data_csv, ##  *** downloadable data as CSV
       res = c(80, 95), ## resolution of plots
       pdf.width = 6, pdf.height = 6,
       add.watermark = watermark

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -788,7 +788,7 @@ PlotModuleServer <- function(id,
             shiny::withProgress(
               {
                 data <- csvFunc()
-                if (is.list(data)) data <- data[[1]]
+                if (is.list(data) && !is.data.frame(data)) data <- data[[1]]
                 write.csv(data, file = file)
                 ## Record downloaded plot
                 record_plot_download(ns("") %>% substr(1, nchar(.) - 1))


### PR DESCRIPTION
This closes #884 

## Description
BA plot + volcano plot where missing x/y information on csv download.

Fixed + updated plotModule: if csv function returns a list the first element is downloaded; however, `is.list()` applied to a `data.frame` returns `TRUE`, so we handle this case properly now. (https://github.com/bigomics/omicsplayground/compare/fix-%23884?expand=1#diff-a42f6c55107e84307d40e58208e01c6a2b4307badc38aa0d6b5df3751e1f57d5R791)