### PR TITLE
Add: checking of organism and datatype in ExtendedTask

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -596,11 +596,6 @@ upload_module_computepgx_server <- function(
           sendSuccessMessageToUser = sendSuccessMessageToUser
         )
 
-        ## Test check dim(counts) & dim(X)
-        dbg("[compute PGX process]: dim.X: ", dim(params$counts)[1], ",", dim(params$counts)[2])
-        dbg("[compute PGX process]: dim.countsX: ", dim(params$countsX)[1], ",", dim(params$countsX)[2])
-        dbg("[compute PGX process]: dim.impX: ", dim(params$impX)[1], ",", dim(params$impX)[2])
-
         path_to_params <- file.path(raw_dir(), "params.RData")
         saveRDS(params, file = path_to_params)
 

--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -22,7 +22,6 @@ upload_table_preview_counts_server <- function(
     height,
     title,
     info.text,
-    upload_datatype,
     caption) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
@@ -52,7 +51,6 @@ upload_table_preview_counts_server <- function(
       dt <- table_data()
       req(!is.null(dt))
 
-      dbg("[preview_counts] is.integer(dt) = ", is.integer(dt))
       is.integer <- is.integer(dt) || all(round(dt) == dt, na.rm = TRUE)
       digits <- ifelse(is.integer, 0, 2)
 
@@ -229,7 +227,6 @@ upload_table_preview_counts_server <- function(
 
     # pass counts to uploaded when uploaded
     observeEvent(input$counts_csv, {
-      dbg("length(input$counts_csv$name) = ", length(input$counts_csv$name))
 
       # check if counts is csv (necessary due to drag and drop of any file)
       ext <- tools::file_ext(input$counts_csv$name)
@@ -270,7 +267,6 @@ upload_table_preview_counts_server <- function(
         uploaded$contrasts.csv <- df
       }
 
-
       sel <- grep("params.RData", input$counts_csv$name)
       if (length(sel)) {
         if (opt$DEVMODE) {
@@ -278,12 +274,6 @@ upload_table_preview_counts_server <- function(
           uploaded$samples.csv <- params$samples
           uploaded$contrasts.csv <- params$contrasts
           uploaded$counts.csv <- params$counts
-          ## recompute_info(
-          ##   list(
-          ##     "name" = params$name,
-          ##     "description" = params$description
-          ##   )
-          ## )
         } else {
           shinyalert::shinyalert(
             title = "Error",
@@ -291,8 +281,10 @@ upload_table_preview_counts_server <- function(
           )
         }
       }
-    }) ## end observeEvent
+      
+    }) ## end observeEvent input$counts.csv
 
+    
     observeEvent(input$remove_counts, {
       delete_all_files_counts <- function(value) {
         if (value) {

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -35,13 +35,13 @@ UploadBoard <- function(id,
     probetype <- shiny::reactiveVal("running")
 
     # add task to detect probetype using annothub
-    ah_task <- ExtendedTask$new(function(organism, probes) {
+    checkprobes_task <- ExtendedTask$new(function(organism, probes) {
       future_promise({
         dbg("[UploadBoard:ExtendedTask.new] detect_probetype started...")
-        probetype0 <- playbase::detect_probetype(organism, probes)
-        dbg("[UploadBoard:ExtendedTask.new] finished! probetype = ", probetype0)
-        if (is.null(probetype0)) probetype0 <- "error"
-        probetype0
+        detected <- playbase::detect_species_probetype(probes,
+          test_species = unique(c(organism, c("Human","Mouse","Rat"))) )
+        dbg("[UploadBoard:ExtendedTask.new] finished!")
+        detected
       })
     })
 
@@ -227,10 +227,11 @@ UploadBoard <- function(id,
     ## Check COUNTS matrix
     ## --------------------------------------------------------
     checked_for_log <- reactiveVal(FALSE)
-
+    organism_checked <- reactiveVal(FALSE)
+    
     uploaded_counts <- shiny::eventReactive(
       {
-        list(uploaded$counts.csv)
+        list(uploaded$counts.csv, upload_organism())
       },
       {
         ## --------------------------------------------------------
@@ -244,7 +245,7 @@ UploadBoard <- function(id,
         checked_for_log(FALSE)
         res <- playbase::pgx.checkINPUT(df0, "COUNTS")
         write_check_output(res$checks, "COUNTS", raw_dir())
-
+        
         # check if error 29 exists (log2 transform detected), give
         # action to user revert to intensities or skip correction.
         if ("e29" %in% names(res$checks)) {
@@ -501,16 +502,6 @@ UploadBoard <- function(id,
         list(status = status, matrix = checked)
       }
     )
-
-    ## output$input_recap <- renderUI({
-    ##   shiny::fluidRow(
-    ##     shiny::column(3, tags$h3(shiny::HTML(paste("<b>Organism:</b> ", upload_organism(), sep = "<br>")))),
-    ##     shiny::column(3, tags$h3(shiny::HTML(paste("<b>Name:</b> ", upload_name(), sep = "<br>")))),
-    ##     shiny::column(3, tags$h3(shiny::HTML(paste("<b>Description:</b> ", upload_description(), sep = "<br>")))),
-    ##     shiny::column(3, tags$h3(shiny::HTML(paste("<b>Data type:</b> ", upload_datatype(), sep = "<br>"))))
-    ##   )
-    ## })
-
 
     output$downloadExampleData <- shiny::downloadHandler(
       filename = "exampledata.zip",
@@ -836,54 +827,79 @@ UploadBoard <- function(id,
         dbg("[UploadBoard] Invoking probetype ExtendedTask")
         probes <- rownames(uploaded$counts.csv)
         probetype("running")
-        ah_task$invoke(upload_organism(), probes)
+        checkprobes_task$invoke(upload_organism(), probes)
       }
     )
 
     observeEvent(
-      ah_task$status(),
+      checkprobes_task$status(),
       {
-        dbg("[observeEvent:ah_task$result] task status = ", ah_task$status())
-        if (ah_task$status() != "success") {
+        dbg("[observeEvent:checkprobes_task$result] task status = ",
+          checkprobes_task$status())
+        if (checkprobes_task$status() != "success") {
           return(NULL)
         }
-        if (ah_task$status() == "error") {
+        if (checkprobes_task$status() == "error") {
           probetype("error")
           return(NULL)
         }
 
-        detected_probetype <- ah_task$result()
+        ## inspect ExtendedTask results
+        detected <- checkprobes_task$result()
         organism <- upload_organism()
+        alt.text <- ""
+        dbg("[UploadBoard:ExtendedTask.new] upload_organism = ", organism)
+        dbg("[UploadBoard:ExtendedTask.new] detect$species = ", detected$species)
+        dbg("[UploadBoard:ExtendedTask.new] detect$probetype = ", detected$probetype)
+        
+        if(!organism %in% detected$species) {
+          detected_probetype <- "error"
+          alt.species <- paste( detected$species, collapse=" or ")
+          if(length(alt.species)) {
+            alt.species <- paste0("<b>",alt.species,"</b>")
+            alt.text <- paste0("Are these perhaps ",alt.species,"?")
+          }
+        } else {
+          detected_probetype <- "error"
+          if(organism %in% names(detected$probetype)) {
+            detected_probetype <- detected$probetype[organism]
+          }
+        }        
+        ##detected_probetype <- detected$probetype
         probetype(detected_probetype) ## set RV
+
         if (detected_probetype == "error") {
           dbg("[UploadBoard] ExtendedTask result has ERROR")
           shinyalert::shinyalert(
             title = "Probes not recognized!",
-            text = paste(
-              "Your probes do not match any probe type for organism <b>",
-              organism, "</b>. Please correct organism or check",
-              "your probe names."
+            text = paste0(
+              "Error. Your probes do not match any probe type for <b>",
+              organism, "</b>. Please check your probe names and select ",
+              "another organism. ", alt.text
             ),
             type = "error",
             size = "s",
             html = TRUE
           )
-        } else {
-          dbg("[UploadBoard] ExtendedTask result SUCCESFUL: detected_probetype = ", detected_probetype)
-          if (0) {
-            shinyalert::shinyalert(
-              title = "Probes OK!",
-              text = paste(
-                "Probe type has been detected successfully.",
-                "\n\nSelected organism: ", organism,
-                "\nDetected probe type: ", detected_probetype
-              ),
-              type = "info",
-              size = "xs"
-            )
-          }
-          dbg()
+        } 
+
+        ## wrong datatype. just give warning. or should we change datatype?
+        if(detected_probetype != "error" &&
+             any(grepl("PROT",detected_probetype)) &&
+             !(upload_datatype() %in% c("proteomics"))) {
+          shinyalert::shinyalert(
+            title = "Is this proteomics data?",
+            text = paste0(
+              "Warning. Your data seems to be <b>proteomics</b> but you have selected ",
+              "<b>", upload_datatype(), "</b> as data type."
+            ),
+            type = "warning",
+            size = "s",
+            html = TRUE
+          )          
         }
+        
+        
       }
     )
 
@@ -891,14 +907,6 @@ UploadBoard <- function(id,
     ## =====================================================================
     ## ===================== PLOTS AND TABLES ==============================
     ## =====================================================================
-
-    ## upload_module_initial_settings_server(
-    ##   id = "initial",
-    ##   upload_organism = upload_organism,
-    ##   upload_datatype = upload_datatype,
-    ##   auth = auth,
-    ##   new_upload = new_upload
-    ## )
 
     upload_table_preview_counts_server(
       id = "counts_preview",
@@ -908,10 +916,8 @@ UploadBoard <- function(id,
       scrollY = "calc(50vh - 140px)",
       width = c("auto", "100%"),
       height = c("100%", TABLE_HEIGHT_MODAL),
-      ##      title = ifelse(tolower(upload_datatype()) == "proteomics", "Uploaded Expression", "Uploaded Counts"),
       title = "Uploaded Counts",
       info.text = "This is the uploaded counts data.",
-      upload_datatype = upload_datatype,
       caption = "This is the uploaded counts data."
     )
 
@@ -992,7 +998,6 @@ UploadBoard <- function(id,
         wizardR::reset("upload_wizard")
 
         # skip upload trigger at first startup
-        dbg("new_upload() = ", new_upload())
         if (new_upload() == 0) {
           return(NULL)
         }

--- a/components/board.upload/R/upload_ui.R
+++ b/components/board.upload/R/upload_ui.R
@@ -6,9 +6,11 @@
 UploadUI <- function(id) {
   ns <- NS(id)
 
-  species1 <- as.character(playbase::SPECIES_TABLE$species_name)
-  species2 <- playbase::allSpecies.ORTHOGENE()
-  AVAILABLE_SPECIES <- c(species1[1:4], intersect(species1, species2))
+  ##species1 <- as.character(playbase::SPECIES_TABLE$species_name)
+  species1 <- playbase::allSpecies.ANNOTHUB()
+  species1 <- sort(unique(c(species1,"Plasmodium falciparum")))
+  AVAILABLE_SPECIES <- c("Human","Mouse","Rat","No organism",species1)
+  AVAILABLE_SPECIES <- c("Human","Mouse","Rat",species1)
 
   body <- div(
     style = "overflow: auto;",


### PR DESCRIPTION
Adding checking and warning of wrong organism (cross checking only human, mouse, rat) in ExtendedTask. Only check the 3 major organisms, this is reasonably fast because we have orgDb for them installed as packages.

![image](https://github.com/user-attachments/assets/2ee66cda-0898-498a-9be8-facc28fef98f)

Is also checks if the probetype is proteomics but the selected datatype is different than 'proteomics'

![image](https://github.com/user-attachments/assets/2e765fa9-02c5-4960-8497-0cccfeb0140e)
