### PR TITLE
Install sf package on requirements and in docker opg build

### DIFF
--- a/dev/requirements.R
+++ b/dev/requirements.R
@@ -119,7 +119,7 @@ pkg.extra <- c(
   'svgPanZoom','rhdf5','monocle','mygene',
   'iheatmapr','RcppZiggurat','Rfast','BH','topGO', 'survcomp','plsRcox',
   'blastula','shinytest2','sodium','cookies',"shinyvalidate", "sparsesvd",
-  "recount"
+  "recount", "sf"
 )
 
 pkg.used <- c(pkg.used, pkg.extra)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,11 @@ WORKDIR /
 RUN R -e "remotes::install_github('bigomics/playbase',dependencies=FALSE)"
 RUN R -e "remotes::install_github('bigomics/bigdash',dependencies=FALSE)"
 
+# NEW INSTALLS THAT ARE BOTH IN OPG-BASE (can be removed when base v4 is built)
+
+# sf also added in requirements (check in final build that its installed before removing)
+RUN R -e "install.packages('sf')"
+
 #------------------------------------------------------------
 # Download fresh code from GitHub (not an R package)
 #------------------------------------------------------------


### PR DESCRIPTION
## Description

This pull request adds the installation of the `sf` package to the requirements file and includes it in the Docker OPG build process. This ensures that the 'sf' package is installed and available for use in the project.


## Problem

- This fixes the issue of venn diagram not showing up:
![image](https://github.com/bigomics/omicsplayground/assets/28757711/0361b552-91a9-44c0-bef1-5786f0053861)

- I do not understand why `sf` was not installed in opg-base v3, as nothing was changed in relation to this package: [PR of v3 docker opg-base](https://github.com/bigomics/omicsplayground/pull/899/files). If you have an idea, please let us know!

## Solution

- sf will be installed in docker opg build and in requirements, when we  build new base (v4), we can remove from docker opg build. 

## Testing

- I will test in a new upload deployment today, as the upload uses v3 base to speed things up.

- This would be picked up by screnshot test, but this board is not included in the snaps.. we should expand and routinely do the tests!


