### PR TITLE
Fix #910: use custom genelist when selected (compare module)

### DIFF
--- a/components/board.compare/R/compare_server.R
+++ b/components/board.compare/R/compare_server.R
@@ -75,6 +75,9 @@ CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "min
       higenes <- rownames(df)[order(df$score, decreasing = TRUE)]
       higenes <- head(higenes, ntop)
       higenes <- paste(higenes, collapse = " ")
+      if(input$hilighttype == "custom") {
+        higenes <- input$genelist
+      }
       hilightgenes({
         genes <- strsplit(higenes, split = "[\t, \n]")[[1]]
         gsub("[ ]", "", genes)


### PR DESCRIPTION
This closes #910 

## Description
The custom list was always used for the plots. However, it was always the top genes (https://github.com/bigomics/omicsplayground/compare/fix-%23910?expand=1#diff-e43f9a0801767a47eb389d49a0ae9257b86156bbdd4b0ad2138e0fd746e2156aR85).

Now, when the user selects `custom` gene list, it is used to select the highlited genes (https://github.com/bigomics/omicsplayground/compare/fix-%23910?expand=1#diff-e43f9a0801767a47eb389d49a0ae9257b86156bbdd4b0ad2138e0fd746e2156aR79)

![image](https://github.com/bigomics/omicsplayground/assets/10220503/9c956a13-e6fd-4604-a6c2-7988b9ee3dce)
