### PR TITLE
Fix #1145: Drugconnectivity breaks for single contrast dataset

### DIFF
--- a/components/board.drugconnectivity/R/drugconnectivity_plot_actmap.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_plot_actmap.R
@@ -107,7 +107,7 @@ drugconnectivity_plot_actmap_server <- function(id,
         } else {
           score <- score[order(-score[, 1]), , drop = FALSE]
         }
-        score <- score[nrow(score):1, ]
+        score <- score[nrow(score):1, , drop = FALSE]
 
         colnames(score) <- substring(colnames(score), 1, 30)
         rownames(score) <- substring(rownames(score), 1, 50)


### PR DESCRIPTION
This closes #1145 

## Description
Single contrast dataset break with `drop = TRUE`

Same dataset as #1144 