### PR TITLE
feat: updated plotmodule cards

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -203,18 +203,13 @@ PlotModuleUI <- function(id,
     tabs <- lapply(1:length(card_names), function(x) {
       bslib::nav_panel(
         card_names[x],
-        bslib::card_body(
-          outputFunc[[x]](ns(paste0("renderfigure", x)), height = height.1) %>%
-            bigLoaders::useSpinner()
-        )
+        outputFunc[[x]](ns(paste0("renderfigure", x))) %>%
+          bigLoaders::useSpinner()
       )
     })
-    tabs <- c(tabs,
-      id = ns("card_selector"), ulClass = "nav navbar-nav header-nav",
-      selected = NULL
-    )
+    tabs <- c(tabs, title = "")
     plot_cards <- do.call(
-      bslib:::buildTabset,
+      bslib::navset_card_pill,
       tabs
     )
   } else {
@@ -235,7 +230,9 @@ PlotModuleUI <- function(id,
       title
     ),
     if (cards) {
-      plot_cards$navList
+      nav_bar <- gsub("nav nav-pills card-header-pills", "nav navbar-nav header-nav", plot_cards$children[[1]])
+      nav_bar <- gsub("card-header bslib-navs-card-title", "bslib-navs-card-title", nav_bar) |> shiny::HTML()
+      nav_bar
     } else {
       shiny::div()
     },
@@ -387,7 +384,7 @@ PlotModuleUI <- function(id,
     bslib::card_body(
       gap = "0px",
       if (cards) {
-        plot_cards$content
+        plot_cards$children[[2]]
       } else {
         plot_cards
       },

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -330,6 +330,8 @@ PlotModuleUI <- function(id,
       bslib::navset_bar,
       tabs_modal
     )
+    plot_cards_modal[[1]] <- gsub("nav navbar-nav nav-underline", "nav navbar-nav", plot_cards_modal[[1]]) |> shiny::HTML()
+    plot_cards_modal[[1]] <- gsub("navbar navbar-default navbar-static-top", "navbar navbar-default navbar-static-top navbar-custom", plot_cards_modal[[1]]) |> shiny::HTML()
   } else {
     plot_cards_modal <- outputFunc2(ns("renderpopup"), width = width.2, height = height.2) %>%
       bigLoaders::useSpinner()

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -207,7 +207,7 @@ PlotModuleUI <- function(id,
           bigLoaders::useSpinner()
       )
     })
-    tabs <- c(tabs, title = "")
+    tabs <- c(tabs, title = "", id = ns("card_selector"))
     plot_cards <- do.call(
       bslib::navset_card_pill,
       tabs
@@ -230,7 +230,7 @@ PlotModuleUI <- function(id,
       title
     ),
     if (cards) {
-      nav_bar <- gsub("nav nav-pills card-header-pills", "nav navbar-nav header-nav", plot_cards$children[[1]])
+      nav_bar <- gsub("nav nav-pills shiny-tab-input card-header-pills", "nav navbar-nav shiny-tab-input header-nav", plot_cards$children[[1]])
       nav_bar <- gsub("card-header bslib-navs-card-title", "bslib-navs-card-title", nav_bar) |> shiny::HTML()
       nav_bar
     } else {

--- a/scss/components/_navbar.scss
+++ b/scss/components/_navbar.scss
@@ -1,0 +1,3 @@
+.navbar-custom {
+    border-bottom: 1px solid gray !important;
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -18,3 +18,4 @@
 @import "components/wizard.scss";
 @import "components/carousel.scss";
 @import "components/tick.scss";
+@import "components/navbar.scss";


### PR DESCRIPTION
## Description
Make use of different `bslib` functions to build the plot card. This ensures that the plot displayed is properly height adjusted when using cards; before that was not the case, the height had to be statically set, which led to problems with different screen sizes, now the plot automatically uses the whole card space.

### Before
![image](https://github.com/user-attachments/assets/94e7552c-ccbc-452f-8ea8-f0b367e451d6)

### After
![image](https://github.com/user-attachments/assets/e4378572-9d14-431c-8354-13a6ac5733e6)