### PR TITLE
Feat: download tables as excel or csv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     magrittr,
     markdown,
     miniUI,
+    openxlsx,
     pairsD3,
     partykit,
     patchwork,

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -156,6 +156,8 @@ PlotModuleUI <- function(id,
     shiny::br(), shiny::br(), shiny::br()
   )
 
+  if ("csv" %in% download.fmt) download.fmt <- c(download.fmt, "excel")
+
   dload.button <- DropdownMenu(
     div(
       style = "width: 150px;",
@@ -468,6 +470,7 @@ PlotModuleServer <- function(id,
                              download.png = NULL,
                              download.html = NULL,
                              download.csv = NULL,
+                             download.excel = NULL,
                              download.obj = NULL,
                              pdf.width = 8,
                              pdf.height = 6,
@@ -577,11 +580,13 @@ PlotModuleServer <- function(id,
       do.html <- "html" %in% download.fmt
       do.obj <- "obj" %in% download.fmt
       do.csv <- !is.null(csvFunc)
+      do.excel <- !is.null(csvFunc)
 
-      PNGFILE <- PDFFILE <- HTMLFILE <- CSVFILE <- NULL
+      PNGFILE <- PDFFILE <- HTMLFILE <- CSVFILE <- EXCELFILE <- NULL
       if (do.pdf) PDFFILE <- paste0(gsub("file", "plot", tempfile()), ".pdf")
       if (do.png) PNGFILE <- paste0(gsub("file", "plot", tempfile()), ".png")
       if (do.csv) CSVFILE <- paste0(gsub("file", "data", tempfile()), ".csv")
+      if (do.excel) EXCELFILE <- paste0(gsub("file", "data", tempfile()), ".xlsx")
       HTMLFILE <- paste0(tempfile(), ".html") ## tempory for webshot
       HTMLFILE
       unlink(HTMLFILE)
@@ -886,6 +891,20 @@ PlotModuleServer <- function(id,
         ) ## end of HTML downloadHandler
       } ## end of do HTML
 
+      # Excel download
+      if (do.excel) {
+        download.excel <- shiny::downloadHandler(
+          filename = paste0(filename, ".xlsx"),
+          content = function(file) {
+            shiny::withProgress({
+              data <- csvFunc()
+              if (is.list(data) && !is.data.frame(data)) data <- data[[1]]
+              openxlsx::write.xlsx(data, file = file)
+            })
+          }
+        )
+      }
+
       ## --------------------------------------------------------------------------------
       ## ------------------------ OUTPUT ------------------------------------------------
       ## --------------------------------------------------------------------------------
@@ -899,6 +918,9 @@ PlotModuleServer <- function(id,
           }
           if (input$downloadOption == "csv") {
             output$download <- download.csv
+          }
+          if (input$downloadOption == "excel") {
+            output$download <- download.excel
           }
           if (input$downloadOption == "html") {
             output$download <- download.html
@@ -926,6 +948,12 @@ PlotModuleServer <- function(id,
               "download",
               card
             )]] <- download.csv
+          }
+          if (input$downloadOption == "excel") {
+            output[[paste0(
+              "download",
+              card
+            )]] <- download.excel
           }
           if (input$downloadOption == "html") {
             output[[paste0(
@@ -1170,6 +1198,7 @@ PlotModuleServer <- function(id,
         download.png = download.png,
         download.html = download.html,
         download.csv = download.csv,
+        download.excel = download.excel,
         saveHTML = saveHTML,
         renderFunc = renderFunc
       )


### PR DESCRIPTION
This closes #1065 

From client feedback: Would be useful to be able to download tables directly as `*.xlsx `instead of `*.csv`. 

For that, I have added a switch to select the format to download.

![image](https://github.com/user-attachments/assets/3667bdcd-3e5b-451b-bdd1-e9b81cd6303e)
