### PR TITLE
Allow categorical phenotypes with only 1 sample per group

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -57,7 +57,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     shiny::observeEvent(pgx$Y, {
       shiny::req(pgx$Y)
       ## input$menuitem  ## upon menuitem change
-      var.types <- colnames(pgx$Y)
+      var.types <- playbase::pgx.getCategoricalPhenotypes(pgx$samples, min.ncat = 2, max.ncat = 999) 
       var.types <- var.types[grep("sample|patient", var.types, invert = TRUE)]
       vv <- c(var.types, rep("<none>", 10))
       var.types0 <- c("<none>", "<cluster>", var.types)

--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -67,7 +67,7 @@ dataview_plot_expression_server <- function(id,
       grpvar <- 1
       grp <- rep(NA, length(samples))
       if (groupby != "<ungrouped>") {
-        grp <- factor(as.character(pgx$Y[samples, groupby]))
+        grp <- factor(as.character(pgx$samples[samples, groupby]))
       }
       # Req to avoid error on dataset change
       shiny::req(length(grp) == length(samples))


### PR DESCRIPTION
Allow categorical phenotypes with only 1 sample per group. Previously this was not allowed because these could be sample names or ids. But some users have "1 sample/replicate per group" data. 