### PR TITLE
Fix #975: sanitize spaces on `input_code`

### DIFF
--- a/components/modules/AuthenticationModule.R
+++ b/components/modules/AuthenticationModule.R
@@ -1140,6 +1140,7 @@ LoginCodeAuthenticationModule <- function(id,
 
       if (email_sent) {
         input_code <- entered_code()
+        input_code <- gsub(" ", "", input_code)
         login.OK <- (input_code == login_code)
 
         if (!login.OK) {


### PR DESCRIPTION
This closes #975 

## Description
This helps to correct mistakes from the users.

On the email they recieve if the code is double clicked, the code + a space is selected, leading to some users getting failed logins just because of that, by sanitizing the spaces on the `input_code` we can avoid those simple fails and improve the experience.