### PR TITLE
Fix #1192: Go graph: object of type 'closure' is not subsettable

### DIFF
--- a/components/board.pathway/R/pathway_table_go_table.R
+++ b/components/board.pathway/R/pathway_table_go_table.R
@@ -75,7 +75,7 @@ functional_table_go_table_server <- function(id,
       filtertable <- fa_filtertable()
       if (filtertable) {
         filter_value <- as.numeric(fa_filtertable_value())
-        df <- df[which(df$meta.q < filter_value), ]
+        dt <- dt[which(dt$meta.q < filter_value), ]
       }
 
       id2 <- paste0("abc(", sub(":", "_", dt$id), ")") ## to match with wrapHyperLink


### PR DESCRIPTION
This closes #1192 

## Description
We were trying to subset the `df` table, which does not exist on this module. Changed for the correct table (`dt`).

![image](https://github.com/user-attachments/assets/ca38a116-4760-40ba-9201-83b04180fee5)
