### PR TITLE
fix feature-UMAP for duplicated symbols && simplify code and options

### DIFF
--- a/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
@@ -24,7 +24,6 @@ featuremap_plot_geneset_map_ui <- function(
       min = 0.1, max = 1.2, value = 0.4, step = 0.1
     ),
     shiny::radioButtons(ns("gsmap_colorby"), "color by:",
-      #
       choices = c("sd.X", "rms.FC"),
       selected = "sd.X", inline = TRUE
     )
@@ -115,16 +114,10 @@ featuremap_plot_table_geneset_map_server <- function(id,
 
       hilight <- filteredGsets()
       nlabel <- as.integer(input$gsmap_nlabel)
-      colorby <- input$gsmap_colorby
 
       F <- playbase::pgx.getMetaMatrix(pgx, level = "geneset")$fc
       F <- scale(F, center = FALSE)
-      if (colorby == "rms.FC") {
-        fc <- (rowMeans(F**2))**0.5
-      } else {
-        cX <- pgx$gsetX - rowMeans(pgx$gsetX, na.rm = TRUE)
-        fc <- sqrt(rowMeans(cX**2))
-      }
+      fc <- sqrt(rowMeans(F**2))
 
       ## conform
       gg <- intersect(rownames(pos), names(fc))
@@ -136,8 +129,7 @@ featuremap_plot_table_geneset_map_server <- function(id,
         fc = fc,
         pos = pos,
         hilight = hilight,
-        nlabel = nlabel,
-        colorby = colorby
+        nlabel = nlabel
       )
     })
 
