### PR TITLE
feat: add autoclose to cog dropdown

### DIFF
--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -319,6 +319,7 @@ app_ui <- function(x) {
           div(
             id = "mainmenu_appsettings",
             bigdash::navbarDropdown(
+              auto_close = "outside",
               shiny::icon("cog"),
               bigdash::navbarDropdownItem(
                 bslib::input_switch("enable_beta", "Enable beta features")


### PR DESCRIPTION
This closes #1081 

Requires https://github.com/bigomics/bigdash/pull/26

## Description

This new option enables the use of the auto close behaviour of boostrap dropdowns, and by setting it to "outside" the issue #1081 is solved.

https://getbootstrap.com/docs/5.3/components/dropdowns/#auto-close-behavior