### PR TITLE
Fix #1021: Error on pathway activation matrices for datasets with one contrast

### DIFF
--- a/components/board.pathway/R/pathway_server.R
+++ b/components/board.pathway/R/pathway_server.R
@@ -120,7 +120,7 @@ PathwayBoard <- function(id, pgx, selected_gsetmethods = reactive(colnames(pgx$g
 
       if (rotate) score2 <- t(score2)
       bluered.pal <- colorRamp(colors = c("royalblue3", "#ebeffa", "white", "#faeeee", "indianred3"))
-      score2 <- score2[nrow(score2):1, ]
+      score2 <- score2[nrow(score2):1, , drop = FALSE]
       x_axis <- colnames(score2)
       y_axis <- rownames(score2)
       fig <- plotly::plot_ly(


### PR DESCRIPTION
This closes #1021 

## Description
The `score2` variable is meant to be a dataframe, from which row/colnames are used to create the activation matrix plots. When dataset contains only one contrast, this variable was subsetted with just one column, which converted it to a named numeric vector. Added `drop = FALSE` to keep it as a dataframe.
![image](https://github.com/user-attachments/assets/bee70dbe-6797-4793-94a9-ddcc9268eacc)