### PR TITLE
style: plotly hoverlabels

### DIFF
--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -105,7 +105,7 @@ clustering_plot_clustpca_server <- function(id,
       if (shapevar %in% colnames(df)) shapevar <- factor(df[, shapevar])
       ann.text <- rep(" ", nrow(df))
 
-      label.samples <- (label == "sample")
+      label.samples <- (label == "<b>Sample</b>")
 
       if (!do3d && label.samples) ann.text <- rownames(df)
       if (!is.null(colvar)) {
@@ -118,8 +118,8 @@ clustering_plot_clustpca_server <- function(id,
       )
 
       Y <- cbind("sample" = rownames(pos), pgx$Y[sel, ])
-      tt.info <- apply(Y, 1, function(y) paste0(colnames(Y), ": ", y, "</br>", collapse = ""))
-      tt.info <- as.character(tt.info)
+      tt.info <- apply(Y, 1, function(y) paste0(colnames(Y), ": <b>", y, "</b></br>", collapse = ""))
+      tt.info <- I(as.character(tt.info))
       cex1 <- c(1.0, 0.8, 0.6)[1 + 1 * (nrow(pos) > 30) + 1 * (nrow(pos) > 200)]
 
       if (do3d) {
@@ -167,7 +167,8 @@ clustering_plot_clustpca_server <- function(id,
         ## 2D plot
         plt <- plotly::plot_ly(
           df,
-          mode = "markers"
+          mode = "markers",
+          hovertemplate = "</br>%{text}<extra></extra>"
         ) %>%
           plotly::add_markers(
             x = df[, 1],

--- a/components/board.correlation/R/correlation_plot_scattercorr.R
+++ b/components/board.correlation/R/correlation_plot_scattercorr.R
@@ -153,7 +153,15 @@ correlation_plot_scattercorr_server <- function(id,
         fit <- lm(y ~ x)
         newdata <- data.frame(x = range(x))
         newdata$y <- predict(fit, newdata)
-        plt <- plotly::plot_ly() %>%
+        plt <- plotly::plot_ly(
+          hovertemplate = paste0(
+            "<b>%{fullData.name}<br>",
+            xlab,
+            " Expression:</b> %{x}<br><b>",
+            gene2,
+            " Expression:</b> %{y}<extra></extra>"
+          )
+        ) %>%
           # Add the points
           plotly::add_trace(
             x = x, y = y, name = pheno, color = klr, type = "scatter", mode = "markers",

--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -12,11 +12,20 @@ dataview_plot_expression_ui <- function(
     info.text) {
   ns <- shiny::NS(id)
 
+  options <- shiny::tagList(
+    shiny::radioButtons(
+      inputId = ns("geneplot_type"),
+      label = "Plot type (only available when {Group by} setting is in use)",
+      choices = c("barplot", "box", "violin")
+    )
+  )
+
   PlotModuleUI(
     ns("pltmod"),
     title = title,
     label = label,
     caption = caption,
+    options = options,
     outputFunc = plotly::plotlyOutput,
     outputFunc2 = plotly::plotlyOutput,
     info.text = info.text,
@@ -70,7 +79,8 @@ dataview_plot_expression_server <- function(id,
         ylab <- tspan("Counts (log2)", js = FALSE)
       }
 
-      geneplot_type <- "barplot"
+      # geneplot_type <- "barplot"
+      geneplot_type <- input$geneplot_type
       pd <- list(
         df = data.frame(
           x = gx,
@@ -105,7 +115,7 @@ dataview_plot_expression_server <- function(id,
         ngrp <- length(unique(df$group))
         cx1 <- ifelse(ngrp < 10, 1, 0.8)
         cx1 <- ifelse(ngrp > 20, 0.6, cx1)
-        if (pd$geneplot_type == "bar") {
+        if (pd$geneplot_type == "barplot") {
           playbase::gx.b3plot(
             df$x,
             df$group,
@@ -210,7 +220,7 @@ dataview_plot_expression_server <- function(id,
         cx1 <- ifelse(ngrp < 10, 1, 0.8)
         cx1 <- ifelse(ngrp > 20, 0.6, cx1)
 
-        if (pd$geneplot_type == "bar") {
+        if (pd$geneplot_type == "barplot") {
           data_mean <- tapply(df$x, df$group, mean)
           data_sd <- tapply(df$x, df$group, sd)
           data <- data.frame(group = names(data_mean), mean = data_mean, sd = data_sd)
@@ -264,8 +274,14 @@ dataview_plot_expression_server <- function(id,
         }
       } else {
         ## plot as regular bar plot
-        fig <- plotly::plot_ly(df, x = ~samples, y = ~x, type = "bar", name = pd$gene)
-
+        fig <- plotly::plot_ly(
+          df,
+          x = ~samples,
+          y = ~x,
+          type = "bar",
+          name = pd$gene,
+          hovertemplate = "<b>Sample: </b>%{x}<br><b>%{yaxis.title.text}:</b> %{y}<extra></extra>"
+        )
         pd$groupby <- ""
         ## fig
       }

--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -280,7 +280,7 @@ dataview_plot_expression_server <- function(id,
           y = ~x,
           type = "bar",
           name = pd$gene,
-          hovertemplate = "<b>Sample: </b>%{x}<br><b>%{yaxis.title.text}:</b> %{y.2f}<extra></extra>"
+          hovertemplate = "<b>Sample: </b>%{x}<br><b>%{yaxis.title.text}:</b> %{y:.2f}<extra></extra>"
         )
         pd$groupby <- ""
         ## fig

--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -280,7 +280,7 @@ dataview_plot_expression_server <- function(id,
           y = ~x,
           type = "bar",
           name = pd$gene,
-          hovertemplate = "<b>Sample: </b>%{x}<br><b>%{yaxis.title.text}:</b> %{y}<extra></extra>"
+          hovertemplate = "<b>Sample: </b>%{x}<br><b>%{yaxis.title.text}:</b> %{y.2f}<extra></extra>"
         )
         pd$groupby <- ""
         ## fig

--- a/components/board.enrichment/R/enrichment_plot_scatter.R
+++ b/components/board.enrichment/R/enrichment_plot_scatter.R
@@ -158,7 +158,15 @@ enrichment_plot_scatter_server <- function(id,
       fit <- lm(sx ~ gx)
       newdata <- data.frame(gx = range(gx))
       newdata$sx <- predict(fit, newdata)
-      plt <- plotly::plot_ly() %>%
+      plt <- plotly::plot_ly(
+        hovertemplate = paste0(
+          "<b>%{fullData.name}<br>",
+          gene,
+          " Expression:</b> %{x}<br><b>",
+          tspan("Geneset", js = FALSE),
+          " Enrichment:</b> %{y}<extra></extra>"
+        )
+      ) %>%
         # Axis
         plotly::layout(
           xaxis = list(title = paste(gene, "expression"), titlefont = 5),


### PR DESCRIPTION
## Description
This PR aims at bringing properly styled hoverlabels to as many plotly plots as possible. This PR is linked to PR https://github.com/bigomics/playbase/pull/132 on playbase, which has the same aim.

### Example
Screenshot of an example plot that has been addressed:

#### Before
![test](https://github.com/user-attachments/assets/0ba351e5-e05f-44f0-976d-9d3cfa78d53f)

#### After
![test](https://github.com/user-attachments/assets/cb5e5af4-5a70-466f-bc56-43ebb76f9680)

