### PR TITLE
Fix #1171: Test geneset markers: subscript out of bounds (custom)

### DIFF
--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -171,7 +171,7 @@ SignatureBoard <- function(id, pgx,
           }
           genes <- union(genes, rx.genes)
         }
-        genes <- intersect(genes, symbols)
+        genes <- intersect(toupper(genes), symbols)
         ## map to probes
         features1 <- playbase::map_probes(pgx$genes, genes,
           column = "human_ortholog", ignore.case = TRUE

--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -171,6 +171,7 @@ SignatureBoard <- function(id, pgx,
           }
           genes <- union(genes, rx.genes)
         }
+        genes <- intersect(genes, symbols)
         ## map to probes
         features1 <- playbase::map_probes(pgx$genes, genes,
           column = "human_ortholog", ignore.case = TRUE


### PR DESCRIPTION
This closes #1171 

![image](https://github.com/user-attachments/assets/d378f5ca-0af5-4ab1-834b-4e79365431bd)
