### PR TITLE
fix: match always with human_ortholog for pcsf

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -639,7 +639,7 @@ app_server <- function(input, output, session) {
 
       ## Beta features
       info("[SERVER] disabling beta features")
-      bigdash.toggleTab(session, "pcsf-tab", show.beta) ## wgcna
+      ## bigdash.toggleTab(session, "pcsf-tab", show.beta) ## wgcna
       bigdash.toggleTab(session, "tcga-tab", show.beta && has.libx)
       toggleTab("drug-tabs", "Connectivity map (beta)", show.beta) ## too slow
       toggleTab("pathway-tabs", "Enrichment Map (beta)", show.beta) ## too slow

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -117,8 +117,7 @@ app_ui <- function(x) {
         ),
         "Clustering" = c(
           clustersamples = "Samples",
-          clusterfeatures = "Features",
-          pcsf = "PCSF (beta)"
+          clusterfeatures = "Features"
         ),
         "Expression" = c(
           diffexpr = "Differential expression",
@@ -139,6 +138,7 @@ app_ui <- function(x) {
         "SystemsBio" = c(
           drug = "Drug connectivity",
           cell = "Cell profiling",
+          pcsf = "PCSF",          
           wgcna = "WGCNA",
           tcga = "TCGA survival (beta)"
         )

--- a/components/board.pcsf/R/pcsf_plot_heatmap.R
+++ b/components/board.pcsf/R/pcsf_plot_heatmap.R
@@ -69,9 +69,9 @@ pcsf_plot_heatmap_server <- function(id,
 
       idx <- res$idx
       genes <- res$genes
-      pgx_input <- pgx$X[res$genes_raw, ]
+      pp <- playbase::map_probes( pgx$genes, genes, column=NULL )
+      pgx_input <- pgx$X[pp, ]
 
-      rownames(pgx_input) <- toupper(rownames(pgx_input))
       playbase::gx.splitmap(
         pgx_input,
         col.annot = pgx$samples,

--- a/components/board.pcsf/R/pcsf_server.R
+++ b/components/board.pcsf/R/pcsf_server.R
@@ -126,7 +126,8 @@ PcsfBoard <- function(id, pgx) {
           ppi = ppi,
           terminals = terminals
         )
-
+        dbg("[pcsf_server.R:pcsf_compute] done!")
+        
         return(out)
       }
     )

--- a/components/board.pcsf/R/pcsf_server.R
+++ b/components/board.pcsf/R/pcsf_server.R
@@ -70,14 +70,7 @@ PcsfBoard <- function(id, pgx) {
 
         # Genes in STRING are based in human genome, thus use ortholog
         genes_raw <- genes
-        if (!pgx$organism %in% c("Human", "human")) {
-          genes_unique <- playbase::probe2symbol(unique(genes), pgx$genes, "human_ortholog")
-          names(genes_unique) <- genes
-          genes <- genes_unique[genes]
-          genes <- genes[genes != ""]
-        }
-
-        genes <- toupper(genes)
+        genes <- playbase::probe2symbol(unique(genes), pgx$genes, "human_ortholog")
         names(idx) <- genes
 
         ## balance number of gene per group??
@@ -89,12 +82,10 @@ PcsfBoard <- function(id, pgx) {
         genes <- genes[which(genes %in% c(STRING$from, STRING$to))]
         rho <- cor(t(pgx$X[genes_raw, ]))
         # Rename cor matrix according to human orthologs
-        if (!pgx$organism %in% c("Human", "human")) {
-          human_gnames <- pgx$genes[rownames(rho), "human_ortholog"]
-          rownames(rho) <- toupper(human_gnames)
-          colnames(rho) <- toupper(human_gnames)
-          rho <- rho[!rownames(rho) == "", !colnames(rho) == ""]
-        }
+        human_gnames <- pgx$genes[rownames(rho), "human_ortholog"]
+        rownames(rho) <- human_gnames
+        colnames(rho) <- human_gnames
+        rho <- rho[!rownames(rho) == "", !colnames(rho) == ""]
         rho.ee <- pmax(rho[cbind(ee$from, ee$to)], 0.001)
         ee$cost <- ee$cost**1 / rho.ee ## balance PPI with experiment
 

--- a/components/board.pcsf/R/pcsf_server.R
+++ b/components/board.pcsf/R/pcsf_server.R
@@ -50,64 +50,78 @@ PcsfBoard <- function(id, pgx) {
 
         NTOP <- 4000
         data(STRING, package = "PCSF")
+
+        ## get foldchanges
         meta <- playbase::pgx.getMetaMatrix(pgx)$fc
+
+        ## Genes in STRING are based in human genome, thus use
+        ## ortholog. For now we collapse to human gene. maybe in
+        ## future we may keep original features and use map features
+        ## to symbol when creating STRING edges. For now this is
+        ## simpler...
+        meta <- playbase::rename_by(meta, pgx$genes, "human_ortholog")
         mx <- rowMeans(meta**2, na.rm = TRUE)**0.5
         genes <- head(names(mx)[order(-abs(mx))], NTOP)
+
+        ## compute gene weight for number of gene sets that they are
+        ## in. this is used to prioritize genes later.
         gsmeta <- playbase::pgx.getMetaMatrix(pgx, level = "geneset")$fc
         rx <- rowMeans(gsmeta**2, na.rm = TRUE)**0.5
         top.gs <- head(names(sort(-abs(rx))), 1000)
-        ngmt <- Matrix::rowSums(pgx$GMT[, top.gs] != 0, na.rm = TRUE)
+
+        ## GMT has organism specific symbol, but we need to map to
+        ## human ortholog
+        G <- pgx$GMT[, top.gs]        
+        G <- playbase::rename_by(G, pgx$genes, from_id="symbol",
+                                 new_id = "human_ortholog")
+        ngmt <- Matrix::rowSums(G != 0, na.rm = TRUE)
         ngmt <- log(1 + ngmt)
 
         ## ------------ find gene clusters --------------
+
+        ## also X needs to be in human ortholog
+        X <- playbase::rename_by(pgx$X, pgx$genes, "human_ortholog")        
+        X <- X[genes,]
         clust <- playbase::pgx.FindClusters(
-          X = scale(t(pgx$X[genes, ])),
+          X = scale(t(X)),
           method = c("kmeans"),
           top.sd = 1000, npca = 40
         )
 
-        idx <- clust[["kmeans"]][, 3]
-
-        # Genes in STRING are based in human genome, thus use ortholog
-        genes_raw <- genes
-        genes <- playbase::probe2symbol(unique(genes), pgx$genes, "human_ortholog")
+        ## take the minimum level that has at least 2 clusters
+        nclust <- apply( clust[["kmeans"]], 2, function(x) length(table(x)))
+        sel <- min(which(nclust > 1))
+        idx <- clust[["kmeans"]][, sel]
         names(idx) <- genes
-
+        idx <- idx[!duplicated(names(idx))]
+        
         ## balance number of gene per group??
-        genes <- unlist(tapply(genes, idx[genes], function(gg) head(gg, 800)))
-
+        genes <- unlist(tapply(names(idx), idx, function(gg) head(gg, 800)))
+        genes <- as.vector(genes)
+        idx <- idx[genes]
+        
         ## ------------ create edge table --------------
         sel <- (STRING$from %in% genes & STRING$to %in% genes)
         ee <- STRING[sel, ]
         genes <- genes[which(genes %in% c(STRING$from, STRING$to))]
-        rho <- cor(t(pgx$X[genes_raw, ]))
-        # Rename cor matrix according to human orthologs
-        human_gnames <- pgx$genes[rownames(rho), "human_ortholog"]
-        rownames(rho) <- human_gnames
-        colnames(rho) <- human_gnames
-        rho <- rho[!rownames(rho) == "", !colnames(rho) == ""]
-        rho.ee <- pmax(rho[cbind(ee$from, ee$to)], 0.001)
+
+        # Create cost matrix from correlation
+        rho <- cor(t(X[genes, ]))
+        rho.ee <- pmax( rho[cbind(ee$from, ee$to)], 1e-4)
         ee$cost <- ee$cost**1 / rho.ee ## balance PPI with experiment
 
         ## ------------ create igraph network --------------
         ppi <- PCSF::construct_interactome(ee)
-        if (!pgx$organism %in% c("Human", "human")) {
-          gene_symbols <- playbase::probe2symbol(genes_raw, pgx$genes, "symbol")
-          gset.wt <- (ngmt[gene_symbols] / max(ngmt[gene_symbols], na.rm = TRUE))
-          terminals <- abs(mx[genes_raw])**1 * (0.1 + gset.wt)**1
-        } else {
-          gset.wt <- (ngmt[genes_raw] / max(ngmt[genes_raw])) ## gene set weighting
-          terminals <- abs(mx[genes_raw])**1 * (0.1 + gset.wt)**1
-        }
-        meta <- meta[genes_raw, , drop = FALSE]
-        rownames(meta) <- toupper(rownames(meta))
-        names(terminals) <- toupper(names(terminals))
-
+        ## gene set weighting. give more weight to genes that are in
+        ## many gene sets.
+        gset.wt <- (ngmt[genes] / max(ngmt[genes])) 
+        terminals <- abs(mx[genes])**1 * (0.1 + gset.wt)**1
+        
         out <- list(
           genes = genes,
-          genes_raw = genes_raw,
           meta = meta,
-          idx = idx[genes],
+          X = X,
+          idx = idx,
           clust = clust,
           ppi = ppi,
           terminals = terminals

--- a/components/board.pcsf/R/pcsf_table_centrality.R
+++ b/components/board.pcsf/R/pcsf_table_centrality.R
@@ -1,0 +1,121 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+##
+
+#' UI code for table code: expression board
+#'
+#' @param id
+#' @param label
+#' @param height
+#' @param width
+#'
+#' @export
+pcsf_table_centrality_ui <- function(
+    id,
+    title,
+    info.text,
+    caption,
+    width,
+    height) {
+  ns <- shiny::NS(id)
+
+  table_opts <- shiny::tagList(
+    withTooltip(shiny::checkboxInput(ns("showq"), "show q-values", FALSE),
+      "Show q-values next to FC values.",
+      placement = "right", options = list(container = "body")
+    )
+  )
+
+  TableModuleUI(
+    ns("datasets"),
+    info.text = info.text,
+    caption = caption,
+    width = width,
+    height = height,
+    options = table_opts,
+    title = title,
+  )
+}
+
+#' Server side table code: expression board
+#'
+#' @param id
+#' @param watermark
+#'
+#' @export
+pcsf_table_centrality__server <- function(id,
+                                          pgx,
+                                          res, # filteredDiffExprTable
+                                          metaFC,
+                                          metaQ,
+                                          height,
+                                          scrollY,
+                                          watermark = FALSE) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    table.RENDER <- shiny::reactive({
+      res <- res()
+      if (is.null(res) || nrow(res) == 0) {
+        return(NULL)
+      }
+      df <- data.frame()
+      ## try(pcsf <- playbase::pgx.computePCSF(pgx, contrast = ct, ntop = 250))
+      
+      ##df <- playbase::pgx.getPCSFcentrality(
+      ##  pgx, contrast=ct, pcsf=pcsf, n=10, plot=FALSE))
+
+      
+      dt <- DT::datatable(df,
+        rownames = FALSE,
+        extensions = c("Scroller"),
+        plugins = "scrollResize",
+        selection = list(mode = "single", target = "row", selected = c(1)),
+        fillContainer = TRUE,
+        options = list(
+          dom = "lfrtip",
+          ## pageLength = 20,##  lengthMenu = c(20, 30, 40, 60, 100, 250),
+          scrollX = TRUE,
+          scrollResize = TRUE,
+          scrollY = scrollY,
+          scroller = TRUE,
+          deferRender = TRUE
+        ) ## end of options.list
+      ) %>%
+        DT::formatStyle(0, target = "row", fontSize = "11px", lineHeight = "70%") %>%
+        DT::formatSignif(columns = fc.cols, digits = 4) %>%
+        DT::formatStyle(
+          "rms.FC",
+          background = color_from_middle(fc.rms, "lightblue", "#f5aeae"),
+          backgroundSize = "98% 88%", backgroundRepeat = "no-repeat",
+          backgroundPosition = "center"
+        ) %>%
+        DT::formatStyle(
+          fc.cols,
+          background = color_from_middle(F, "lightblue", "#f5aeae"),
+          backgroundSize = "98% 88%", backgroundRepeat = "no-repeat",
+          backgroundPosition = "center"
+        )
+
+      if (length(qv.cols) > 0) {
+        dt <- dt %>%
+          DT::formatSignif(columns = qv.cols, digits = 4)
+      }
+      return(dt)
+    })
+
+    table.RENDER_modal <- shiny::reactive({
+      dt <- fctable.RENDER()
+      dt$x$options$scrollY <- SCROLLY_MODAL
+      return(dt)
+    })
+
+    TableModuleServer(
+      "centrality",
+      func = table.RENDER,
+      func2 = table.RENDER_modal,
+      selector = "none"
+    )
+  }) # end module server
+} # end server

--- a/components/board.pcsf/R/pcsf_ui.R
+++ b/components/board.pcsf/R/pcsf_ui.R
@@ -43,7 +43,7 @@ PcsfInputs <- function(id) {
     ),
     hr(),
     withTooltip(
-      shiny::sliderInput(ns("pcsf_beta"), "Solution size:", -5, 5, -3, 0.5),
+      shiny::sliderInput(ns("pcsf_beta"), "Solution size:", -4, 4, -2, 1),
       "Select contrast.",
       placement = "right"
     ),

--- a/components/board.pcsf/R/pcsf_ui.R
+++ b/components/board.pcsf/R/pcsf_ui.R
@@ -14,7 +14,7 @@ PcsfInputs <- function(id) {
         ns("colorby"),
         "Color nodes by:",
         choices = c("gene.cluster", "contrast"),
-        selected = "gene.cluster",
+        selected = "contrast",
         inline = TRUE
       ),
       "Choose how to color the nodes",
@@ -43,7 +43,7 @@ PcsfInputs <- function(id) {
     ),
     hr(),
     withTooltip(
-      shiny::sliderInput(ns("pcsf_beta"), "Solution size:", -4, 4, -2, 1),
+      shiny::sliderInput(ns("pcsf_beta"), "Solution size:", -4, 4, 0, 1),
       "Select contrast.",
       placement = "right"
     ),
@@ -106,6 +106,14 @@ PcsfUI <- function(id) {
               height = c("100%", "75vh"),
               width = c("auto", "100%")
             )
+            ## pcsf_table_centrality_ui(
+            ##   ns("centrality_table"),
+            ##   title = tspan("Gene centrality"),
+            ##   info.text = "",
+            ##   caption = "Table showing the centrality score of genes.",
+            ##   width = c("100%", "100%"),
+            ##   height = c("100%", TABLE_HEIGHT_MODAL)
+            ## )
           )
         )
       )


### PR DESCRIPTION
## Description
Make sure that for all types of data/organisms the human ortholog names are used in order to match with PCSF data.