### PR TITLE
Add real-time error feedback to upload wizard

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -547,6 +547,7 @@ UploadBoard <- function(id,
     observeEvent(
       input$upload_wizard_locked, {
         
+        browser()
         # summaryze all error logs
         summary_checks <- list(
           checklist$samples.csv$checks,
@@ -557,39 +558,36 @@ UploadBoard <- function(id,
           )
 
         
-        # chekc which checks have error results
-        find_content <- !sapply(summary_checks, function(x) is.null(x) || length(x) ==0 )
-
-        summary_checks <- summary_checks[find_content]
-
-
-        # get the names of each list within summary checks
-        get_all_codes <- sapply(summary_checks, function(x) names(x))
-
         
-        # check if any any code is error code
-        error_list <- playbase::PGX_CHECKS
-        error_list <- error_list[error_list$warning_type=="error", ]
+        if(length(summary_checks >0)) {
+          # chekc which checks have error results
+          find_content <- !sapply(summary_checks, function(x) is.null(x) || length(x) ==0 )
 
-        if(get_all_codes %in% error_list$error){
+          summary_checks <- summary_checks[find_content]
+
+
+          # get the names of each list within summary checks
+          get_all_codes <- sapply(summary_checks, function(x) names(x))
+
           
-          # which warning is error
-          which_error <- which(get_all_codes %in% error_list$error)
+          # check if any any code is error code
+          error_list <- playbase::PGX_CHECKS
+          error_list <- error_list[error_list$warning_type=="error", ]
 
-          result_alert <- check_to_html(
-                unlist(summary_checks[which_error],  recursive = FALSE),
-                pass_msg = "All counts checks passed",
-                null_msg = "Fix any errors with your input first."
-          )
+          if(get_all_codes %in% error_list$error){
+            
+            # which warning is error
+            which_error <- which(get_all_codes %in% error_list$error)
 
-          # return shiny alert with result_alert
-          shinyalert::shinyalert(
-            title = "Please review your input:",
-            text = result_alert,
-            type = "error",
-            html = TRUE
-          )
-        } else {
+            result_alert <- check_to_html(
+                  unlist(summary_checks[which_error],  recursive = FALSE),
+                  pass_msg = "All counts checks passed",
+                  null_msg = "Fix any errors with your input first."
+            )
+          } 
+        }
+        
+        if (length(summary_checks) == 0) {
           shinyalert::shinyalert(
             title = "Upload wizard locked",
             text = "Please complete the current step before proceeding.",

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -546,8 +546,7 @@ UploadBoard <- function(id,
     # warn user when locked button is clicked (UX)
     observeEvent(
       input$upload_wizard_locked, {
-        browser()
-
+        
         # summaryze all error logs
         summary_checks <- list(
           checklist$samples.csv$checks,
@@ -573,20 +572,30 @@ UploadBoard <- function(id,
         error_list <- error_list[error_list$warning_type=="error", ]
 
         if(get_all_codes %in% error_list$error){
-          # placeholder for warnings
+          
+          # which warning is error
+          which_error <- which(get_all_codes %in% error_list$error)
 
+          result_alert <- check_to_html(
+                unlist(summary_checks[which_error],  recursive = FALSE),
+                pass_msg = "All counts checks passed",
+                null_msg = "Fix any errors with your input first."
+          )
+
+          # return shiny alert with result_alert
+          shinyalert::shinyalert(
+            title = "Please review your input:",
+            text = result_alert,
+            type = "error",
+            html = TRUE
+          )
+        } else {
+          shinyalert::shinyalert(
+            title = "Upload wizard locked",
+            text = "Please complete the current step before proceeding.",
+            type = "warning"
+          )
         }
-
-        
-
-
-
-        checked_contrasts()
-        shinyalert::shinyalert(
-          title = "Upload wizard locked",
-          text = "Please complete the current step before proceeding.",
-          type = "warning"
-        )
       })
 
     # wizard lock/unlock logic

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -546,8 +546,7 @@ UploadBoard <- function(id,
     # warn user when locked button is clicked (UX)
     observeEvent(
       input$upload_wizard_locked, {
-        
-        browser()
+
         # summaryze all error logs
         summary_checks <- list(
           checklist$samples.csv$checks,
@@ -557,11 +556,16 @@ UploadBoard <- function(id,
           checklist$samples_contrasts$checks
           )
 
-        
-        
-        if(length(summary_checks >0)) {
+        browser()
+
+        summary_check_content <- length(unlist(summary_checks, recursive = FALSE))
+
+        if(summary_check_content > 0 ) {
           # chekc which checks have error results
-          find_content <- !sapply(summary_checks, function(x) is.null(x) || length(x) ==0 )
+          find_content <- !sapply(
+            summary_checks,
+            function(x) is.null(x) || length(x) == 0
+            )
 
           summary_checks <- summary_checks[find_content]
 
@@ -587,7 +591,7 @@ UploadBoard <- function(id,
           } 
         }
         
-        if (length(summary_checks) == 0) {
+        if (summary_check_content == 0) {
           shinyalert::shinyalert(
             title = "Upload wizard locked",
             text = "Please complete the current step before proceeding.",

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -554,9 +554,7 @@ UploadBoard <- function(id,
           checklist$contrasts.csv$checks,
           checklist$samples_counts$checks,
           checklist$samples_contrasts$checks
-          )
-
-        browser()
+        )
 
         summary_check_content <- length(unlist(summary_checks, recursive = FALSE))
 
@@ -588,9 +586,17 @@ UploadBoard <- function(id,
                   pass_msg = "All counts checks passed",
                   null_msg = "Fix any errors with your input first."
             )
-          } 
+
+            # return shiny alert with result_alert
+            shinyalert::shinyalert(
+              title = "Please review your input:",
+              text = result_alert,
+              type = "error",
+              html = TRUE
+            )
+          }
         }
-        
+
         if (summary_check_content == 0) {
           shinyalert::shinyalert(
             title = "Upload wizard locked",

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -546,6 +546,42 @@ UploadBoard <- function(id,
     # warn user when locked button is clicked (UX)
     observeEvent(
       input$upload_wizard_locked, {
+        browser()
+
+        # summaryze all error logs
+        summary_checks <- list(
+          checklist$samples.csv$checks,
+          checklist$counts.csv$checks,
+          checklist$contrasts.csv$checks,
+          checklist$samples_counts$checks,
+          checklist$samples_contrasts$checks
+          )
+
+        
+        # chekc which checks have error results
+        find_content <- !sapply(summary_checks, function(x) is.null(x) || length(x) ==0 )
+
+        summary_checks <- summary_checks[find_content]
+
+
+        # get the names of each list within summary checks
+        get_all_codes <- sapply(summary_checks, function(x) names(x))
+
+        
+        # check if any any code is error code
+        error_list <- playbase::PGX_CHECKS
+        error_list <- error_list[error_list$warning_type=="error", ]
+
+        if(get_all_codes %in% error_list$error){
+          # placeholder for warnings
+
+        }
+
+        
+
+
+
+        checked_contrasts()
         shinyalert::shinyalert(
           title = "Upload wizard locked",
           text = "Please complete the current step before proceeding.",


### PR DESCRIPTION
This pull request adds the feature of providing real-time error feedback to the upload wizard. It centralizes all warnings to give real-time feedback to the user, adds a shinyalert with error message only, and includes minor fixes and refactoring for when there are no errors in the summary. 

@ivokwee the shinyalert can become anything (messages embed in a different part of wizard), as its centralized its easy for future development