### PR TITLE
redesign UI elements: bring geneset volcano upfront

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_barplot.R
+++ b/components/board.enrichment/R/enrichment_plot_barplot.R
@@ -18,12 +18,20 @@ enrichment_plot_barplot_ui <- function(
   options <- shiny::tagList(
     withTooltip(
       shiny::checkboxInput(
-        ns("gs_ungroup1"), "ungroup samples", FALSE
+        ns("ungroup"), "ungroup samples", FALSE
       ),
       "Ungroup samples in the plot",
       placement = "top",
       options = list(container = "body")
-    )
+    ),
+    withTooltip(
+      shiny::checkboxInput(
+        ns("show_others"), "show others", FALSE
+      ),
+      "Show other samples as 'others' in the plot",
+      placement = "top",
+      options = list(container = "body")
+    )    
   )
 
   PlotModuleUI(
@@ -77,11 +85,10 @@ enrichment_plot_barplot_server <- function(id,
 
       grouped <- TRUE
       grouped <- FALSE
-      grouped <- !input$gs_ungroup1
+      grouped <- !input$ungroup
       has.design <- !is.null(pgx$model.parameters$design)
       collapse.others <- ifelse(has.design, FALSE, TRUE)
-      #
-
+      
       ngrp <- length(unique(pgx$samples$group))
       srt <- ifelse(!grouped || ngrp > 4, 30, 0)
       if (!grouped && ncol(pgx$X) > 15) srt <- 60
@@ -91,6 +98,7 @@ enrichment_plot_barplot_server <- function(id,
         logscale = TRUE,
         level = "geneset",
         collapse.others = collapse.others,
+        showothers = input$show_others,        
         grouped = grouped,
         cex = 1.1,
         srt = srt,

--- a/components/board.enrichment/R/enrichment_plot_geneplot.R
+++ b/components/board.enrichment/R/enrichment_plot_geneplot.R
@@ -24,11 +24,16 @@ enrichment_plot_geneplot_ui <- function(
   ns <- shiny::NS(id)
 
   options <- shiny::tagList(
-    withTooltip(shiny::checkboxInput(ns("gs_ungroup2"), "ungroup samples", FALSE),
+    withTooltip(shiny::checkboxInput(ns("ungroup"), "ungroup samples", FALSE),
       "Ungroup samples in the plot",
       placement = "top",
       options = list(container = "body")
-    )
+    ),
+    withTooltip(shiny::checkboxInput(ns("show_others"), "show others", FALSE),
+      "Show other samples as 'others' in the plot",
+      placement = "top",
+      options = list(container = "body")
+    ),
   )
 
   PlotModuleUI(
@@ -87,17 +92,20 @@ enrichment_plot_geneplot_server <- function(id,
         probe <- sel$rn
         gene <- sel$gene
         ngrp <- length(unique(pgx$samples$group))
-        grouped <- !input$gs_ungroup2
+        grouped <- !input$ungroup
         srt <- ifelse(!grouped || ngrp > 4, 30, 0)
         if (!grouped && ncol(pgx$X) > 15) srt <- 60
-
+        has.design <- !is.null(pgx$model.parameters$design)
+        collapse.others <- ifelse(has.design, FALSE, TRUE)
+        
         playbase::pgx.plotExpression(
           pgx,
           probe,
           comp = comp0,
           logscale = TRUE,
           level = "gene",
-          collapse.others = FALSE,
+          collapse.others = collapse.others,
+          showothers = input$show_others,
           grouped = grouped,
           srt = srt,
           main = "",

--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -172,7 +172,9 @@ enrichment_plot_top_enrich_gsets_server <- function(id,
             yth = 1, ## threshold for which points get label
             cbar.width = 32,
             tooltips = NULL,
-            cex.text = cex.text
+            cex.text = cex.text,
+            cex.title = 1.1,
+            cex.axis = 1.3            
           ) %>% plotly::layout(
             margin = list(l = 30, r = 10, t = 20, b = 40)
           )
@@ -188,7 +190,8 @@ enrichment_plot_top_enrich_gsets_server <- function(id,
             yth = 999, ## threshold for which points get label
             cbar.width = 15,
             tooltips = NULL,
-            cex.text = cex.text
+            cex.text = cex.text,
+            cex.axis = 0.8                        
           ) %>%
             plotly::add_text(
               x = x.title, y = y.title, text = gset.name,

--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -98,7 +98,7 @@ enrichment_plot_volcano_server <- function(id,
       ))
     })
 
-    plotly.RENDER <- function() {
+    plotly.RENDER <- function(marker.size=3, lab.cex=1) {
       pd <- plot_data()
       shiny::req(pd)
 
@@ -111,11 +111,12 @@ enrichment_plot_volcano_server <- function(id,
         marker.type = "scattergl",
         highlight = pd[["sel.genes"]],
         label = pd[["sel.genes"]],
+        label.cex = lab.cex,
         psig = pd[["fdr"]],
         lfc = pd[["lfc"]],
         xlab = "Effect size (log2FC)",
         ylab = "Significance (-log10q)",
-        marker.size = 3,
+        marker.size = marker.size,
         displayModeBar = FALSE,
         showlegend = FALSE,
         color_up_down = TRUE
@@ -123,6 +124,16 @@ enrichment_plot_volcano_server <- function(id,
         plotly::layout(margin = list(b = 60))
     }
 
+    plotly.RENDER2 <- function() {
+      plotly.RENDER(marker.size = 8, lab.cex=1.5) %>%
+        plotly::layout(
+          font = list(size = 18),
+          legend = list(
+            font = list(size = 18)
+          )
+        )
+    }
+    
     base.RENDER <- function() {
       pd <- plot_data()
       shiny::req(pd)
@@ -158,15 +169,15 @@ enrichment_plot_volcano_server <- function(id,
         lfc = pd[["lfc"]],
         xlab = "Effect size (log2FC)",
         ylab = "Significance (-log10q)",
-        marker.size = 1.5,
-        label.cex = 5,
+        marker.size = 1.8,
+        label.cex = 6,
         axis.text.size = 22,
         showlegend = FALSE
       )
     }
 
     plot_grid <- list(
-      list(plotlib = "plotly", func = plotly.RENDER, func2 = plotly.RENDER, card = 1),
+      list(plotlib = "plotly", func = plotly.RENDER, func2 = plotly.RENDER2, card = 1),
       list(plotlib = "ggplot", func = base.RENDER, func2 = base.RENDER.modal, card = 2)
     )
 

--- a/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
+++ b/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
@@ -72,28 +72,28 @@ enrichment_table_enrichment_analysis_server <- function(id,
 
       ## wrap genesets names with known links.
       GS_link <- playbase::wrapHyperLink(
-        rep_len("<i class='fa-solid fa-arrow-up-right-from-square'></i>", nrow(rpt)),
+        rep_len("<i class='fa-solid fa-arrow-up-right-from-square weblink'></i>", nrow(rpt)),
         rownames(rpt)
       ) |> HandleNoLinkFound(
-        NoLinkString = "<i class='fa-solid fa-arrow-up-right-from-square'></i>",
+        NoLinkString = "<i class='fa-solid fa-arrow-up-right-from-square weblink'></i>",
         SubstituteString = "<i class='fa-solid fa-arrow-up-right-from-square blank_icon'></i>"
       )
-      selectmode <- "single"
-
+      rpt$GS <- paste(rpt$GS, "&nbsp;", GS_link)
+      colnames(rpt) <- sub("GS", "geneset", colnames(rpt))
+            
       is.numcol <- sapply(rpt, function(col) is.numeric(col) && !is.integer(col))
       numcols <- which(is.numcol & !colnames(rpt) %in% c("size"))
       numcols <- colnames(rpt)[numcols]
 
-      colnames(rpt) <- sub("GS", "geneset", colnames(rpt))
 
       DT::datatable(rpt,
         class = "compact cell-border stripe hover",
-        rownames = GS_link,
-        escape = FALSE,
+        rownames = FALSE,
+        escape = c(-1, -2),        
         extensions = c("Scroller"),
         plugins = "scrollResize",
         fillContainer = TRUE,
-        selection = list(mode = selectmode, target = "row", selected = 1),
+        selection = list(mode = "single", target = "row", selected = 1),
         options = list(
           dom = "frtip",
           paging = TRUE,

--- a/components/board.enrichment/R/enrichment_table_gset_enrich_all_contrasts.R
+++ b/components/board.enrichment/R/enrichment_table_gset_enrich_all_contrasts.R
@@ -65,7 +65,6 @@ enrichment_table_gset_enrich_all_contrasts_server <- function(id,
       if (show.q) {
         F1 <- do.call(cbind, lapply(1:ncol(F), function(i) cbind(F[, i], Q[, i])))
         colnames(F1) <- as.vector(rbind(paste0("ES.", colnames(F)), paste0("q.", colnames(Q))))
-        #
         df <- data.frame(geneset = gs, rms.ES = fc.rms, F1, check.names = FALSE)
       } else {
         F1 <- F
@@ -77,18 +76,7 @@ enrichment_table_gset_enrich_all_contrasts_server <- function(id,
       res <- getFilteredGeneSetTable()
       df <- df[intersect(rownames(df), rownames(res)), ] ## take intersection of current comparison
       df <- df[order(-df$rms.ES), ]
-      ## wrap with hyperlink
-      geneset_link <- playbase::wrapHyperLink(
-        rep_len("<i class='fa-solid fa-arrow-up-right-from-square'></i>", nrow(df)),
-        rownames(df)
-      ) |> HandleNoLinkFound(
-        NoLinkString = "<i class='fa-solid fa-arrow-up-right-from-square'></i>",
-        SubstituteString = "<i class='fa-solid fa-arrow-up-right-from-square blank_icon'></i>"
-      )
-      df$i <- geneset_link
-      new_order <- c(names(df)[1], "i", names(df)[names(df) != "i" & names(df) != names(df)[1]])
-      df <- df[, new_order]
-
+      
       colnames(df) <- gsub("_", " ", colnames(df)) ## so it allows wrap line
       colnames(F1) <- gsub("_", " ", colnames(F1)) ## so it allows wrap line
       qv.cols <- grep("^q", colnames(df))
@@ -103,17 +91,28 @@ enrichment_table_gset_enrich_all_contrasts_server <- function(id,
       )
     })
 
-    fctable.RENDER <- function() {
+    table.RENDER <- function() {
       td <- table_data()
       df <- td$df
       qv.cols <- td$qv.cols
       fc.cols <- td$fc.cols
       F <- td$F
 
+      ## wrap with hyperlink
+      geneset_link <- playbase::wrapHyperLink(
+        rep_len("<i class='fa-solid fa-arrow-up-right-from-square weblink'></i>", nrow(df)),
+        rownames(df)
+      ) |> HandleNoLinkFound(
+        NoLinkString = "<i class='fa-solid fa-arrow-up-right-from-square weblink'></i>",
+        SubstituteString = "<i class='fa-solid fa-arrow-up-right-from-square blank_icon'></i>"
+      )
+
+      df$geneset <- paste(df$geneset, "&nbsp;", geneset_link)
+      
       dt <- DT::datatable(
         df,
         rownames = NULL,
-        escape = FALSE,
+        escape = c(-1,-2),
         class = "compact cell-border stripe hover",
         extensions = c("Scroller"),
         plugins = "scrollResize",
@@ -150,16 +149,16 @@ enrichment_table_gset_enrich_all_contrasts_server <- function(id,
       return(dt)
     }
 
-    fctable.RENDER_modal <- function() {
-      dt <- fctable.RENDER()
+    table.RENDER_modal <- function() {
+      dt <- table.RENDER()
       dt$x$options$scrollY <- SCROLLY_MODAL
       return(dt)
     }
 
     TableModuleServer(
       "datasets",
-      func = fctable.RENDER,
-      func2 = fctable.RENDER_modal,
+      func = table.RENDER,
+      func2 = table.RENDER_modal,
       csvFunc = table_data,
       selector = "none"
     )

--- a/components/board.enrichment/R/enrichment_ui.R
+++ b/components/board.enrichment/R/enrichment_ui.R
@@ -69,7 +69,7 @@ EnrichmentUI <- function(id) {
     shiny::tabPanel(
       "Enrichment",
       bslib::layout_columns(
-        col_widths = c(6, 6),
+        col_widths = c(5, 4, 3),
         height = halfH,
         enrichment_plot_top_enrich_gsets_ui(
           ns("topEnriched"),
@@ -107,23 +107,6 @@ EnrichmentUI <- function(id) {
           height = c("100%", TABLE_HEIGHT_MODAL),
           width = c("auto", "100%")
         ),
-        enrichment_plot_freq_top_gsets_ui(
-          ns("topEnrichedFreq"),
-          title = "Frequency in top gene sets",
-          info.text = "Barchart showing the number of times a gene is present in the top-N genesets for the selected {Contrast} sorted by frequency. Genes that are frequently shared among the top enriched gene sets may suggest driver genes.",
-          info.methods = "See Top enriched gene sets",
-          info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#functional-analyses",
-          caption = "Gene frequency plot indicating the most recurring genes across the most correlated gene sets.",
-          height = c("100%", TABLE_HEIGHT_MODAL),
-          width = c("auto", "100%")
-        )
-      )
-    ),
-    shiny::tabPanel(
-      "Geneset expression",
-      bslib::layout_columns(
-        col_widths = c(3, 3, 3, 3),
-        height = halfH,
         enrichment_plot_volcano_ui(
           ns("subplot_volcano"),
           title = "Volcano plot",
@@ -183,10 +166,17 @@ EnrichmentUI <- function(id) {
           caption = "Barplot of the selected gene set in the phenotypic groups. ",
           height = c("100%", TABLE_HEIGHT_MODAL),
           width = c("auto", 900)
-        ),
+        )
+      )
+    ),
+    shiny::tabPanel(
+      tspan("Gene expression"),
+      bslib::layout_columns(
+        col_widths = c(3, 4, 5),
+        height = halfH,
         enrichment_plot_geneplot_ui(
           ns("subplot_geneplot"),
-          title = "Expression geneplot",
+          title = "Expression plot",
           info.text = "An expression barplot per sample group for the gene that is selected from the genes Table II. Samples can be ungrouped in the barplot by selecting ungroup samples from the plot Settings.",
           caption = "Barplot of the selected gene in the phenotypic groups. ",
           height = c("100%", TABLE_HEIGHT_MODAL),
@@ -195,13 +185,23 @@ EnrichmentUI <- function(id) {
         enrichment_plot_scatter_ui(
           ns("subplot_scatter"),
           title = "Enrichment vs. expression",
-          info.text = "Scatter plot of enrichment scores versus expression values for selected {Contrast} for the gene set selected from the Enrichment analysis table and the gene selected from the genes table.",
+          info.text = "Scatter plot of enrichment scores versus expression values for selected {Comparison} for the gene set selected from the Enrichment analysis table and the gene selected from the genes table.",
           info.methods = "See Enrichment barplot",
           info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#functional-analyses",
           caption = "Scatter plot of the selected gene set enrichment scores versus the selected gene expression values by sample.",
           height = c("100%", TABLE_HEIGHT_MODAL),
           width = c("auto", 900)
-        )
+        ),
+        enrichment_plot_freq_top_gsets_ui(
+          ns("topEnrichedFreq"),
+          title = "Frequency in top gene sets",
+          info.text = "Barchart showing the number of times a gene is present in the top-N genesets for the selected {Contrast} sorted by frequency. Genes that are frequently shared among the top enriched gene sets may suggest driver genes.",
+          info.methods = "See Top enriched gene sets",
+          info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#functional-analyses",
+          caption = "Gene frequency plot indicating the most recurring genes across the most correlated gene sets.",
+          height = c("100%", TABLE_HEIGHT_MODAL),
+          width = c("auto", "100%")
+        )        
       )
     ),
     shiny::tabPanel(

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -208,13 +208,13 @@ expression_plot_volcano_server <- function(id,
         highlight = pd[["sel.genes"]],
         label = pd[["lab.genes"]],
         label.names = label.names,
-        label.cex = 5,
+        label.cex = 6,
         axis.text.size = 22,
         psig = pd[["fdr"]],
         lfc = pd[["lfc"]],
         xlab = "Effect size (log2FC)",
         ylab = pd[["ylab"]],
-        marker.size = 1.5,
+        marker.size = 1.8,
         showlegend = FALSE
       )
     }

--- a/components/board.pathway/R/pathway_plot_go_network.R
+++ b/components/board.pathway/R/pathway_plot_go_network.R
@@ -66,11 +66,12 @@ functional_plot_go_network_server <- function(id,
                                               watermark = FALSE) {
   moduleServer(
     id, function(input, output, session) {
+      
       plot_data <- shiny::reactive({
         fa_contrast <- fa_contrast()
-
+        score <- pgx$meta.go$pathscore[, fa_contrast]        
         res <- list(
-          pgx = pgx,
+          score = score,
           fa_contrast = fa_contrast
         )
         return(res)
@@ -78,9 +79,7 @@ functional_plot_go_network_server <- function(id,
 
       plot_RENDER <- shiny::reactive({
         res <- plot_data()
-        pgx <- res$pgx
         comparison <- res$fa_contrast
-
         require(igraph)
 
         methods <- c("fisher", "gsva", "camera")
@@ -181,8 +180,11 @@ functional_plot_go_network_server <- function(id,
 
         visNetwork::visNetwork(gr$nodes, gr$edges) %>%
           visNetwork::visEdges(
-            smooth = FALSE, hidden = FALSE, arrows = list(enabled = TRUE),
-            scaling = list(min = 10 * cex, max = 30 * cex), width = 5 * cex
+            smooth = FALSE,
+            hidden = FALSE,
+            arrows = list(enabled = TRUE),
+            scaling = list(min = 10 * cex, max = 30 * cex),
+            width = 5 * cex
           ) %>%
           visNetwork::visNodes(
             font = list(size = font.size * cex, vadjust = 0),
@@ -197,6 +199,7 @@ functional_plot_go_network_server <- function(id,
         "plot",
         plotlib = "visnetwork",
         func = plot_RENDER,
+        csvFunc = plot_data,
         res = 72,
         pdf.width = 10, pdf.height = 8,
         add.watermark = watermark


### PR DESCRIPTION
Reshuflle UI plots in geneset module. Bring volcano to first page. Rational: Volcano plot is more informative for first analysis.Putting gene frequency together with gene/protein centric plots on second page.

Before:

![image](https://github.com/user-attachments/assets/6d40418c-2dc2-494f-a89e-2818fa3bf0b0)


After:
![image](https://github.com/user-attachments/assets/83749fb9-c496-41a6-9daf-977a1c35c9d3)
