### PR TITLE
Clean info + up/down coloring

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -15,18 +15,6 @@ enrichment_plot_volcano_ui <- function(
     width) {
   ns <- shiny::NS(id)
 
-  plot_opts <- shiny::tagList(
-    withTooltip(
-      shiny::checkboxInput(
-        inputId = ns("color_up_down"),
-        label = "Color up/down regulated",
-        value = TRUE
-      ),
-      "Color up/down regulated features.",
-      placement = "left", options = list(container = "body")
-    )
-  )
-
   PlotModuleUI(
     ns("plot"),
     title = title,
@@ -40,7 +28,6 @@ enrichment_plot_volcano_ui <- function(
     caption = caption,
     plotlib = "plotly",
     plotlib2 = "plotly",
-    options = plot_opts,
     download.fmt = c("png", "pdf")
   )
 }
@@ -112,7 +99,7 @@ enrichment_plot_volcano_server <- function(id,
         marker.size = 3,
         displayModeBar = FALSE,
         showlegend = FALSE,
-        color_up_down = input$color_up_down
+        color_up_down = TRUE
       ) %>%
         plotly::layout(margin = list(b = 60))
     })

--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -26,15 +26,6 @@ enrichment_plot_volcanoall_ui <- function(
         inline = TRUE, selected = "No"
       ),
       "Number of top genesets to consider for counting the gene frequency."
-    ),
-    withTooltip(
-      shiny::checkboxInput(
-        inputId = ns("color_up_down"),
-        label = "Color up/down regulated",
-        value = TRUE
-      ),
-      "Color up/down regulated features.",
-      placement = "left", options = list(container = "body")
     )
   )
 
@@ -134,7 +125,7 @@ enrichment_plot_volcanoall_server <- function(id,
         n_rows = n_rows,
         margin_l = margin_l,
         margin_b = margin_b,
-        color_up_down = input$color_up_down,
+        color_up_down = TRUE,
         by_sig = FALSE,
         highlight = pd[["gset_selected"]],
         label = pd[["gset_selected"]]

--- a/components/board.enrichment/R/enrichment_plot_volcanomethods.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanomethods.R
@@ -20,15 +20,6 @@ enrichment_plot_volcanomethods_ui <- function(
     withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", TRUE),
       "Scale the volcano plots individually per method..",
       placement = "right", options = list(container = "body")
-    ),
-    withTooltip(
-      shiny::checkboxInput(
-        inputId = ns("color_up_down"),
-        label = "Color up/down regulated",
-        value = TRUE
-      ),
-      "Color up/down regulated features.",
-      placement = "left", options = list(container = "body")
     )
   )
 