@@ -147,7 +139,6 @@ featuremap_plot_table_geneset_map_server <- function(id,
       fc <- pd$fc
       hilight <- pd$hilight
       nlabel <- pd$nlabel
-      colorby <- pd$colorby
       colgamma <- as.numeric(input$gsmap_gamma)
       fc <- sign(fc) * abs(fc / max(abs(fc), na.rm = TRUE))**colgamma
       if (length(setdiff(names(fc), hilight))) {
@@ -160,7 +151,7 @@ featuremap_plot_table_geneset_map_server <- function(id,
         fc,
         hilight,
         nlabel = nlabel,
-        title = colorby,
+        title = "rms.FC",
         cex = cex,
         cex.label = cex.label,
         source = ns("geneset_umap"),
@@ -218,45 +209,18 @@ featuremap_plot_table_geneset_map_server <- function(id,
         sel.gsets <- rownames(pos)
       }
 
-      if (!r_fulltable()) {
-        if (!is.null(sel.gsets)) {
-          filt.gsets <- filteredGsets()
-          sel.gsets <- intersect(sel.gsets, filt.gsets)
-        } else {
-          sel.gsets <- filteredGsets()
-        }
+      if (!is.null(sel.gsets)) {
+        filt.gsets <- filteredGsets()
+        sel.gsets <- intersect(sel.gsets, filt.gsets)
       }
 
-      pheno <- "tissue"
-      pheno <- sigvar()
-      is.fc <- FALSE
-      if (any(pheno %in% colnames(pgx$samples))) {
-        gg <- intersect(sel.gsets, rownames(pgx$gsetX))
-        X <- pgx$gsetX[gg, , drop = FALSE]
-        X <- X - rowMeans(X, na.rm = TRUE)
-        y <- pgx$samples[, pheno]
-        if (nrow(X) == 1) {
-          F <- tapply(1:ncol(X), y, function(i) {
-            rowMeans(X[, c(i, i), drop = FALSE])
-          })
-          F <- data.frame(t(F))
-          rownames(F) <- gg
-        } else {
-          F <- do.call(cbind, tapply(1:ncol(X), y, function(i) {
-            rowMeans(X[, c(i, i), drop = FALSE])
-          }))
-        }
-        is.fc <- FALSE
-      } else {
-        F <- playbase::pgx.getMetaMatrix(pgx, level = "geneset")$fc
-        gg <- intersect(sel.gsets, rownames(F))
-        F <- F[gg, , drop = FALSE]
-        is.fc <- TRUE
-      }
+      contrasts <- sigvar()
+      F <- playbase::pgx.getMetaMatrix(pgx, level = "geneset")$fc
+      gg <- intersect(sel.gsets, rownames(F))
+      F <- F[gg, contrasts, drop = FALSE]
 
       F <- F[order(-rowMeans(F**2)), , drop = FALSE]
-      F <- cbind(sd.X = sqrt(rowMeans(F**2)), F)
-      if (is.fc) colnames(F)[1] <- "rms.FC"
+      F <- cbind(rms.FC = sqrt(rowMeans(F**2)), F)
       F <- round(F, digits = 3)
       gs.db <- sub(":.*", "", rownames(F))
       gs <- sub(".*[:]", "", rownames(F))

--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -81,65 +81,18 @@ FeatureMapBoard <- function(id, pgx) {
 
     observeEvent(
       {
-        list(input$sigvar, pgx$samples)
-      },
-      {
-        shiny::req(pgx$samples, input$sigvar)
-        if (input$sigvar %in% colnames(pgx$samples)) {
-          y <- setdiff(pgx$samples[, input$sigvar], c(NA))
-          y <- c("<average>", sort(unique(y)))
-          shiny::updateSelectInput(session, "ref_group", choices = y)
-        }
-      }
-    )
-
-    observeEvent(
-      {
-        list(pgx$samples, pgx$X, input$showvar)
+        list(pgx$samples, pgx$X)
       },
       {
         shiny::req(pgx$samples)
         shiny::req(pgx$X)
-        shiny::req(input$showvar)
 
-        if (input$showvar == "phenotype") {
-          cvar <- playbase::pgx.getCategoricalPhenotypes(pgx$samples, max.ncat = 99)
-          cvar0 <- head(grep("^[.]", cvar, invert = TRUE, value = TRUE), 1)
-          shiny::updateSelectInput(session, "sigvar", choices = cvar, selected = cvar0)
-        }
-        if (input$showvar == "comparisons") {
-          cvar <- colnames(pgx$model.parameters$contr.matrix)
-          sel.cvar <- head(cvar, 8)
-          shiny::updateSelectizeInput(session, "selcomp",
-            choices = cvar,
-            selected = sel.cvar
-          )
-          shiny::updateSelectInput(session, "ref_group", choices = "  ")
-        }
-      }
-    )
-
-    observeEvent(
-      {
-        list(pgx$samples, input$showvar, input$sigvar)
-      },
-      {
-        shiny::req(pgx$samples, input$sigvar, input$showvar)
-        if (input$sigvar %in% colnames(pgx$samples)) {
-          y <- setdiff(pgx$samples[, input$sigvar], c(NA))
-          y <- c("<average>", sort(unique(y)))
-          shiny::updateSelectInput(session, "ref_group", choices = y)
-        }
-      }
-    )
-
-    observeEvent(
-      {
-        list(input$selcomp)
-      },
-      {
-        ## shiny::req(pgx$samples, input$sigvar, input$showvar)
-        shiny::updateSelectInput(session, "ref_group", choices = " ")
+        cvar <- colnames(pgx$model.parameters$contr.matrix)
+        sel.cvar <- head(cvar, 8)
+        shiny::updateSelectizeInput(session, "selcomp",
+                                    choices = cvar,
+                                    selected = sel.cvar
+                                    )
       }
     )
 
@@ -308,23 +261,13 @@ FeatureMapBoard <- function(id, pgx) {
     ## =========================== MODULES ============================================
     ## ================================================================================
 
-    sigvar2 <- shiny::reactive({
-      if (input$showvar == "phenotype") {
-        return(input$sigvar)
-      }
-      if (input$showvar == "comparisons") {
-        return(input$selcomp)
-      }
-    })
-
     # Gene Map
     featuremap_plot_gene_map_server(
       "geneUMAP",
       pgx = pgx,
       plotUMAP = plotUMAP,
-      sigvar = sigvar2,
+      sigvar = reactive(input$selcomp),
       filteredGenes = filteredGenes,
-      r_fulltable = shiny::reactive(input$show_fulltable),
       watermark = WATERMARK
     )
 
@@ -332,7 +275,7 @@ FeatureMapBoard <- function(id, pgx) {
     featuremap_plot_gene_sig_server(
       "geneSigPlots",
       pgx = pgx,
-      sigvar = sigvar2,
+      sigvar = reactive(input$selcomp),
       ref_group = shiny::reactive(input$ref_group),
       plotFeaturesPanel = plotFeaturesPanel,
       watermark = WATERMARK
@@ -344,8 +287,7 @@ FeatureMapBoard <- function(id, pgx) {
       pgx = pgx,
       plotUMAP = plotUMAP,
       filter_gsets = shiny::reactive(input$filter_gsets),
-      sigvar = sigvar2,
-      r_fulltable = shiny::reactive(input$show_fulltable),
+      sigvar = reactive(input$selcomp),
       watermark = WATERMARK
     )
 
@@ -353,7 +295,7 @@ FeatureMapBoard <- function(id, pgx) {
     featuremap_plot_gset_sig_server(
       "gsetSigPlots",
       pgx = pgx,
-      sigvar = sigvar2,
+      sigvar = reactive(input$selcomp),
       ref_group = shiny::reactive(input$ref_group),
       plotFeaturesPanel = plotFeaturesPanel,
       watermark = WATERMARK

--- a/components/board.featuremap/R/featuremap_ui.R
+++ b/components/board.featuremap/R/featuremap_ui.R
@@ -9,37 +9,11 @@ FeatureMapInputs <- function(id) {
     shiny::br(),
     ## data set parameters
     withTooltip(
-      shiny::radioButtons(
-        ns("showvar"), "Show:",
-        inline = TRUE,
-        choices = c("phenotype", "comparisons")
-      ),
-      "Show gene signatures colored by phenotype conditions (relative expression)
-       or by comparisons (logFC).",
-      placement = "right", options = list(container = "body")
-    ),
-    shiny::conditionalPanel(
-      "input.showvar == 'phenotype'",
-      ns = ns,
-      withTooltip(
-        shiny::selectInput(ns("sigvar"), NULL, choices = NULL, multiple = FALSE),
-        "Select the phenotype conditions to show in the signatures plot.",
-        placement = "top"
-      ),
-      withTooltip(
-        shiny::selectInput(ns("ref_group"), "Reference:", choices = NULL),
-        "Reference group. If no group is selected the average is used as reference.",
-        placement = "right", options = list(container = "body")
-      )
-    ),
-    shiny::conditionalPanel(
-      "input.showvar == 'comparisons'",
-      ns = ns,
-      withTooltip(
-        shiny::selectizeInput(ns("selcomp"), NULL, choices = NULL, multiple = TRUE),
-        "Select the comparisons to show in the signatures plot.",
-        placement = "top"
-      )
+      shiny::selectizeInput(
+        ns("selcomp"), "Show comparisons:",
+        choices = NULL, multiple = TRUE),
+      "Select the comparisons to show in the signatures plot.",
+      placement = "top"
     ),
     hr(),
     shiny::conditionalPanel(
@@ -75,11 +49,6 @@ FeatureMapInputs <- function(id) {
         "Filter the genesets to highlight on the map.",
         placement = "right", options = list(container = "body")
       )
-    ),
-    shiny::hr(),
-    withTooltip(
-      shiny::checkboxInput(ns("show_fulltable"), "Show full table", FALSE),
-      "Show full table. Not filtered."
     )
     ## shiny::br(),
     ## shiny::br(),


### PR DESCRIPTION
The current code was not suitable to handle datasets with many duplicated symbols such as common in peptide level proteomics (PTM-TMT, or transcript level RNAseq). Mainly the current code was removing all other probes with duplicated symbols. 