### PR TITLE
feat: do not highlight genes under thresholds

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -91,6 +91,9 @@ enrichment_plot_volcano_server <- function(id,
       lfc <- 0.20
       lfc <- as.numeric(gs_lfc())
 
+      sig.genes <- fc.genes[which(qval <= fdr & abs(fx) > lfc)]
+      sel.genes <- intersect(sig.genes, sel.genes)
+
       playbase::plotlyVolcano(
         x = fx,
         y = -log10(qval),


### PR DESCRIPTION
## Description
Added a step on the geneset expression volcano plot to remove the genes that fall under the significance filters, that way we only visualize those above it.

### Before
![image](https://github.com/bigomics/omicsplayground/assets/10220503/edd3283e-a91e-4c89-ba99-18a840544b9c)

### After
![image](https://github.com/bigomics/omicsplayground/assets/10220503/0201c6f3-d478-4bf5-8154-a0364c5fc7f5)
