### PR TITLE
fix: if no labels matched return plain wikipath

### DIFF
--- a/components/board.pathway/R/pathway_wikipathview.R
+++ b/components/board.pathway/R/pathway_wikipathview.R
@@ -76,24 +76,23 @@ wikipathview <- function(wp, val) {
   }
 
   if (!is.null(val)) {
-    if (sum(names(val) %in% toupper(labels)) == 0) {
-      return(NULL)
-    }
-    found_indexes <- which(toupper(labels) %in% names(val))
-    labels <- labels[found_indexes]
-    rect_nodes <- rect_nodes[found_indexes]
-    val <- val[toupper(labels)]
-    rr <- as.character(round(66 * pmin(1, abs(val / 2.0))**0.5))
-    rr <- stringr::str_pad(rr, width = 2, pad = "0")
-    colors <- ifelse(val > 0, paste0("#ff0000", rr), paste0("#0055ff", rr))
-    if (isClassic) {
-      current_style <- xml_attr(rect_nodes, "style")
-      new_style <- paste0(current_style, " fill:", colors, ";")
-      lapply(seq_along(new_style), function(x) {
-        xml_set_attr(rect_nodes[x], "style", new_style[x])
-      })
-    } else {
-      xml_attr(rect_nodes, "fill") <- colors
+    if (sum(names(val) %in% toupper(labels)) > 0) {
+      found_indexes <- which(toupper(labels) %in% names(val))
+      labels <- labels[found_indexes]
+      rect_nodes <- rect_nodes[found_indexes]
+      val <- val[toupper(labels)]
+      rr <- as.character(round(66 * pmin(1, abs(val / 2.0))**0.5))
+      rr <- stringr::str_pad(rr, width = 2, pad = "0")
+      colors <- ifelse(val > 0, paste0("#ff0000", rr), paste0("#0055ff", rr))
+      if (isClassic) {
+        current_style <- xml_attr(rect_nodes, "style")
+        new_style <- paste0(current_style, " fill:", colors, ";")
+        lapply(seq_along(new_style), function(x) {
+          xml_set_attr(rect_nodes[x], "style", new_style[x])
+        })
+      } else {
+        xml_attr(rect_nodes, "fill") <- colors
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Before, if there was no matches between the WikiPathway genes and the pgx genes, we returned `NULL` (figure 1). It looks better to still display the WikiPathway, just not colored (figure 2).

### Figure 1
![image](https://github.com/bigomics/omicsplayground/assets/10220503/a9e16526-188f-4433-a536-61a954814404)

### Figure 2
![image](https://github.com/bigomics/omicsplayground/assets/10220503/fbb49001-5651-46cc-b362-0abb0beb2620)