### PR TITLE
Fix #888: select correct q/fc columns + filter volcano plots by gene family

### DIFF
--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -103,6 +103,7 @@ expression_plot_volcanoAll_server <- function(id,
     plotly_plots <- function(cex = 2, yrange = 0.5, n_rows = 2, margin_l = 50, margin_b = 50) {
       pd <- plot_data()
       shiny::req(pd)
+      sel.genes <- pd[["sel.genes"]]
 
       # Input vars
       fdr <- pd[["fdr"]]
@@ -110,8 +111,8 @@ expression_plot_volcanoAll_server <- function(id,
       ## meta tables
       fc_cols <- grep("fc.*", colnames(pd[["FQ"]]))
       q_cols <- grep("q.*", colnames(pd[["FQ"]]))
-      fc <- pd[["FQ"]][, fc_cols, drop = FALSE]
-      qv <- pd[["FQ"]][, q_cols, drop = FALSE]
+      fc <- pd[["FQ"]][which(rownames(pd[["FQ"]]) %in% sel.genes), fc_cols, drop = FALSE]
+      qv <- pd[["FQ"]][which(rownames(pd[["FQ"]]) %in% sel.genes), q_cols, drop = FALSE]
       colnames(fc) <- gsub("fc.", "", colnames(fc))
       colnames(qv) <- gsub("q.", "", colnames(qv))
       rm(pd)

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -97,10 +97,8 @@ expression_plot_volcanoMethods_server <- function(id,
       ## meta tables
       comp <- pd[["comp"]]
       mx <- pd[["pgx"]]$gx.meta$meta[[comp]]
-      fc_cols <- grep("fc.*", colnames(mx))
-      q_cols <- grep("q.*", colnames(mx))
-      fc <- mx[, fc_cols, drop = FALSE]
-      qv <- mx[, q_cols, drop = FALSE]
+      fc <- mx[, "fc", drop = FALSE]
+      qv <- mx[, "q", drop = FALSE]
       rm(mx, pd)
       # Call volcano plots
       all_plts <- playbase::plotlyVolcano_multi(

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -97,8 +97,8 @@ expression_plot_volcanoMethods_server <- function(id,
       ## meta tables
       comp <- pd[["comp"]]
       mx <- pd[["pgx"]]$gx.meta$meta[[comp]]
-      fc <- mx[, "fc", drop = FALSE]
-      qv <- mx[, "q", drop = FALSE]
+      fc <- mx[which(rownames(mx) %in% sel.genes), "fc", drop = FALSE]
+      qv <- mx[which(rownames(mx) %in% sel.genes), "q", drop = FALSE]
       rm(mx, pd)
       # Call volcano plots
       all_plts <- playbase::plotlyVolcano_multi(


### PR DESCRIPTION
This closes #888 

## Description
Incorrect Q columns were grabbed for the Volcano by method plot.

+ Filter volcano plots by family of genes.

