### PR TITLE
Update labeltype input selector when datasets is changed

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -695,6 +695,23 @@ app_server <- function(input, output, session) {
     }
   )
 
+  # if labeltype is updated (via different pgx data types), we need to update the selector choice
+  shiny::observeEvent(
+    {
+      labeltype()
+    },
+    {
+      # if input$selected_labeltype does not match labeltype, we need to update the selector
+      if (input$selected_labeltype != labeltype()) {
+        shiny::updateSelectInput(
+          session,
+          "selected_labeltype",
+          selected = labeltype()
+        )
+      }
+    }
+  )
+
   ## -------------------------------------------------------------
   ## Session Timers
   ## -------------------------------------------------------------


### PR DESCRIPTION
This pull request updates the labeltype input selector when the datasets are changed. Previously, when the labeltype was updated via different pgx data types, the selector choice was not updated accordingly. This PR fixes that issue by checking if the selected labeltype matches the current labeltype, and if not, updating the selector to reflect the current labeltype.