### PR TITLE
Fix #1196: Clustering > Samples: (k=1) Module expression attempt to set 'colnames' on an object with less than two dimensions

### DIFF
--- a/components/board.clustering/R/clustering_plot_genemodule.R
+++ b/components/board.clustering/R/clustering_plot_genemodule.R
@@ -66,6 +66,10 @@ clustering_plot_genemodule_server <- function(id,
       mat <- res$mat
       idx <- res$idx
       modx <- sapply(1:ncol(mat), function(i) tapply(mat[, i], idx, mean))
+      if (is.null(dim(modx))) {
+        modx <- matrix(modx, nrow = 1)
+        rownames(modx) <- unique(idx)
+      }
       colnames(modx) <- colnames(mat)
 
       return(list(


### PR DESCRIPTION
This closes #1196 

## Description
sapply returns a numeric vector, make it a single row matrix so downstream code works as expected

![image](https://github.com/user-attachments/assets/0fd561f5-dadd-41e5-8a73-6fb6d0555e90)
