### PR TITLE
Fix #1168: Sample heatmap, splitby gene breaks on some genes

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -151,7 +151,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
           return()
         }
         if (input$hm_splitby == "gene") {
-          xgenes <- sort(rownames(pgx$X))
+          xgenes <- sort(rownames(getFilteredMatrix()$zx))
           shiny::updateSelectizeInput(session, "hm_splitvar", choices = xgenes, server = TRUE)
         }
         if (input$hm_splitby == "phenotype") {


### PR DESCRIPTION
This closes #1168 

## Description
`getFilteredMatrix()$zx` dimensions do not match `pgx$X` (mouse dataset hubspot ticket 9820365760) since `zx` is filtered. Given `splitvar` gene is used to subset `zx`, this leads to a subsetting error.