### PR TITLE
fix: call correct colMeans method

### DIFF
--- a/components/board.pathway/R/pathway_enrichmap.R
+++ b/components/board.pathway/R/pathway_enrichmap.R
@@ -93,7 +93,7 @@ compute_enrichmentmap <- function(pgx, qsig = 0.05, ntop = 120, wt = 1, contrast
 
   ## marker genes for each cluster
   gset <- V(graph)$name
-  gs.genes <- tapply(V(graph)$name, cl$membership, function(s) names(which(colMeans(G[s, ] != 0) > 0.2)))
+  gs.genes <- tapply(gset, cl$membership, function(s) names(which(Matrix::colMeans(G[s, ] != 0) > 0.2)))
   unique.genes <- names(which(table(unlist(gs.genes)) == 1))
   marker.genes <- lapply(gs.genes, function(gg) intersect(gg, unique.genes))
 


### PR DESCRIPTION
## Description
Because not calling the correct `colMeans` method, this error was occurring
![image](https://github.com/user-attachments/assets/35388466-d724-49f2-b396-8bf21466c8ac)

By calling the `colMeans` method from the `Matrix` library specifically, the plot is displayed correctly.
![image](https://github.com/user-attachments/assets/8847e62e-b2e7-4f67-8623-880b4366c6b6)
