### PR TITLE
feat: normalization defaults for proteomics

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -766,11 +766,16 @@ upload_module_normalization_server <- function(
                   ns = ns,
                   shiny::selectInput(
                     ns("normalization_method"), NULL,
-                    choices = c(
-                      "CPM", "CPM+quantile", ## "quantile",
-                      "maxMedian", "maxSum", ## "TMM",
-                      "reference"
-                    ),
+                    choices = if(grepl("proteomics", upload_datatype(), ignore.case = TRUE)){
+                      c(
+                        "maxMedian", "maxSum", ## "TMM",
+                        "reference"
+                      )} else {
+                      c(
+                        "CPM", "CPM+quantile", ## "quantile",
+                        "maxMedian", "maxSum", ## "TMM",
+                        "reference"
+                      )},
                     selected = ifelse(grepl("proteomics", upload_datatype(), ignore.case = TRUE),
                       "maxMedian", "CPM+quantile"
                     )


### PR DESCRIPTION
As per MA request:

When uploading proteomics data, do not display CPM/CPM+quantile normalizatioin methods.