### PR TITLE
Fix #973: handle 1 geneset table

### DIFF
--- a/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
@@ -230,9 +230,17 @@ featuremap_plot_table_geneset_map_server <- function(id,
         X <- pgx$gsetX[gg, , drop = FALSE]
         X <- X - rowMeans(X, na.rm = TRUE)
         y <- pgx$samples[, pheno]
-        F <- do.call(cbind, tapply(1:ncol(X), y, function(i) {
-          rowMeans(X[, c(i, i), drop = FALSE])
-        }))
+        if (nrow(X) == 1) {
+          F <- tapply(1:ncol(X), y, function(i) {
+            rowMeans(X[, c(i, i), drop = FALSE])
+          })
+          F <- data.frame(t(F))
+          rownames(F) <- gg
+        } else {
+          F <- do.call(cbind, tapply(1:ncol(X), y, function(i) {
+            rowMeans(X[, c(i, i), drop = FALSE])
+          }))
+        }
         is.fc <- FALSE
       } else {
         F <- playbase::pgx.getMetaMatrix(pgx, level = "geneset")$fc


### PR DESCRIPTION
This closes #973 

## Description
There was an issue when the genesets table had to display one row. Added the correct handle to display the information properly.

![Screenshot from 2024-06-25 12-40-43](https://github.com/bigomics/omicsplayground/assets/10220503/0c8b8bbe-d126-455d-86d4-1e85cfc8d03e)
