### PR TITLE
feat: add req for data change

### DIFF
--- a/components/board.dataview/R/dataview_table_rawdata.R
+++ b/components/board.dataview/R/dataview_table_rawdata.R
@@ -71,6 +71,9 @@ dataview_table_rawdata_server <- function(id,
       }
       x0 <- x
 
+      # Handle to avoid errors on dataset change
+      shiny::req(any(rownames(x) == gene))
+
       k <- which(rownames(x) == gene)
       rho <- cor(t(logx), logx[k, ], use = "pairwise")[, 1]
       rho <- rho[match(rownames(x), names(rho))]


### PR DESCRIPTION
When changing datasets, at a point on the reactivity triggered by it, the selected gene is still from the old data, which can be that is not found on the new dataset. That caused an error; by adding this `req` we avoid it. 

## Improvements
1. no split-second error message is displayed on the platform
2. no ticket is created