### PR TITLE
Compare datasets: Fix issues with custom features and single gene scatter plot in Fold change

### DIFF
--- a/components/board.compare/R/compare_plot_fcfc.R
+++ b/components/board.compare/R/compare_plot_fcfc.R
@@ -75,7 +75,7 @@ compare_plot_fcfc_server <- function(id,
       genes <- sample(rownames(FC), sample_size)
 
       if (any(hilight %in% genes)) {
-        genes <- c(hilight, genes)
+        genes <- c(intersect(hilight, genes), genes)
       }
 
       genes <- unique(genes)


### PR DESCRIPTION
This pull request addresses two issues. The first issue, fix 898, solves a problem where custom features were not included in the rownames and caused plot to crash. We now validate that which prevents the plot from crashing due to mismatch dimensiosn: https://github.com/bigomics/omicsplayground/issues/1074

The second issue allows for highlighting of a single gene in the scatterplot, that is now possible. https://github.com/bigomics/omicsplayground/issues/898


**Feature without match does not crash plot:**

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/46479415-5643-4d0a-a42c-9c9f94f3a793">

**Single gene can be highlighted:**

<img width="1119" alt="image" src="https://github.com/user-attachments/assets/db6c00c2-e073-406d-bc46-18b5762fab10">

