### PR TITLE
binarize continous phenotype variables 

### DIFF
--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -185,19 +185,12 @@ upload_module_makecontrast_server <- function(
           "Please select at least one phenotype"
         ))
 
+        ## create conditions from phenotype matrix
         df <- phenoRT()
         if ("<samples>" %in% input$param) {
           df <- cbind(df, "<samples>" = rownames(df))
         }
-        df <- type.convert(df, as.is = TRUE)
-        ii <- which(sapply(df, class) %in% c("numeric", "integer"))
-        if (length(ii)) {
-          for (i in ii) {
-            x <- df[, i]
-            df[, i] <- c("low", "high")[1 + 1 * (x >= mean(x, na.rm = TRUE))]
-          }
-        }
-        
+        df <- playbase::binarizeNumericalColumns(df) 
         pp <- intersect(input$param, colnames(df))
         ss <- colnames(countsRT())
         df1 <- df[ss, pp, drop = FALSE]


### PR DESCRIPTION
This PR enables continuous phenotypes to be binarized (at median) to be used in making contrast. Partly adressing issue #518 

This worked before but somehow did not work anymore. Reason was that the internal sample matrix was "matrix" instead of "data.frame". This is fixed in this PR, and binarizeNumericalColumns was rewritten. Needs latest updated playbase.