### PR TITLE
Fix #1166: Biomarkers: error on dataset change

### DIFF
--- a/components/board.biomarker/R/biomarker_plot_boxplots.R
+++ b/components/board.biomarker/R/biomarker_plot_boxplots.R
@@ -66,6 +66,7 @@ biomarker_plot_boxplots_server <- function(id,
       plot_data <- shiny::reactive({
         res <- calcVariableImportance()
         shiny::req(res)
+        shiny::req(is_computed())
 
         ## get variables used in the tree solution
         vars <- setdiff(res$rf$frame$var, "<leaf>")
@@ -103,7 +104,6 @@ biomarker_plot_boxplots_server <- function(id,
       plot.RENDER <- function() {
         pdata <- plot_data()
 
-        shiny::validate(shiny::need(is_computed(), "Please select target class and run 'Compute'"))
         shiny::req(pdata)
 
         ## vars, X, y

--- a/components/board.biomarker/R/biomarker_plot_decisiontree.R
+++ b/components/board.biomarker/R/biomarker_plot_decisiontree.R
@@ -56,13 +56,13 @@ biomarker_plot_decisiontree_server <- function(id,
       plot_data <- shiny::reactive({
         res <- calcVariableImportance()
         shiny::req(res)
+        shiny::req(is_computed())
         return(res)
       })
 
       plot.RENDER <- function() {
         res <- plot_data()
 
-        shiny::validate(shiny::need(is_computed(), "Please select target class and run 'Compute'"))
         shiny::req(res)
         par(mfrow = c(1, 1), mar = c(1, 0, 2, 0))
         is.surv <- grepl("Surv", res$rf$call)[2]

--- a/components/board.biomarker/R/biomarker_plot_heatmap.R
+++ b/components/board.biomarker/R/biomarker_plot_heatmap.R
@@ -70,6 +70,7 @@ biomarker_plot_heatmap_server <- function(id,
       ## return data structure for plots
       plot_data <- shiny::reactive({
         shiny::req(pgx$X)
+        shiny::req(is_computed())
 
         res <- calcVariableImportance()
         if (is.null(res)) {

--- a/components/board.biomarker/R/biomarker_server.R
+++ b/components/board.biomarker/R/biomarker_server.R
@@ -147,7 +147,8 @@ BiomarkerBoard <- function(id, pgx) {
         list(
           input$pdx_predicted,
           input$pdx_samplefilter,
-          input$pdx_filter
+          input$pdx_filter,
+          pgx$X
         )
       },
       {


### PR DESCRIPTION
This closes #1166 

## Description
First of all, set `is_computed` to `FALSE` on dataset change 

https://github.com/bigomics/omicsplayground/compare/fix-1166?expand=1#diff-6b0bf34f6e06c7f0b4db18ca6cdb1f987a2fdaf14765c0862fdb307808463adcL149-L154

Then, add `shiny::req` for `is_computed` so plots are left blank (as on the inital state of the application) instead of the 4 of them displaying "Please select target class and run 'Compute'".