### PR TITLE
feat: no title on ggplot volcano plots

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -153,7 +153,8 @@ enrichment_plot_volcano_server <- function(id,
         xlab = "Effect size (log2FC)",
         ylab = "Significance (-log10q)",
         marker.size = 1,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 
@@ -175,7 +176,8 @@ enrichment_plot_volcano_server <- function(id,
         marker.size = 2,
         label.cex = 6,
         axis.text.size = 24,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 

--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -190,7 +190,8 @@ enrichment_plot_volcanoall_server <- function(id,
         xlab = "Effect size (log2FC)",
         ylab = "Significance (-log10p)",
         marker.size = 1.2,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 

--- a/components/board.enrichment/R/enrichment_plot_volcanomethods.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanomethods.R
@@ -173,7 +173,8 @@ enrichment_plot_volcanomethods_server <- function(id,
         xlab = "Effect size (log2FC)",
         ylab = "Significance (-log10p)",
         marker.size = 1.2,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -190,7 +190,8 @@ expression_plot_volcano_server <- function(id,
         xlab = "Effect size (log2FC)",
         ylab = pd[["ylab"]],
         marker.size = 1,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 
@@ -215,7 +216,8 @@ expression_plot_volcano_server <- function(id,
         xlab = "Effect size (log2FC)",
         ylab = pd[["ylab"]],
         marker.size = 1.8,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -215,7 +215,8 @@ expression_plot_volcanoAll_server <- function(id,
         psig = pd[["fdr"]],
         lfc = pd[["lfc"]],
         marker.size = 1.2,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -238,7 +238,8 @@ expression_plot_volcanoMethods_server <- function(id,
         label.cex = label.cex,
         ylab = "Significance (-log10q)",
         xlab = "Effect size (log2FC)",
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 

--- a/components/board.signature/R/signature_plot_volcano.R
+++ b/components/board.signature/R/signature_plot_volcano.R
@@ -267,7 +267,8 @@ signature_plot_volcano_server <- function(id,
         xlab = "Effect size (log2FC)",
         ylab = "Significance (-log10p)",
         marker.size = 1.2,
-        showlegend = FALSE
+        showlegend = FALSE,
+        title = NULL
       )
     }
 


### PR DESCRIPTION
## Description
Set the title argument to `NULL` for the ggplot volcanos, this is to match the current plotly counterparts.

### Plotly
![image](https://github.com/user-attachments/assets/b0f893d8-208e-425b-af7e-5e53ec98bf9d)

### Before
![image](https://github.com/user-attachments/assets/2e1b4d57-fbf5-4546-ac24-b37ade61ec8a)

### After
![image](https://github.com/user-attachments/assets/df49e0f6-78ef-4d33-8858-27660f2fc876)
