### PR TITLE
autodetect of metabolomics probetype; remove probetype selectinput

### DIFF
--- a/components/board.upload/R/upload_ui.R
+++ b/components/board.upload/R/upload_ui.R
@@ -34,7 +34,7 @@ UploadUI <- function(id) {
             selected = DEFAULTS$datatype
           )
         ),
-        shiny::uiOutput(ns("probe_type_ui")),
+##        shiny::uiOutput(ns("probe_type_ui")),
         div(
           p("Organism:", style = "text-align: left; margin: 0 0 2px 0; font-weight: bold;"),
           shiny::selectInput(

--- a/scss/components/_wizard.scss
+++ b/scss/components/_wizard.scss
@@ -12,9 +12,9 @@
 }
 
 .wizard .wizard-nav.dots .wizard-step .dot {
-    top: -25px;
-    height: 18px;
-    width: 18px;
+    top: -25px !important;
+    height: 18px !important;
+    width: 18px !important;
 }
 
 .wizard .wizard-content {


### PR DESCRIPTION
Added auto detection of probetype for metabolomics. Removes manual selection of probetype at uploading. Needs updated playbase with new function `mbx.detect_probetype()`

