### PR TITLE
Fix #938: Different geneset names on playdata / pgx file

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -35,6 +35,7 @@ enrichment_plot_volcano_server <- function(id,
                                            gs_fdr,
                                            gs_lfc,
                                            subplot.MAR,
+                                           geneDetails,
                                            watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     volcano.RENDER <- shiny::reactive({
@@ -63,9 +64,7 @@ enrichment_plot_volcano_server <- function(id,
         text(0.5, 0.5, "Please select a geneset", col = "grey50")
         return()
       }
-      gs <- gs[1]
-
-      gset <- playdata::getGSETS(gs)[[1]]
+      gset <- geneDetails()$feature
       jj <- match(toupper(gset), toupper(limma$gene_name))
       sel.genes <- setdiff(limma$gene_name[jj], c(NA, "", " "))
 

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -468,6 +468,7 @@ EnrichmentBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$
       gs_fdr = shiny::reactive(input$gs_fdr),
       gs_lfc = shiny::reactive(input$gs_lfc),
       subplot.MAR = subplot.MAR,
+      geneDetails = geneDetails,
       watermark = WATERMARK
     )
 


### PR DESCRIPTION
This closes #938 

## Description
Use the same info that the "Genes in gene set" table uses, which comes from the pgx object.

@mauromiguelm Not sure if using the `feature` column is correct with multi-species.