### PR TITLE
Fix #1083: Nodes in GO graph cannot be moved anymore

### DIFF
--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -37,7 +37,6 @@ app_ui <- function(x) {
     #-------------------------------------------------------
     ## Build USERMENU
     #-------------------------------------------------------
-
     VERSION <- scan(file.path(OPG, "VERSION"), character())[1]
 
     upgrade.tab <- NULL
@@ -71,6 +70,7 @@ app_ui <- function(x) {
         shiny::tags$head(shiny::tags$script(src = "custom/dropdown-helper.js")),
         shiny::tags$head(shiny::tags$link(rel = "stylesheet", href = "custom/styles.min.css")),
         shiny::tags$head(shiny::tags$link(rel = "shortcut icon", href = "custom/favicon.ico")),
+        visnetwork = visNetwork::visNetworkOutput("a", height = "0px"),
         shinyjs::useShinyjs(),
         waiter::use_waiter(),
         sever::useSever(),


### PR DESCRIPTION
This closes #1083 

## Description
It seems that for visnetwork to properly work, it has to be somehow initialized before loading the data+modules. Probably it has to do with some JS initialization not happening.

A little bit confusing solution nevertheless.