### PR TITLE
Fix #1180: Data upload: umap plot error no match between samples/counts

### DIFF
--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -200,6 +200,10 @@ upload_table_preview_samples_server <- function(
       y <- Y[, sel]
       hilight2 <- colnames(X)
       if (ncol(X) > 100) hilight2 <- NULL
+      shiny::validate(shiny::need(
+        any(rownames(X) %in% names(y)),
+        "No matches between samples and counts."
+      ))
       playbase::pgx.dimPlot(
         X, y,
         method = "umap",


### PR DESCRIPTION
This closes #1180 

## Description
Control the case with shiny validate.

![image](https://github.com/user-attachments/assets/0aae23bc-aae7-45d0-983d-cdd64cb63a90)