@@ -117,7 +108,7 @@ enrichment_plot_volcanomethods_server <- function(id,
         n_rows = n_rows,
         margin_l = margin_l,
         margin_b = margin_b,
-        color_up_down = input$color_up_down,
+        color_up_down = TRUE,
         label = label,
         highlight = highlight,
         by_sig = FALSE

--- a/components/board.enrichment/R/enrichment_ui.R
+++ b/components/board.enrichment/R/enrichment_ui.R
@@ -127,7 +127,7 @@ EnrichmentUI <- function(id) {
         enrichment_plot_volcano_ui(
           ns("subplot_volcano"),
           title = "Volcano plot",
-          info.text = "Volcano-plot showing significance versus fold-change for the selected {Contrast}. By selecting a geneset on the Enrichment analysis table, the genes from it will be highlighted. The plot can be colored by using the {Color up/down regulated} plot setting.",
+          info.text = "Volcano-plot showing significance versus fold-change for the selected {Contrast}. By selecting a geneset on the Enrichment analysis table, the genes from it will be highlighted.",
           info.methods = "Statistical significance assessed using three independent statistical methods: DESeq2 (Wald test) [1], edgeR (QLF test) [2] and limma-trend [3]. The maximum q-value of the three methods is taken as aggregate q-value, which corresponds to taking the intersection of significant genes from all three tests.",
           info.references = list(
             list(
@@ -255,7 +255,7 @@ EnrichmentUI <- function(id) {
         enrichment_plot_volcanoall_ui(
           id = ns("volcanoAll"),
           title = "Volcano plots for all contrasts",
-          info.text = "Volcano plot of genesets for all contrasts displaying fold-change versus significance. The plots can be colored by using the {Color up/down regulated} plot setting; also the plots can be scaled using the {scale per method} plot setting.",
+          info.text = "Volcano plot of genesets for all contrasts displaying fold-change versus significance. The plots can be scaled using the {scale per method} plot setting.",
           info.methods = "Statistical significance assessed using three independent statistical methods: DESeq2 (Wald test) [1], edgeR (QLF test) [2] and limma-trend [3]. The maximum q-value of the three methods is taken as aggregate q-value, which corresponds to taking the intersection of significant genes from all three tests. By comparing multiple volcano plots, it can immediately be seen which comparison is statistically weak or strong.",
           info.references = list(
             list(
@@ -286,7 +286,7 @@ EnrichmentUI <- function(id) {
         enrichment_plot_volcanomethods_ui(
           ns("volcanoMethods"),
           title = "Volcano plots for all methods",
-          info.text = "Volcano plot of genesets for the selected {Contrast} displaying fold-change versus significance. The plots can be colored by using the {Color up/down regulated} plot setting; also the plots can be scaled using the {scale per method} plot setting.",
+          info.text = "Volcano plot of genesets for the selected {Contrast} displaying fold-change versus significance. The plots can be scaled using the {scale per method} plot setting.",
           info.methods = "Statistical significance assessed using multiple statistical methods: DESeq2 (Wald test) [1], edgeR (QLF test) [2] and limma-trend [3]. By comparing multiple volcano plots, it can immediately be seen which method is statistically weak or strong.",
           info.references = list(
             list(

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -24,17 +24,6 @@ expression_plot_volcano_ui <- function(id,
                                        height,
                                        width) {
   ns <- shiny::NS(id)
-  plot_opts <- shiny::tagList(
-    withTooltip(
-      shiny::checkboxInput(
-        inputId = ns("color_up_down"),
-        label = "Color up/down regulated",
-        value = TRUE
-      ),
-      "Color up/down regulated features.",
-      placement = "left", options = list(container = "body")
-    )
-  )
 
   PlotModuleUI(
     ns("pltmod"),
@@ -44,8 +33,6 @@ expression_plot_volcano_ui <- function(id,
     info.methods = info.methods,
     info.references = info.references,
     info.extra_link = info.extra_link,
-    ##    options = plot_opts,
-    options = NULL,
     title = title,
     caption = caption,
     download.fmt = c("png", "pdf", "csv"),

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -30,15 +30,6 @@ expression_plot_volcanoAll_ui <- function(id,
       "Scale each volcano plots individually.",
       placement = "right", options = list(container = "body")
     )
-    ## withTooltip(
-    ##   shiny::checkboxInput(
-    ##     inputId = ns("color_up_down"),
-    ##     label = "Color up/down regulated",
-    ##     value = TRUE
-    ##   ),
-    ##   "Color up/down regulated features.",
-    ##   placement = "left", options = list(container = "body")
-    ## )
   )
 
   PlotModuleUI(

--- a/components/board.expression/R/expression_ui.R
+++ b/components/board.expression/R/expression_ui.R
@@ -89,7 +89,7 @@ ExpressionUI <- function(id) {
         expression_plot_volcano_ui(ns("plots_volcano"),
           label = "a",
           title = "Volcano plot",
-          info.text = "Volcano plot of genes for the selected {Contrast} displaying fold-change versus significance. By selecting a specific gene under the Differential expression analysis table it will be highlighted. Similarly, if a geneset is selected under the Gene sets with gene table it will be highlighted. The plot can be colored by using the {Color up/down regulated} plot setting.",
+          info.text = "Volcano plot of genes for the selected {Contrast} displaying fold-change versus significance. By selecting a specific gene under the Differential expression analysis table it will be highlighted. Similarly, if a geneset is selected under the Gene sets with gene table it will be highlighted.",
           info.methods = "Statistical significance assessed using three independent statistical methods: DESeq2 (Wald test) [1], edgeR (QLF test) [2] and limma-trend [3]. The maximum q-value of the three methods is taken as aggregate q-value, which corresponds to taking the intersection of significant genes from all three tests.",
           info.references = list(
             list(
@@ -113,7 +113,7 @@ ExpressionUI <- function(id) {
         expression_plot_maplot_ui(
           id = ns("plots_maplot"),
           title = "MA plot",
-          info.text = "MA plot of genes for the selected {Contrast} displaying fold-change (M-values) versus the mean intensity (A-values). By selecting a specific gene under the Differential expression analysis table it will be highlighted. Similarly, if a geneset is selected under the Gene sets with gene table it will be highlighted. The plot can be colored by using the {Color up/down regulated} plot setting.",
+          info.text = "MA plot of genes for the selected {Contrast} displaying fold-change (M-values) versus the mean intensity (A-values). By selecting a specific gene under the Differential expression analysis table it will be highlighted. Similarly, if a geneset is selected under the Gene sets with gene table it will be highlighted.",
           info.methods = "See Volcano plot",
           info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#statistical-testing",
           caption = "MA-plot displaying signal intensity versus fold-change.",

--- a/components/board.featuremap/R/featuremap_ui.R
+++ b/components/board.featuremap/R/featuremap_ui.R
@@ -88,8 +88,8 @@ FeatureMapUI <- function(id) {
             featuremap_plot_gene_map_ui(
               ns("geneUMAP"),
               title = "Feature UMAP",
-              info.text = "UMAP clustering of features colored by standard-deviation of log-expression or fold-change which can be set using the {color by} plot setting. The color intensity threshold can be set using the {color gamma} plot setting. Additionally it is possible to select the number of labels displayed using the {nr labels} plot setting. By selecting this plot (by drag&drop) the Gene table is subset.",
-              info.methods = "Clustering of genes performed with Uniform Manifold Approximation and Projection (UMAP) using the top 1000 most varying features, then reduced to 50 PCA dimensions before computing the UMAP embedding. Performed using the uwot R package [1]. The distance metric is covariance of the feature expression. Features that are clustered nearby have high covariance.",
+              info.text = "UMAP clustering of features colored by standard-deviation of log-expression or fold-change which can be set using the {color by} plot setting. The color intensity threshold can be set using the {color gamma} plot setting. Additionally it is possible to select the number of labels displayed using the {nr labels} plot setting. By selecting this plot (by drag&drop) the Feature table is subset.",
+              info.methods = "Clustering of features performed with Uniform Manifold Approximation and Projection (UMAP) using the top 1000 most varying features, then reduced to 50 PCA dimensions before computing the UMAP embedding. Performed using the uwot R package [1]. The distance metric is covariance of the feature expression. Features that are clustered nearby have high covariance.",
               info.references = list(
                 list(
                   "Melville J (2024) uwot: The Uniform Manifold Approximation and Projection (UMAP) Method for Dimensionality Reduction.",
@@ -105,7 +105,7 @@ FeatureMapUI <- function(id) {
               ns("geneSigPlots"),
               title = "Feature signatures",
               info.text = "UMAP clustering of features colored by relative log-expression of the phenotype group.",
-              info.methods = "See Gene UMAP",
+              info.methods = "See Feature UMAP",
               info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#clustering",
               caption = "Feature signature maps coloured by differential expression.",
               height = height1,
@@ -115,7 +115,7 @@ FeatureMapUI <- function(id) {
           featuremap_table_gene_map_ui(
             ns("geneUMAP"),
             title = "Feature table",
-            info.text = "The contents of this table can be subsetted by selecting (by click&drag) on the Feature map plot.",
+            info.text = "The contents of this table can be subsetted by selecting (by click&drag) on the Feature UMAP plot.",
             caption = "",
             height = height2,
             width = c("auto", "100%")
@@ -150,7 +150,7 @@ FeatureMapUI <- function(id) {
               ns("gsetSigPlots"),
               title = "Geneset signatures",
               "UMAP clustering of genesets colored by relative log-expression of the phenotype group.",
-              info.methods = "See Gene UMAP",
+              info.methods = "See Geneset UMAP",
               info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#clustering",
               caption = "Geneset signature maps coloured by differential expression.",
               height = height1,
@@ -160,7 +160,7 @@ FeatureMapUI <- function(id) {
           featuremap_table_geneset_map_ui(
             ns("gsetUMAP"),
             title = "Geneset table",
-            info.text = "The contents of this table can be subsetted by selecting an area (by click&drag) on the Geneset map plot.",
+            info.text = "The contents of this table can be subsetted by selecting an area (by click&drag) on the Geneset UMAP plot.",
             caption = "",
             height = height2,
             width = c("auto", "100%")

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -50,7 +50,8 @@ PlotModuleUI <- function(id,
   height.2 <- ifnotchar.int(height[2])
 
   if (translate) {
-    info.text <- tspan(info.text)
+    info.text <- tspan(info.text, js = translate_js)
+    info.methods <- tspan(info.methods, js = translate_js)
     title <- tspan(title, js = translate_js)
     caption2 <- tspan(caption2, js = translate_js)
     caption <- tspan(caption, js = translate_js)


### PR DESCRIPTION
Plots that had the option to be colored by up/down regulated features have been set to be colored by default and the option has been removed. The info texts have been modified to not say that there is that option. Also some minor tweaks to other info texts has been done.