### PR TITLE
Fix #1202: Package versions: length of 'dimnames' [2] not equal to array extent

### DIFF
--- a/components/board.user/R/appsettings_server.R
+++ b/components/board.user/R/appsettings_server.R
@@ -38,10 +38,7 @@ AppSettingsBoard <- function(id, auth, pgx) {
     )
 
     packages.RENDER <- function() {
-      pkg <- read.table(file.path(OPG, "RPackageLicenses.txt"), sep = "!", header = TRUE)[, 1]
-      pkg <- strsplit(gsub("[ ]{2,}", ",", trimws(pkg)), split = ",")
-      pkg <- do.call(rbind, pkg)
-      colnames(pkg) <- c("Package", "Version", "License")
+      pkg <- read.table(file.path(OPG, "RPackageLicenses.txt"), sep = "\t", header = TRUE)
       DT::datatable(pkg,
         rownames = FALSE,
         plugins = "scrollResize",


### PR DESCRIPTION
This closes #1202 

## Description
Parse file with current format.

![image](https://github.com/user-attachments/assets/1324c737-cdfa-4ef8-8326-f32fda56f36b)
