### PR TITLE
Fix #1147: NA genesets on enrichment analysis

### DIFF
--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -242,7 +242,6 @@ EnrichmentBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$
           names(meta.fc) <- rownames(pgx$gset.meta$meta[[comp]])
 
           # subset rnaX by pp
-
           AveExpr1 <- Matrix::rowMeans(G %*% rnaX[pp, s1], na.rm = TRUE) / ngenes
           AveExpr0 <- Matrix::rowMeans(G %*% rnaX[pp, s0], na.rm = TRUE) / ngenes
           remove(rnaX)
@@ -254,9 +253,9 @@ EnrichmentBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$
         AveExpr0 <- mean0 - meta.fc / 2
 
         # Subset meta.fc with non-na values
-        meta.fc <- meta.fc[!is.na(meta.fc)]
-
+        meta.fc <- meta.fc[which(!is.na(meta.fc) & !is.na(mean0))]
         gs <- intersect(names(meta.fc), rownames(meta))
+
         if (!is.data.frame(pgx$gset.meta$info)) {
           rpt <- data.frame(
             logFC = meta.fc[gs],

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -253,6 +253,9 @@ EnrichmentBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$
         AveExpr1 <- mean0 + meta.fc / 2
         AveExpr0 <- mean0 - meta.fc / 2
 
+        # Subset meta.fc with non-na values
+        meta.fc <- meta.fc[!is.na(meta.fc)]
+
         gs <- intersect(names(meta.fc), rownames(meta))
         if (!is.data.frame(pgx$gset.meta$info)) {
           rpt <- data.frame(


### PR DESCRIPTION
This closes #1147 

## Description
If not filtered out they are displayed as NA rows, which then break the other plots.

Same dataset as #1144 