### PR TITLE
Fix #1143: Sample QC broken if NAs on X matrix

### DIFF
--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -381,7 +381,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         ss <- names(total.counts)
         prop.counts <- prop.counts[, ss, drop = FALSE]
         counts <- counts[, ss, drop = FALSE]
-        if (any(pgx$X[, samples, drop = FALSE] < 0)) {
+        if (any(pgx$X[, samples, drop = FALSE] < 0, na.rm = TRUE)) {
           offset <- 1e-6
         } else {
           offset <- 1


### PR DESCRIPTION
This closes #1143 

## Description
If there are NAs inside the `any`, it returns a non-logical value that breaks the if statement

@ivokwee I can send you the dataset to double check