### PR TITLE
Allow custom annotation columns in the counts.csv file

### DIFF
--- a/components/board.dataview/R/dataview_table_rawdata.R
+++ b/components/board.dataview/R/dataview_table_rawdata.R
@@ -13,10 +13,23 @@ dataview_table_rawdata_ui <- function(
     info.text) {
   ns <- shiny::NS(id)
 
+
+  options <- shiny::tagList(
+    withTooltip(
+      shiny::checkboxInput(
+        ns("show_full_table"),
+        "show full annotation",
+        FALSE
+      ),
+      "Show full table. Show all feature annotation columns."
+    )
+  )
+  
   TableModuleUI(
     ns("datasets"),
     info.text = info.text,
     caption = caption,
+    options = options,
     width = width,
     height = height,
     title = title
@@ -49,48 +62,6 @@ dataview_table_rawdata_server <- function(id,
       if (is.null(gene) || gene == "" || is.na(gene)) {
         gene <- rownames(pgx$X)[1]
       }
-
-      ## if (data_type %in% c("counts", "abundance","linear")) {
-      ##   x <- parse_sample(pgx$counts)
-      ##   x_cpm <- parse_sample(pgx$X)
-      ## } else {
-      ##   ## log2CPM
-      ##   x <- parse_sample(pgx$X)
-      ## }
-      ## x0 <- x
-      ## ## Quickly (?) calculated correlation to selected gene
-      ## ## compute statistics
-      ## rho <- sdx <- avg <- NULL
-      ## if (data_type == "counts") {
-      ##   xgenes <- pgx$genes[rownames(x), "gene_name"]
-      ##   k <- which(xgenes == gene)
-      ##   xgenes_cpm <- pgx$genes[rownames(x_cpm), "gene_name"]
-      ##   k_cpm <- which(xgenes_cpm == gene)
-      ## } else {
-      ##   ## log2CPM
-      ##   xgenes <- pgx$genes[rownames(x), "gene_name"]
-      ##   k <- which(xgenes == gene)
-      ## }
-      ## if (data_type == "counts") {
-      ##   # compute the geometric mean, exp(mean(log(x+1)))
-      ##   logx <- log(x[rownames(x), ] + 1)
-      ##   # correlation should be equal between counts and logCPM, use logCPM
-      ##   rho <- cor(t(x_cpm[, colnames(x)]), x_cpm[k_cpm, colnames(x)], use = "pairwise")[, 1]
-      ##   rho <- round(rho[rownames(x_cpm)], digits = 3)
-      ##   rho <- rho[match(rownames(x), names(rho))]
-      ##   names(rho) <- rownames(x)
-      ##   # geometric std deviation
-      ##   sdx <- round(exp(apply(logx[, samples], 1, sd, na.rm = TRUE)), digits = 3)
-      ##   # geometric mean
-      ##   avg <- round(exp(rowMeans(logx, na.rm = TRUE)), digits = 3)
-      ## } else {
-      ##   # compute the geometric mean, mean(x)
-      ##   logx <- x
-      ##   rho <- cor(t(logx[, samples]), logx[k, samples], use = "pairwise")[, 1]
-      ##   rho <- round(rho[rownames(logx)], digits = 3)
-      ##   sdx <- round(apply(logx[, samples], 1, sd, na.rm = TRUE), digits = 3)
-      ##   avg <- round(rowMeans(logx, na.rm = TRUE), digits = 3)
-      ## }
 
       logx <- parse_sample(pgx$X)
       if (data_type == "counts") {
@@ -135,28 +106,27 @@ dataview_table_rawdata_server <- function(id,
         return(NULL)
       }
 
-      dbg("[dataview_rawdata:table_data] create dataframe")
+      ## create final dataframe
       pp <- rownames(x)
-      feature <- pgx$genes[pp, "feature"]
-      symbol <- pgx$genes[pp, "symbol"]
-      gene.title <- pgx$genes[pp, "gene_title"]
-      gene.title <- substring(gene.title, 1, 50)
+      annot <- pgx$genes[pp,]
+      if(!input$show_full_table) {
+        annot <- annot[,c("feature","symbol","gene_title")]
+      }
+      annot$gene_title <- substring(annot$gene_title, 1, 50)
+      if (mean(head(annot$feature, 1000) == head(annot$symbol, 1000)) > 0.8) {
+        annot$symbol <- NULL
+      }
 
       df <- data.frame(
-        feature = feature,
-        symbol = symbol,
-        title = gene.title,
+        annot,
         rho = rho,
         SD = sdx,
         AVG = avg,
         as.matrix(x),
         check.names = FALSE
       )
-
+      
       ## if symbol and feature as same, drop symbol column
-      if (mean(head(df$feature, 1000) == head(df$symbol, 1000)) > 0.8) {
-        df$symbol <- NULL
-      }
       df <- df[order(-df$rho, -df$SD), , drop = FALSE]
 
       list(

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -16,6 +16,7 @@ upload_module_computepgx_server <- function(
     norm_method,
     samplesRT,
     contrastsRT,
+    annotRT = reactive(NULL),
     raw_dir,
     metaRT,
     lib.dir,
@@ -407,7 +408,6 @@ upload_module_computepgx_server <- function(
       PROCESS_LIST <- list()
       computedPGX <- shiny::reactiveVal(NULL)
       custom_geneset <- list(gmt = NULL, info = NULL)
-      annot_table <- NULL
       processx_error <- list(user_email = NULL, pgx_name = NULL, pgx_path = NULL, error = NULL)
 
       ## react on custom GMT upload
@@ -501,6 +501,11 @@ upload_module_computepgx_server <- function(
         samples <- samplesRT()
         samples <- data.frame(samples, stringsAsFactors = FALSE, check.names = FALSE)
         contrasts <- as.matrix(contrastsRT())
+        annot_table <- annotRT()
+
+        dbg("[upload_module_computepgx_server] dim(annot_table) = ", dim(annot_table))
+        
+        ## annot_table <- NULL  ## DISABLED FOR NOW
 
         ## -----------------------------------------------------------
         ## Set statistical methods and run parameters
@@ -559,7 +564,6 @@ upload_module_computepgx_server <- function(
           # Extra tables
           annot_table = annot_table,
           custom.geneset = custom_geneset,
-
           # Options
           batch.correct = FALSE,
           norm_method = norm_method,

--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -251,6 +251,10 @@ upload_table_preview_counts_server <- function(
       if (length(sel)) {
         df <- playbase::read_counts(input$counts_csv$datapath[sel[1]])
         uploaded$counts.csv <- df
+
+        ## if counts file contains annotation
+        af <- playbase::read_annot(input$counts_csv$datapath[sel[1]])
+        uploaded$annot.csv <- af
       }
 
       sel <- grep("samples", tolower(input$counts_csv$name))

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -102,9 +102,9 @@ UploadBoard <- function(id,
     })
 
 
-    ## ================================================================================
-    ## ====================== NEW DATA UPLOAD =========================================
-    ## ================================================================================
+    ## ============================================================================
+    ## ================== NEW DATA UPLOAD =========================================
+    ## ============================================================================
 
     ## keeps track of how pgx was obtained: uploaded or computed. NEED
     ## RETHINK: is this robust to multiple users on same R process?
@@ -117,20 +117,6 @@ UploadBoard <- function(id,
       ignoreNULL = TRUE
     )
 
-
-    shiny::observeEvent(
-      {
-        list(uploaded, input$tabs)
-      },
-      {
-        dbg("[upload_server:observeEvent(names.uploaded)] names(uploaded) = ", names(uploaded))
-        dbg("[upload_server:observeEvent(names.uploaded)] input$tabs = ", input$tabs)
-        if (is.null(uploaded$counts.csv) && is.null(uploaded$samples.csv)) {
-          dbg("[upload_server:observeEvent(names.uploaded)] *** UPLOADED EMPTY *** ")
-        }
-      },
-      ignoreNULL = FALSE
-    )
 
     shiny::observeEvent(uploaded_pgx(), {
       new_pgx <- uploaded_pgx()
@@ -517,6 +503,27 @@ UploadBoard <- function(id,
       }
     )
 
+
+    ## --------------------------------------------------------
+    ## Check annotation matrix
+    ## --------------------------------------------------------
+    checked_annot <- shiny::eventReactive(
+    {
+        list(uploaded$annot.csv, uploaded$counts.csv)
+      }, {
+
+        shiny::req(nrow(uploaded$annot.csv) &&  nrow(uploaded$counts.csv))
+        
+        status <- "OK"
+        checked <- uploaded$annot.csv
+        
+        list(status = status, matrix = checked)
+      })
+
+    ## --------------------------------------------------------
+    ## Download example data
+    ## --------------------------------------------------------
+
     output$downloadExampleData <- shiny::downloadHandler(
       filename = "exampledata.zip",
       content = function(file) {
@@ -600,6 +607,7 @@ UploadBoard <- function(id,
       norm_method = corrected1$norm_method(),
       samplesRT = shiny::reactive(checked_samples_counts()$SAMPLES),
       contrastsRT = modified_ct,
+      annotRT = shiny::reactive(checked_annot()$matrix),
       raw_dir = raw_dir,
       metaRT = shiny::reactive(uploaded$meta),
       upload_organism = upload_organism,
@@ -650,7 +658,7 @@ UploadBoard <- function(id,
         result_alert <- NULL
 
         if (summary_check_content > 0) {
-          # chekc which checks have error results
+          # check which checks have error results
           find_content <- !sapply(
             summary_checks,
             function(x) is.null(x) || length(x) == 0


### PR DESCRIPTION
Allow extra custom annotation columns in the counts.csv file which can be shown in the DataView/DataTable with a checkbox 'show full table'. This allows users to add extra feature annotation columns. Any columns that overlap with OPG will overwrite our annotation so in principle this can be used for custom annotation of non-supported organisms, or if users want to use a specific annotation

PS1. Tried with mpoc PTM data.
PS2. Needs latest updated playbase with new read_annot() function
PS3. This could also be used for custom-annotation for non-supported species. Most people seems to have gene annotation and expression values in one file.

![image](https://github.com/user-attachments/assets/389c5e44-703b-43c1-837d-f187c632e659)

