### PR TITLE
Fix #962: allowing users to highlight specific genes on the Gene UMAP plot

### DIFF
--- a/components/board.featuremap/R/featuremap_plot_table_gene_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_gene_map.R
@@ -68,7 +68,7 @@ featuremap_plot_gene_map_server <- function(id,
                                             pgx,
                                             plotUMAP,
                                             sigvar,
-                                            filter_genes,
+                                            filteredGenes,
                                             r_fulltable,
                                             watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
@@ -79,27 +79,6 @@ featuremap_plot_gene_map_server <- function(id,
       colnames(pos) <- c("x", "y")
       pos
     }
-
-    filteredGenes <- shiny::reactive({
-      shiny::req(pgx$X)
-      shiny::validate(need(filter_genes(), "Please input at least one value in Annotate genes!"))
-      sel <- filter_genes()
-      filtgenes <- c()
-      if (is.null(pgx$version) | pgx$organism == "Human") {
-        filtgenes <- unlist(lapply(sel, function(genes) playdata::FAMILIES[[genes]]))
-      } else {
-        filtgenes <- unlist(lapply(sel, function(genes) {
-          if (genes == "<all>") {
-            x <- pgx$genes$symbol
-          } else {
-            x <- playdata::FAMILIES[[genes]]
-            x <- pgx$genes$symbol[match(x, pgx$genes$human_ortholog, nomatch = 0)]
-          }
-          return(x)
-        }))
-      }
-      filtgenes
-    })
 
     plot_data <- shiny::reactive({
       pos <- getUMAP()
@@ -240,9 +219,17 @@ featuremap_plot_gene_map_server <- function(id,
         X <- X[gg, , drop = FALSE]
         X <- X - rowMeans(X)
         y <- pgx$samples[, pheno]
-        FC <- do.call(cbind, tapply(1:ncol(X), y, function(i) {
-          rowMeans(X[, i, drop = FALSE])
-        }))
+        if (length(gg) == 1) {
+          FC <- tapply(1:ncol(X), y, function(i) {
+            rowMeans(X[, i, drop = FALSE])
+          })
+          rownames(FC) <- gg
+        } else {
+          FC <- do.call(cbind, tapply(1:ncol(X), y, function(i) {
+            rowMeans(X[, i, drop = FALSE])
+          }))
+        }
+        
         is.fc <- FALSE
       } else {
         FC <- playbase::pgx.getMetaMatrix(pgx, level = "gene")$fc

--- a/components/board.featuremap/R/featuremap_ui.R
+++ b/components/board.featuremap/R/featuremap_ui.R
@@ -54,6 +54,18 @@ FeatureMapInputs <- function(id) {
       )
     ),
     shiny::conditionalPanel(
+      "input.tabs == 'Gene' && input.filter_genes.includes('<custom>')",
+      ns = ns,
+      withTooltip(
+        shiny::textAreaInput(ns("customlist"), NULL,
+          value = NULL,
+          rows = 5, placeholder = "Paste your custom gene list"
+        ),
+        "Paste a custom list of genes to highlight.",
+        placement = "bottom"
+      )
+    ),
+    shiny::conditionalPanel(
       "input.tabs == 'Geneset'",
       ns = ns,
       withTooltip(


### PR DESCRIPTION
This closes #962 

## Description
This adds a `<custom>` option to filter out genes which opens a new conditional panel where the genes of interest can be inputed. Also, I have moved the `filteredGenes` function from the `featuremap_plot_table_gene_map.R` file to `featuremap_server.R` so that we can re-use it on the signature UMAP plot on the future if required.

![image](https://github.com/bigomics/omicsplayground/assets/10220503/a650bbc3-097f-49c1-81a9-cc05b99db425)
