### PR TITLE
feat: probe filter defaults for proteomics

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -186,6 +186,14 @@ opt.file <- file.path(ETC, "OPTIONS")
 if (!file.exists(opt.file)) stop("FATAL ERROR: cannot find OPTIONS file")
 opt <- playbase::pgx.readOptions(file = opt.file, default = opt.default) ## global!
 
+message("\n************************************************")
+message("************* SETTING DEFAULTS ***************")
+message("************************************************")
+
+defaults.file <- file.path(ETC, "DEFAULTS.yml")
+if (!file.exists(defaults.file)) stop("FATAL ERROR: cannot find DEFAULTS.yml file")
+DEFAULTS <<- yaml::read_yaml(defaults.file)
+
 ## Check and set authentication method
 if (Sys.getenv("PLAYGROUND_AUTHENTICATION") != "") {
   auth <- Sys.getenv("PLAYGROUND_AUTHENTICATION")

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -84,21 +84,7 @@ upload_module_computepgx_server <- function(
       DEV.SELECTED <- c()
 
       ## Probe filtering defaults
-      PROBE_FILTER_SELECTED <- shiny::eventReactive(
-        {
-          upload_datatype()
-        },
-        {
-          if (tolower(upload_datatype()) == "proteomics") {
-            mm <- DEFAULTS$computation_options$probe_filtering$proteomics
-          } else {
-            mm <- DEFAULTS$computation_options$probe_filtering$default
-          }
-          return(mm)
-        }
-      )
-
-
+      PROBE_FILTER_SELECTED <- DEFAULTS$computation_options$probe_filtering
 
       readthedocs_url <- "https://omicsplayground.readthedocs.io/en/latest/dataprep/geneset.html"
 
@@ -172,11 +158,10 @@ upload_module_computepgx_server <- function(
                   shiny::HTML("<h4>Probe filtering:</h4>"),
                   choiceValues =
                     c(
-                      "only.hugo",
+                      "append.symbol",
                       "remove.notexpressed",
                       "remove.unknown",
                       "only.proteincoding"
-                      ## "skip.normalization"
                     ),
                   choiceNames =
                     c(
@@ -184,10 +169,8 @@ upload_module_computepgx_server <- function(
                       "Remove not-expressed",
                       "Remove features without symbol",
                       "Remove Rik/ORF/LOC genes"
-                      ## "Skip normalization"
-                      ## "Exclude immunogenes",
                     ),
-                  selected = PROBE_FILTER_SELECTED()
+                  selected = PROBE_FILTER_SELECTED
                 )
               ),
               bslib::card(
@@ -540,7 +523,7 @@ upload_module_computepgx_server <- function(
         use.design <- TRUE
         prune.samples <- FALSE
         flt <- input$filter_methods
-        only.hugo <- ("only.hugo" %in% flt)
+        append.symbol <- ("append.symbol" %in% flt)
         do.protein <- ("proteingenes" %in% flt)
         remove.unknown <- ("remove.unknown" %in% flt)
         ## do.normalization <- !("skip.normalization" %in% flt)
@@ -584,8 +567,8 @@ upload_module_computepgx_server <- function(
           filter.genes = filter.genes,
           only.known = !remove.unknown,
           only.proteincoding = only.proteincoding,
-          only.hugo = only.hugo,
-          convert.hugo = only.hugo,
+          only.hugo = append.symbol,  ## DEPRECATED
+          convert.hugo = append.symbol,  ## should be renamed
           do.cluster = TRUE,
           cluster.contrasts = FALSE,
           max.genes = max.genes,

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -90,13 +90,9 @@ upload_module_computepgx_server <- function(
         },
         {
           if (tolower(upload_datatype()) == "proteomics") {
-            mm <- c()
+            mm <- DEFAULTS$computation_options$probe_filtering$proteomics
           } else {
-            mm <- c(
-              "remove.notexpressed",
-              "remove.unknown",
-              "only.proteincoding"
-            )
+            mm <- DEFAULTS$computation_options$probe_filtering$default
           }
           return(mm)
         }

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -83,6 +83,27 @@ upload_module_computepgx_server <- function(
       DEV.NAMES <- c("noLM + prune")
       DEV.SELECTED <- c()
 
+      ## Probe filtering defaults
+      PROBE_FILTER_SELECTED <- shiny::eventReactive(
+        {
+          upload_datatype()
+        },
+        {
+          if (tolower(upload_datatype()) == "proteomics") {
+            mm <- c()
+          } else {
+            mm <- c(
+              "remove.notexpressed",
+              "remove.unknown",
+              "only.proteincoding"
+            )
+          }
+          return(mm)
+        }
+      )
+
+
+
       readthedocs_url <- "https://omicsplayground.readthedocs.io/en/latest/dataprep/geneset.html"
 
       output$UI <- shiny::renderUI({
@@ -170,12 +191,7 @@ upload_module_computepgx_server <- function(
                       ## "Skip normalization"
                       ## "Exclude immunogenes",
                     ),
-                  selected = c(
-                    ## "only.hugo",
-                    "remove.notexpressed",
-                    "remove.unknown",
-                    "only.proteincoding"
-                  )
+                  selected = PROBE_FILTER_SELECTED()
                 )
               ),
               bslib::card(

--- a/etc/DEFAULTS.yml
+++ b/etc/DEFAULTS.yml
@@ -1,0 +1,7 @@
+computation_options: 
+  probe_filtering:
+    default:
+      - remove.notexpressed
+      - remove.unknown
+      - only.proteincoding
+    proteomics: []

--- a/etc/DEFAULTS.yml
+++ b/etc/DEFAULTS.yml
@@ -1,7 +1,7 @@
 computation_options: 
   probe_filtering:
-    default:
-      - remove.notexpressed
-      - remove.unknown
-      - only.proteincoding
-    proteomics: []
+#    - append.symbol
+    - remove.notexpressed    
+    - remove.unknown
+    - only.proteincoding
+


### PR DESCRIPTION
## Description
All probe filter are set as disabled by default for proteomics data.

![image](https://github.com/user-attachments/assets/424964fe-62fd-4cc1-87ef-6a24de9ff904)
