### PR TITLE
fix: check dimensions of table

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -664,7 +664,7 @@ upload_module_normalization_server <- function(
           list(r_counts(), r_samples(), r_contrasts())
         },
         {
-          shiny::req(r_counts(), r_samples(), r_contrasts())
+          shiny::req(dim(r_counts()), dim(r_samples()), dim(r_contrasts()))
           X <- r_counts()
           samples <- r_samples()
           contrasts <- r_contrasts()


### PR DESCRIPTION
## Description
This fixes an issue found by Axel when uploading data. Related to `shiny::req` not being quite stable when used with matrices. It is more robust to check dimensions/length/etc rather than the contents of a matrix.