### PR TITLE
fix grey dots due to incomplete selection

### DIFF
--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -112,20 +112,31 @@ expression_plot_maplot_server <- function(id,
       return(plot_data)
     })
 
+    getLabels <- reactive({
+      res <- res()
+      symbols <- playbase::probe2symbol(
+        probes = rownames(res), res, query = "symbol", fill_na = TRUE
+      )
+      names <- playbase::probe2symbol(
+        probes = rownames(res), res, query = "gene_title", fill_na = TRUE
+      )
+      features <- rownames(res)
+      if (labeltype() == "symbol") {
+        label.names <- symbols
+      } else if (labeltype() == "name") {
+        label.names <- names
+      } else {
+        label.names <- features
+      }
+      label.names
+    })    
+    
     plotly.RENDER <- function(marker.size = 4, lab.cex = 1) {
       pd <- plot_data()
       shiny::req(pd)
 
-      if (labeltype() == "symbol") {
-        names <- pd[["features"]]
-        label.names <- pd[["symbols"]]
-      } else if (labeltype() == "name") {
-        names <- pd[["symbols"]]
-        label.names <- pd[["names"]]
-      } else {
-        names <- pd[["symbols"]]
-        label.names <- pd[["features"]]
-      }
+      names <- pd[["features"]]
+      label.names <- getLabels()
 
       plt <- playbase::plotlyMA(
         x = pd[["x"]],

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -111,22 +111,32 @@ expression_plot_volcano_server <- function(id,
       ))
     })
 
