### PR TITLE
Fix error in geneinfo module for features that do not have symbol

### DIFF
--- a/components/board.dataview/R/dataview_module_geneinfo.R
+++ b/components/board.dataview/R/dataview_module_geneinfo.R
@@ -96,7 +96,7 @@ dataview_module_geneinfo_server <- function(id,
 
       ## add feature name is not symbol
       info$feature <- NULL
-      if (feature != symbol) {
+      if (!is.na(symbol) && feature != symbol) {
         info <- c(feature = feature, info)
       }
       ## info$organism <- NULL


### PR DESCRIPTION
## Summary

This pull request fixes the error "missing value where TRUE/FALSE needed" in the `geneinfo` module. The issue was resolved by modifying the code in the `dataview_module_geneinfo_server` function. Specifically, the condition `if (feature != symbol)` was updated to include a check for `!is.na(symbol)`. This ensures that the feature name is not added if the symbol is missing.
```r
  109: domain$wrapSync
  108: promises::with_promise_domain
  107: withReactiveDomain
  106: domain$wrapSync
  105: promises::with_promise_domain
  104: ctx$run
  103: self$.updateValue
  102: ..stacktraceoff..
  101: geneinfo_data
  100: func
   99: renderUI
   98: func
   97: force
   96: withVisible
   95: withCallingHandlers
   94: domain$wrapSync
   93: promises::with_promise_domain
   92: captureStackTraces
   91: doTryCatch
   90: tryCatchOne
   89: tryCatchList
   88: tryCatch
   87: do
   86: hybrid_chain
   85: renderFunc
   84: output$dataview-geneinfo-mod-renderfigure
```
## Examples

- If a dataset has features that did not map to symbol (any dataset), we will get this error:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/c61b10e2-a519-4394-a4b5-6736b98b072a">


- after the fix
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/114236b0-ceb7-4db4-9db2-8616a3ca21bf">



