### PR TITLE
Fix #1156: Clustering>Samples>Pheno distri error when no phenotype is selected

### DIFF
--- a/components/board.clustering/R/clustering_plot_phenoplot.R
+++ b/components/board.clustering/R/clustering_plot_phenoplot.R
@@ -66,6 +66,10 @@ clustering_plot_phenoplot_server <- function(id,
       pd <- plot_data()
       showlabels <- input$showlabels
       pheno <- selected_phenotypes()
+      shiny::validate(shiny::need(
+        length(pheno) > 0,
+        "Please select at least one phenotype."
+      ))
       Y <- pd[, pheno, drop = FALSE]
       pos <- pd[, c("x", "y")]
 


### PR DESCRIPTION
This closes #1156

## Description
Added a validator function to check the length of the `pheno` object.

![image](https://github.com/user-attachments/assets/de3f4274-e90f-48df-af35-da899befa49c)
