### PR TITLE
Fix #1109: Unable to delete message should be changed 

### DIFF
--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -634,9 +634,17 @@ loading_table_datasets_server <- function(id,
             inputId = "confirmdelete"
           )
         } else {
+          msg <- paste(
+            "Deleteing is disabled for your account.",
+            "Please <a href='https://events.bigomics.ch/upgrade' target='_blank'>",
+            "<b><u>upgrade</u></b></a> to enable it."
+          )
           shinyalert::shinyalert(
             title = "Oops!",
-            text = "Delete is disabled for your account"
+            text = HTML(msg),
+            showCancelButton = TRUE,
+            showConfirmButton = FALSE,
+            html = TRUE
           )
         }
       },


### PR DESCRIPTION
This closes #1109 

## Description
I took a slightly different approach to replicate the same style of message displayed when users exceed max datasets.

![image](https://github.com/user-attachments/assets/615c3fbd-66ab-4f2d-991c-eb49537f89b5)

Unfortunately shinyalert escapes html from the text on the buttons, so we would need to hack it a little bit to add links there. I thought it was easier and more convenient to add it as text, just as we already do for max datasets.

```
  msg <- paste(
    msg, "Please <a href='https://events.bigomics.ch/upgrade' target='_blank'>",
    "<b><u>upgrade</u></b></a> or get free extra datasets by entering our",
    "<a href='https://bigomics.ch/contact-us' target='_blank'><b><u>Ambassador",
    "or Promoter</u></b></a> program."
  )

  shinyalert::shinyalert(
    title = "Your storage is full!",
    text = HTML(msg),
    html = TRUE,
    type = "warning"
  )
```