### PR TITLE
Fix #966: edge case no replication on samples

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -59,8 +59,7 @@ upload_module_computepgx_server <- function(
       EXTRA.SELECTED <- c("deconv", "drugs", "wordcloud", "connectivity", "wgcna")
 
       ONESAMPLE.GENE_METHODS <- c("ttest", "ttest.welch")
-      ONESAMPLE.GENESET_METHODS <- sort(c("spearman", "gsva", "fgsea", "ssgsea", "fisher"))
-
+      ONESAMPLE.GENESET_METHODS <- sort(c("fgsea", "fisher"))
       DEV.METHODS <- c("noLM.prune")
       DEV.NAMES <- c("noLM + prune")
       DEV.SELECTED <- c()
@@ -343,8 +342,7 @@ upload_module_computepgx_server <- function(
 
       shiny::observeEvent(contrastsRT(), {
         contrasts <- as.data.frame(contrastsRT())
-        has_one <- apply(contrasts, 2, function(x) all(table(x) == 1))
-
+        has_one <- apply(contrasts, 2, function(x) any(table(x) == 1))
         if (any(has_one)) {
           shinyalert::shinyalert(
             title = "WARNING",
@@ -360,7 +358,7 @@ upload_module_computepgx_server <- function(
           shiny::updateCheckboxGroupInput(session,
             "gset_methods",
             choices = ONESAMPLE.GENESET_METHODS,
-            sel = c("fisher", "fgsea", "gsva")
+            sel = c("fisher", "fgsea")
           )
         }
       })


### PR DESCRIPTION
This closes #966 

The original problem described in #966 was not actually the point of error for that user, but rather [this line](https://github.com/bigomics/playbase/blob/533acd28c0ac44ea5e9c8faa404df1f4820d2cc9/R/gset-meta.r#L540) when the linear modeling has no degrees of freedom: 1vs1 samples or 1 vs many. https://stat.ethz.ch/pipermail/bioconductor/2009-May/027834.html

## Description
1) We were just checking the case when we had one sample compared against one sample; when the problems occur when we have one vs many as well, therefore on `has_one`, we now do `any` instead of `all`.
2) When this occurs, the `ONESAMPLE.GENESET_METHODS` that actually work are way more reduced.