### PR TITLE
feat: hubspot data check

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -179,7 +179,8 @@ opt.default <- list(
   TIMEOUT = 0,
   WATERMARK = TRUE,
   APACHE_COOKIE_PATH = OPG,
-  DEVMODE = FALSE
+  DEVMODE = FALSE,
+  HUBSPOT_CHECK = FALSE
 )
 
 opt.file <- file.path(ETC, "OPTIONS")

--- a/components/modules/AuthenticationModule.R
+++ b/components/modules/AuthenticationModule.R
@@ -944,47 +944,7 @@ LoginCodeAuthenticationModule <- function(id,
       ## (OPTION HUBSPOT_CHECK defined step) Check if user has updated info on Hubspot
       ## If not, redirect to auth where the popup will be prompted to the user
       if (opt$HUBSPOT_CHECK) {
-        dbg("[LoginCodeAuthenticationModule] checking in hubspot for user data")
-        search_body <- create_hubspot_search(user_email)
-        credential <- file.path(ETC, "hubspot_creds")
-        if (!file.exists(credential)) {
-          stop("Error: Hubspot check is TRUE but no /etc/hubspot_creds file is on the deploy.")
-        }
-        HUBSPOT_SECRET <- readLines(credential)
-        response <- hubspot_post(
-            url = "https://api.hubapi.com/crm/v3/objects/contacts/search",
-            body = search_body,
-            access_token = HUBSPOT_SECRET
-        )
-        if (httr::content(response)$total == 1) {
-          lastname <- httr::content(response)$results[[1]]$properties$lastname
-          firstname <- httr::content(response)$results[[1]]$properties$firstname
-          jobtitle <- httr::content(response)$results[[1]]$properties$jobtitle
-          background <- httr::content(response)$results[[1]]$properties$background
-          bioinfos_team <- httr::content(response)$results[[1]]$properties$bioinformaticians_in_the_team
-          id <- httr::content(response)$results[[1]]$id
-          is_null_or_empty <- function(x) {
-              is.null(x) || (is.character(x) && x == "")
-          }
-          is_any_null_or_empty <- is_null_or_empty(lastname) |
-                  is_null_or_empty(firstname) |
-                  is_null_or_empty(jobtitle) |
-                  is_null_or_empty(background) |
-                  is_null_or_empty(bioinfos_team)
-          time_since_update <- as.numeric(Sys.Date() - as.Date(httr::content(response)$results[[1]]$updatedAt))
-          if (time_since_update < 1) {
-            dbg("[LoginCodeAuthenticationModule] user is less than one day old, skipping data complete check")
-            is_any_null_or_empty <- FALSE
-          }
-          if(is_any_null_or_empty) { # Missing info, redirect to auth
-            dbg("[LoginCodeAuthenticationModule] missing data for ", user_email, " redirecting to auth")
-            shinyjs::runjs(
-              "window.location.replace('https://auth.bigomics.ch/#!/login?email=hola@hola.com');"
-            )
-          }
-        } else {
-          warning("[HUBSPOT] Error: User ", user_email, " not on HubSpot")
-        }
+        checkHubspot(user_email)
       }
 
       # create user_dir (always), set path, and set options

--- a/components/modules/AuthenticationModule_functions.R
+++ b/components/modules/AuthenticationModule_functions.R
@@ -318,7 +318,53 @@ checkEmail <- function(email, domain = NULL, blocked_domain = NULL, user_databas
   list(valid = TRUE, "email ok")
 }
 
-
+checkHubspot <- function(user_email) {
+  dbg("[HubSpotCheckModule] checking hubspot for user data for email: ", user_email)
+  search_body <- create_hubspot_search(user_email)
+  credential <- file.path(ETC, "hubspot_creds")
+  if (!file.exists(credential)) {
+    stop("[HubSpotCheckModule] Error: Hubspot check is TRUE but no /etc/hubspot_creds file is on the deploy.")
+  }
+  HUBSPOT_SECRET <- readLines(credential)
+  response <- hubspot_post(
+      url = "https://api.hubapi.com/crm/v3/objects/contacts/search",
+      body = search_body,
+      access_token = HUBSPOT_SECRET
+  )
+  if (httr::content(response)$total == 1) {
+    lastname <- httr::content(response)$results[[1]]$properties$lastname
+    firstname <- httr::content(response)$results[[1]]$properties$firstname
+    jobtitle <- httr::content(response)$results[[1]]$properties$jobtitle
+    background <- httr::content(response)$results[[1]]$properties$background
+    bioinfos_team <- httr::content(response)$results[[1]]$properties$bioinformaticians_in_the_team
+    id <- httr::content(response)$results[[1]]$id
+    is_null_or_empty <- function(x) {
+        is.null(x) || (is.character(x) && x == "")
+    }
+    is_any_null_or_empty <- is_null_or_empty(lastname) |
+            is_null_or_empty(firstname) |
+            is_null_or_empty(jobtitle) |
+            is_null_or_empty(background) |
+            is_null_or_empty(bioinfos_team)
+    time_since_update <- as.numeric(Sys.Date() - as.Date(httr::content(response)$results[[1]]$updatedAt))
+    if (time_since_update < 1) {
+      dbg("[HubSpotCheckModule] user is less than one day old, skipping data complete check")
+      is_any_null_or_empty <- FALSE
+    }
+    if(is_any_null_or_empty) { # Missing info, redirect to auth
+      dbg("[HubSpotCheckModule] missing data for ", user_email, " redirecting to auth")
+      shinyjs::runjs(
+        paste0(
+          "window.location.replace('https://auth.bigomics.ch/#!/login?email=",
+          user_email,
+          "');"
+        )
+      )
+    }
+  } else {
+    warning("[HubSpotCheckModule] Error: User ", user_email, " not on HubSpot")
+  }
+}
 
 ## ================================================================================
 ## ================================= END OF FILE ==================================

--- a/components/modules/HubspotModule.R
+++ b/components/modules/HubspotModule.R
@@ -1,0 +1,40 @@
+hubspot_post <- function(url, body, access_token, type = "POST") {
+    auth <- hubspot_auth_header(access_token)
+    if (type == "POST") {
+      response <- httr::POST(
+          url,
+          body = body,
+          httr::content_type("application/json"),
+          auth
+      )
+    } else if (type == "PATCH") {
+      response <- httr::PATCH(
+          url,
+          body = body,
+          httr::content_type("application/json"),
+          auth
+      )
+    }
+    return(response)
+}
+
+create_hubspot_search <- function(email) {
+    body <- list(
+    filterGroups = list(
+      list(
+        filters = list(
+          list(
+            value = tolower(email),
+            propertyName = "email",
+            operator = "EQ"
+          )
+        )
+      )
+    ),
+    properties = list("email", "firstname", "lastname", "jobtitle", "background", "bioinformaticians_in_the_team")
+  ) |> jsonlite::toJSON(auto_unbox = TRUE)
+}
+
+hubspot_auth_header <- function(access_token) {
+  httr::add_headers(Authorization = paste0("Bearer ", access_token))
+}


### PR DESCRIPTION
This addresses an issue that was raised with the introduction of cookies.

If a user is logged in to the platform, the re-access to it can be though the site URL instead of through auth page (given cookies log you in). Why is this a problem (sometimes)? In auth we have different checks regarding the data we have from the users, therefore, if they do not go through it, we miss that information.

By checking this information on OPG, we can redirect them to auth when we are missing data (or continue normal login if everything is fine).

This behaviour can be controlled through the OPTIONS file and is only intended for free deployment.