### PR TITLE
fix: modal captions translation

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -52,8 +52,8 @@ PlotModuleUI <- function(id,
   if (translate) {
     info.text <- tspan(info.text)
     title <- tspan(title, js = translate_js)
-    caption <- tspan(caption, js = translate_js)
     caption2 <- tspan(caption2, js = translate_js)
+    caption <- tspan(caption, js = translate_js)
   }
 
   getOutputFunc <- function(plotlib) {


### PR DESCRIPTION
## Description
On default plot module `caption = caption2`, therefore `caption2` got translate 2 times (when no specific `caption2` is provided) leading to some errors:

Before:
![image](https://github.com/user-attachments/assets/0f76a296-b1d9-40fe-976f-10e31305ee16)

After:
![image](https://github.com/user-attachments/assets/f6dd34bc-b312-42fd-a125-ff7e33e04ad6)
