### PR TITLE
Wizard bug

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -484,22 +484,16 @@ upload_module_computepgx_server <- function(
         }
         shiny::req(!(p %in% c("error", "running", ""))) ## wait for process??
 
-
-        ## max.datasets <- as.integer(auth$options$MAX_DATASETS)
-        ## pgxdir <- auth$user_dir
-        ## numpgx <- length(dir(pgxdir, pattern = "*.pgx$"))
-        ## if (!auth$options$ENABLE_DELETE) {
-        ##   numpgx <- length(dir(pgxdir, pattern = "*.pgx$|*.pgx_$")) ## count deleted...
-        ## }
-        ## if (numpgx >= max.datasets) {
-        ##   shinyalert_storage_full(numpgx, max.datasets) ## from ui-alerts.R
-        ##   return(NULL)
-        ## }
-
         ## -----------------------------------------------------------
         ## Retrieve the most recent matrices from reactive values
         ## -----------------------------------------------------------
+
+        dbg("[UploadBoard:observe.upload_wizard] 1: !!!!")
+
         counts <- countsRT()
+
+        dbg("[UploadBoard:observe.upload_wizard] 2: !!!!")
+        
         countsX <- countsX()
         impX <- impX()
         samples <- samplesRT()
@@ -571,7 +565,7 @@ upload_module_computepgx_server <- function(
           custom.geneset = custom_geneset,
           # Options
           batch.correct = FALSE,
-          norm_method = norm_method,
+          norm_method = norm_method(),
           ## normalize = do.normalization,
           prune.samples = TRUE,
           filter.genes = filter.genes,

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -824,11 +824,8 @@ UploadBoard <- function(id,
       ),
       {
         req(input$upload_wizard == "step_compute")
-
-        dbg("[UploadServer:observe] LOCKING observer")
         
         pgx_files <- playbase::pgxinfo.read(auth$user_dir, file = "datasets-info.csv")
-
         if (!is.null(upload_name()) && upload_name() %in% pgx_files$dataset) {
           shinyalert::shinyalert(
             title = "Invalid name",

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -628,31 +628,39 @@ UploadBoard <- function(id,
       is.count = TRUE
     )
 
+    corrected2 <- reactiveValues()
+    observe({
+      corrected2$counts <- corrected1$counts()
+      corrected2$X <- corrected1$X()
+      corrected2$impX <- corrected1$impX()       
+    })
+        
     computed_pgx <- upload_module_computepgx_server(
       id = "compute",
-      ## countsRT = shiny::reactive(checked_samples_counts()$COUNTS),
-      ## countsRT = corrected1$counts,
-      countsRT = corrected1$counts,
-      countsX = corrected1$X,
-      impX = corrected1$impX,
-      norm_method = corrected1$norm_method(),
+#      countsRT = corrected1$counts,
+#      countsX = corrected1$X,
+#      impX = corrected1$impX,
+      countsRT = reactive(corrected2$counts),
+      countsX = reactive(corrected2$X),
+      impX = reactive(corrected2$impX),
+      norm_method = shiny::reactive(corrected1$norm_method()),
       samplesRT = shiny::reactive(checked_samples_counts()$SAMPLES),
       contrastsRT = modified_ct,
       annotRT = shiny::reactive(checked_annot()$matrix),
       raw_dir = raw_dir,
       metaRT = shiny::reactive(uploaded$meta),
-      upload_organism = upload_organism,
-      alertready = FALSE,
       lib.dir = FILES,
       auth = auth,
       create_raw_dir = create_raw_dir,
+      alertready = FALSE,
       height = "100%",
       recompute_info = recompute_info,
       inactivityCounter = inactivityCounter,
       upload_wizard = reactive(input$upload_wizard),
-      upload_datatype = upload_datatype,
       upload_name = upload_name,
       upload_description = upload_description,
+      upload_datatype = upload_datatype,
+      upload_organism = upload_organism,
       upload_gx_methods = upload_gx_methods,
       upload_gset_methods = upload_gset_methods,
       process_counter = process_counter,
@@ -817,6 +825,8 @@ UploadBoard <- function(id,
       {
         req(input$upload_wizard == "step_compute")
 
+        dbg("[UploadServer:observe] LOCKING observer")
+        
         pgx_files <- playbase::pgxinfo.read(auth$user_dir, file = "datasets-info.csv")
 
         if (!is.null(upload_name()) && upload_name() %in% pgx_files$dataset) {


### PR DESCRIPTION
There was reported a but that at the final compute step the wizard resets to the beginning. I could replicate this error. It seems bit depending on the dataset and whether batchcorrection was done or not. App gets "stuck" and resets at computation step https://github.com/bigomics/omicsplayground/blob/6bdc181c08db75c5b09b910b93d895fba99b37e1/components/board.upload/R/upload_module_computepgx.R#L491
just before calling countsRT()

Really strange bug. My solution was to introduce reactiveValues in UploadServer that copies the reactive outputs from NormalizationModule. This is done as corrected2:

https://github.com/bigomics/omicsplayground/blob/6bdc181c08db75c5b09b910b93d895fba99b37e1/components/board.upload/R/upload_server.R#L631C1-L636C7

Bug seems fixed.

Data used was mouse proteomics data. Ask me for dataset.