### PR TITLE
fix: color ALL significative genes

### DIFF
--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -327,8 +327,8 @@ ExpressionBoard <- function(id, pgx) {
       res <- fullDiffExprTable()
       features <- input$gx_features
       fam.genes <- res$symbol
-      fdr <- input$gx_fdr
-      lfc <- input$gx_lfc
+      fdr <- as.numeric(input$gx_fdr)
+      lfc <- as.numeric(input$gx_lfc)
       if (features != "<all>") {
         gset <- playdata::getGSETS(features)
         fam.genes <- unique(unlist(gset))


### PR DESCRIPTION
## Description
Not converting the thresholds to class numeric was causing some detection issues

### Before (example-data)
![image](https://github.com/user-attachments/assets/bfcc32a3-fe34-404b-8d42-1bce72f35ad8)

### After (example-data)
![image](https://github.com/user-attachments/assets/995e7127-6e32-4b4c-8a43-f241f7809b09)
