### PR TITLE
Fix 945: robust file extension detection

### DIFF
--- a/components/board.upload/R/upload_module_preview_contrasts.R
+++ b/components/board.upload/R/upload_module_preview_contrasts.R
@@ -254,7 +254,8 @@ upload_table_preview_contrasts_server <- function(
     # pass counts to uploaded when uploaded
     observeEvent(input$contrasts_csv, {
       # check if contrasts is csv (necessary due to drag and drop of any file)
-      if (!grepl("csv", input$contrasts_csv$name, ignore.case = TRUE)) {
+      ext <- tools::file_ext(input$contrasts_csv$name)[1]
+      if (ext != "csv") {
         shinyalert::shinyalert(
           title = "File format not supported.",
           text = "Please make sure the file is a CSV file.",

--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -157,8 +157,8 @@ upload_table_preview_counts_server <- function(
     # pass counts to uploaded when uploaded
     observeEvent(input$counts_csv, {
       # check if counts is csv (necessary due to drag and drop of any file)
-
-      if (!grepl("csv", input$counts_csv$name, ignore.case = TRUE)) {
+      ext <- tools::file_ext(input$counts_csv$name)[1]
+      if (ext != "csv") {
         shinyalert::shinyalert(
           title = "File format not supported.",
           text = "Please make sure the file is a CSV file.",

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -155,7 +155,8 @@ upload_table_preview_samples_server <- function(
     # pass counts to uploaded when uploaded
     observeEvent(input$samples_csv, {
       # check if samples is csv (necessary due to drag and drop of any file)
-      if (!grepl("csv", input$samples_csv$name, ignore.case = TRUE)) {
+      ext <- tools::file_ext(input$samples_csv$name)[1]
+      if (ext != "csv") {
         shinyalert::shinyalert(
           title = "File format not supported.",
           text = "Please make sure the file is a CSV file.",


### PR DESCRIPTION
This closes #945 

## Description
The issue was triggered when a counts file with the name `counts.csv.xlsx` was introduced into the platform. The extension detection was based on `grep("csv", filename)`, which returned true even though the file extension of the file is `xlsx`. 

Changed the function to detect the file extension to `tools::file_ext` for a more robust approach.

Applied it to counts/contrasts/samples functions.