### PR TITLE
Fix #1037:  Hover over plotmodule title gives ugly HTML text

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -231,7 +231,7 @@ PlotModuleUI <- function(id,
     shiny::div(
       class = "plotmodule-title",
       style = "white-space: nowrap; overflow: hidden; text-overflow: clip;",
-      title = title, title
+      title
     ),
     if (cards) {
       plot_cards$navList


### PR DESCRIPTION
This closes #1037 

## Description
The tooltip was looking ugly with the addition of i18n + it added no value having a tooltip that displayed exactly the same text as on the title.

Removed the tooltip on the title.