### PR TITLE
Fix #1137: Clustering undefined columns selected when pheno name contains spaces

### DIFF
--- a/components/board.clustering/R/clustering_plot_phenoplot.R
+++ b/components/board.clustering/R/clustering_plot_phenoplot.R
@@ -58,7 +58,7 @@ clustering_plot_phenoplot_server <- function(id,
       pos <- pos[jj, ]
       Y <- pgx$Y[jj, kk, drop = FALSE]
       ## complete dataframe for downloading
-      df <- data.frame(pos, Y)
+      df <- data.frame(pos, Y, check.names = FALSE)
       return(df)
     })
 

--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -232,7 +232,7 @@ clustering_plot_splitmap_server <- function(id,
       splitx <- filt$grp
 
       ## iheatmapr needs factors for sharing between groups
-      annotF <- data.frame(as.list(annot), stringsAsFactors = TRUE)
+      annotF <- data.frame(as.list(annot), stringsAsFactors = TRUE, check.names = FALSE)
       rownames(annotF) <- rownames(annot)
 
       sel <- selected_phenotypes()


### PR DESCRIPTION
This closes #1137 

## Description
Checking names when creating a data frame will remove spaces, which are present on the phenotype names -- therefore crashing the plots. By not checking them we keep the same names and the plots are fine.