+    getLabels <- reactive({
+      res <- res()
+      symbols <- playbase::probe2symbol(
+        probes = rownames(res), res, query = "symbol", fill_na = TRUE
+      )
+      names <- playbase::probe2symbol(
+        probes = rownames(res), res, query = "gene_title", fill_na = TRUE
+      )
+      features <- rownames(res)
+      if (labeltype() == "symbol") {
+        label.names <- symbols
+      } else if (labeltype() == "name") {
+        label.names <- names
+      } else {
+        label.names <- features
+      }
+      label.names
+    })    
 
     plotly.RENDER <- function(marker.size = 4, lab.cex = 1) {
       pd <- plot_data()
       shiny::req(pd)
 
-      if (labeltype() == "symbol") {
-        names <- pd[["features"]]
-        label.names <- pd[["symbols"]]
-      } else if (labeltype() == "name") {
-        names <- pd[["features"]]
-        label.names <- pd[["names"]]
-      } else {
-        names <- pd[["symbols"]]
-        label.names <- pd[["features"]]
-      }
-
+      label.names <- getLabels()
+      names <- pd$features
+      
       plt <- playbase::plotlyVolcano(
         x = pd[["x"]],
         y = pd[["y"]],
@@ -164,13 +174,8 @@ expression_plot_volcano_server <- function(id,
       pd <- plot_data()
       shiny::req(pd)
 
-      if (labeltype() == "symbol") {
-        names <- pd[["features"]]
-        label.names <- pd[["symbols"]]
-      } else {
-        names <- pd[["symbols"]]
-        label.names <- pd[["features"]]
-      }
+      label.names <- getLabels()
+      names <- pd$features
 
       playbase::ggVolcano(
         x = pd[["x"]],
@@ -193,13 +198,8 @@ expression_plot_volcano_server <- function(id,
       pd <- plot_data()
       shiny::req(pd)
 
-      if (labeltype() == "symbol") {
-        names <- pd[["features"]]
-        label.names <- pd[["symbols"]]
-      } else {
-        names <- pd[["symbols"]]
-        label.names <- pd[["features"]]
-      }
+      label.names <- getLabels()
+      names <- pd$features
 
       playbase::ggVolcano(
         x = pd[["x"]],

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -79,9 +79,6 @@ expression_plot_volcanoAll_server <- function(id,
       Q <- ct$Q
       P <- ct$P
 
-      dbg("[expression_plot_volcanoAll_server] dimF = ", dim(F))
-      ##      browser()
-
       fdr <- as.numeric(fdr())
       lfc <- as.numeric(lfc())
       comp <- colnames(F)

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -183,7 +183,7 @@ expression_plot_volcanoAll_server <- function(id,
 
       fc <- pd$F
       qv <- pd$P
-      gene_names <- rep(rownames(fc), each = ncol(fc))
+      feature_names <- rep(rownames(fc), each = ncol(fc))
       label.names <- rep(pd$label.names, each = ncol(fc))
       pivot.fc <- data.frame(fc) %>%
         tidyr::pivot_longer(
@@ -204,7 +204,7 @@ expression_plot_volcanoAll_server <- function(id,
       playbase::ggVolcano(
         x,
         y,
-        gene_names,
+        names = feature_names,
         facet = facet,
         label = pd[["lab.genes"]],
         highlight = pd[["sel.genes"]],

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -186,7 +186,7 @@ expression_plot_volcanoAll_server <- function(id,
 
       fc <- pd$F
       qv <- pd$P
-      gene_names <- rep(pd$names, each = ncol(fc))
+      gene_names <- rep(rownames(fc), each = ncol(fc))
       label.names <- rep(pd$label.names, each = ncol(fc))
       pivot.fc <- data.frame(fc) %>%
         tidyr::pivot_longer(

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -351,10 +351,11 @@ ExpressionBoard <- function(id, pgx) {
         gset <- playdata::getGSETS(features)
         fam.genes <- unique(unlist(gset))
       }
-      jj <- match(fam.genes, res$symbol)
-      sel.genes <- rownames(res)[setdiff(jj, NA)]
+##      jj <- match(fam.genes, res$symbol)
+      jj <- which( res$symbol %in% fam.genes )
+      sel.features <- rownames(res)[setdiff(jj, NA)]
 
-      fc.genes <- rownames(res)
+      features <- rownames(res)
 
       qval <- res[, grep("adj.P.Val|meta.q|qval|padj", colnames(res))[1]]
       qval <- pmax(qval, 1e-20)
@@ -367,14 +368,14 @@ ExpressionBoard <- function(id, pgx) {
       scaled.y <- scale(y, center = FALSE)
 
       if (input$show_pv) {
-        sig.genes <- fc.genes[which(pval <= fdr & abs(x) > lfc)]
+        sig.genes <- features[which(pval <= fdr & abs(x) > lfc)]
       } else {
-        sig.genes <- fc.genes[which(qval <= fdr & abs(x) > lfc)]
+        sig.genes <- features[which(qval <= fdr & abs(x) > lfc)]
       }
-      sel.genes <- intersect(sig.genes, sel.genes)
+      sel.features <- intersect(sig.genes, sel.features)
 
       impt <- function(g) {
-        j <- match(g, fc.genes)
+        j <- match(g, features)
         x1 <- scaled.x[j]
         y1 <- scaled.y[j]
         x <- sign(x1) * (x1**2 + 0.25 * y1**2)
@@ -386,25 +387,25 @@ ExpressionBoard <- function(id, pgx) {
       gset.selected <- !is.null(gsettable_rows_selected()) && !is.null(df2)
 
       if (gene.selected && !gset.selected) {
-        lab.genes <- rownames(df1)[genetable_rows_selected()]
-        sel.genes <- lab.genes
+        lab.features <- rownames(df1)[genetable_rows_selected()]
+        sel.features <- lab.features
         lab.cex <- 1.3
       } else if (gene.selected && gset.selected) {
-        sel.genes <- genes_in_sel_geneset()
-        lab.genes <- c(
-          head(sel.genes[order(impt(sel.genes))], 10),
-          head(sel.genes[order(-impt(sel.genes))], 10)
+        sel.features <- genes_in_sel_geneset()
+        lab.features <- c(
+          head(sel.features[order(impt(sel.features))], 10),
+          head(sel.features[order(-impt(sel.features))], 10)
         )
         lab.cex <- 1
       } else {
-        lab.genes <- c(
-          head(sel.genes[order(impt(sel.genes))], 10),
-          head(sel.genes[order(-impt(sel.genes))], 10)
+        lab.features <- c(
+          head(sel.features[order(impt(sel.features))], 10),
+          head(sel.features[order(-impt(sel.features))], 10)
         )
         lab.cex <- 1
       }
 
-      res <- list("sel.genes" = sel.genes, "lab.genes" = lab.genes, "fc.genes" = fc.genes)
+      res <- list("sel.genes" = sel.features, "lab.genes" = lab.features, "fc.genes" = features)
       return(res)
     })
 


### PR DESCRIPTION
fix grey dots in volcano due to incomplete selection when multiple features map to same symbols.

Before:
![image](https://github.com/user-attachments/assets/e0b66bc3-0b49-41ff-904d-78e64f528953)

After (using PTM data):
![image](https://github.com/user-attachments/assets/a3ffd5a7-b3ed-4a5a-bcd6-bce6b4fb48ce)
