### PR TITLE
Fix stackedbarplot for genes with low frequency

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_freq_top_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_freq_top_gsets.R
@@ -130,7 +130,9 @@ enrichment_plot_freq_top_gsets_server <- function(id,
       F <- F[order(-Matrix::rowSums(F)), , drop = FALSE]
 
       sel.zero <- which(Matrix::rowSums(abs(F)) < 1e-4)
-      if (length(sel.zero)) rownames(F)[sel.zero] <- ""
+      if (length(sel.zero)) {
+        F <- F[-sel.zero, , drop = FALSE]
+      }
 
       if (return_csv) {
         return(F)


### PR DESCRIPTION
This pull request fixes an issue with the stackedbarplot for genes with low frequency. The commit includes a patch that removes rows with zero values from the matrix before plotting.

Fixes https://github.com/bigomics/omicsplayground/issues/1025