### PR TITLE
Fix bad cookies

### DIFF
--- a/components/modules/AuthenticationModule.R
+++ b/components/modules/AuthenticationModule.R
@@ -913,7 +913,7 @@ LoginCodeAuthenticationModule <- function(id,
     ## --------------------------------------
     decrypted_cookie <- get_and_decrypt_cookie(session)
     query_email <- shiny::isolate(shiny::getQueryString()$email)
-    if (!is.null(query_email)) {
+    if (!is.null(query_email) & !is.null(decrypted_cookie)) {
       if (query_email != decrypted_cookie) {
         # If the query email is different than the cookie email
         # we assume that the user wants to login

--- a/components/modules/CookiesModule.R
+++ b/components/modules/CookiesModule.R
@@ -16,8 +16,16 @@ extract_cookie_value <- function(session, cookie_name) {
 # Decrypt cookie
 decrypt_cookie <- function(cookie, nonce) {
   key_base64 <- readLines(file.path(OPG, "etc/keys/cookie.txt"))[1]
-  email_nonce_raw <- sodium::hex2bin(nonce)
-  email_raw <- sodium::hex2bin(cookie)
+  email_nonce_raw <- tryCatch({
+    sodium::hex2bin(nonce)
+  }, error = function(w) {
+    ""
+  })
+  email_raw <- tryCatch({
+    sodium::hex2bin(cookie)
+  }, error = function(w) {
+    ""
+  })
   attr(email_raw, "nonce") <- email_nonce_raw
   # Return NULL if not successful decryption
   email <- tryCatch(


### PR DESCRIPTION
## Description
If the `decrypted_cookie` not checked for non-null, a malformed / broken cookie breaks the application, as on the following line the comparison does not yield a TRUE/FALSE value.

Also: a broken cookie can stop the application when converting from hex to bin; adding a trycatch to
handle it.