### PR TITLE
Fix #933: show info text when no geneset is selected

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -42,6 +42,7 @@ enrichment_plot_volcano_server <- function(id,
       par(mar = subplot.MAR)
 
       shiny::req(pgx$X)
+      shiny::validate(shiny::need(!is.null(gset_selected()), "Please select a geneset."))
 
       comp <- 1
       gs <- 1
@@ -58,11 +59,6 @@ enrichment_plot_volcano_server <- function(id,
       limma <- cbind(gx.annot, limma1)
 
       gs <- gset_selected()
-      if (is.null(gs) || length(gs) == 0) {
-        frame()
-        text(0.5, 0.5, "Please select a geneset", col = "grey50")
-        return()
-      }
       gs <- gs[1]
 
       gset <- playdata::getGSETS(gs)[[1]]


### PR DESCRIPTION
This closes #933 

## Description
There was still the old code that worked for `plotlib = base` (https://github.com/bigomics/omicsplayground/commit/b3d173fa0fa6d4cb2ebdf87a58330d3c7c77dc63#diff-a27198345275f3afc0a16b0b184db42e6a5c7f3d356a53eaf0aadf91bfd8da1bL61-L65). With plotly we have to use `shiny::validate`.