### PR TITLE
Fix #1158: Test genesets: 'x' must be an array of at least two dimensions

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -680,6 +680,7 @@ app_server <- function(input, output, session) {
         info("[SERVER] disabling WGCNA and PCSF for metabolomics data")
         bigdash.hideTab(session, "pcsf-tab")
         bigdash.hideTab(session, "wgcna-tab")
+        bigdash.hideTab(session, "cmap-tab")
       }
 
       info("[SERVER] trigger on change dataset done!")

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -1137,15 +1137,15 @@ app_server <- function(input, output, session) {
 
     # Skip if error is repeated
     # Initialize variable as well
-    if (!exists("err_traceback_prev")) {
-      err_traceback_prev <<- ""
+    if (!exists("err_prev")) {
+      err_prev <<- ""
     }
-    if (err_traceback == err_traceback_prev) {
+    if (error$message == err_prev) {
       return()
     }
 
     # Save globally last error
-    err_traceback_prev <<- err_traceback
+    err_prev <<- error$message
 
     pgx_name <- NULL
     user_email <- auth$email

--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -318,7 +318,7 @@ SignatureBoard <- function(id, pgx,
 
       N <- cbind(
         k1 = Matrix::rowSums(G != 0), n1 = ncol(G),
-        k2 = Matrix::rowSums(G[, ii] != 0), n2 = length(ii)
+        k2 = Matrix::rowSums(G[, ii, drop = FALSE] != 0), n2 = length(ii)
       )
       rownames(N) <- rownames(G)
       N <- N[which(N[, 1] > 0 | N[, 3] > 0), ]
@@ -348,7 +348,7 @@ SignatureBoard <- function(id, pgx,
       names(fx) <- gg
 
       gset <- names(y)[which(y != 0)]
-      G1 <- G[aa, which(y != 0)]
+      G1 <- G[aa, which(y != 0), drop = FALSE]
       commongenes <- apply(G1, 1, function(x) colnames(G1)[which(x != 0)])
       for (i in 1:length(commongenes)) {
         gg <- commongenes[[i]]


### PR DESCRIPTION
This closes #1158 

## Description
as always, single case breaks things. adding `drop=FALSE`.

![image](https://github.com/user-attachments/assets/661fc9d5-f45e-43ce-9e6f-b94fc20a0df1)
