### PR TITLE
Fix #1198: Cluster > Samples: Filter + average: argument of length 0

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -111,6 +111,10 @@ clustering_plot_splitmap_server <- function(id,
       annot <- filt$annot
       zx.idx <- filt$idx
 
+      shiny::validate(shiny::need(
+        ncol(zx) > 1, "Filtering too restrictive. Please change 'Filter samples' settings."
+      ))
+
       return(list(
         zx = zx,
         annot = annot,


### PR DESCRIPTION
This closes #1198 

## Description
if filter is so restrictive heatmap is just one column, then it crashes, 1 column heatmap makes no sense so better to validate that we have at least two columns, putting this code on the plot_data function ensures that both static and dynamic are OK

![image](https://github.com/user-attachments/assets/9a0f8a39-b155-4592-bb41-caca4b9db24e)
