### PR TITLE
Fix #1206: Feature-set ranking: No finite residual standard deviations

### DIFF
--- a/components/board.biomarker/R/biomarker_plot_featurerank.R
+++ b/components/board.biomarker/R/biomarker_plot_featurerank.R
@@ -159,7 +159,13 @@ biomarker_plot_featurerank_server <- function(id,
           if (method %in% c("p-value", "meta")) {
             jj <- which(!is.na(grp))
             design <- model.matrix(~ grp[jj])
-            suppressWarnings(fit <- limma::eBayes(limma::lmFit(X1[, jj, drop = FALSE], design)))
+            fit <- tryCatch({
+              suppressWarnings(limma::eBayes(limma::lmFit(X1[, jj, drop = FALSE], design)))
+            }, error = function(w){NA})
+            if (all(is.na(fit))) {
+              score[j] <- NA
+              next
+            }
             suppressWarnings(suppressMessages(top <- limma::topTable(fit)))
             s2 <- mean(-log10(1e-99 + top$adj.P.Val), na.rm = TRUE)
           }


### PR DESCRIPTION
This closes #1206 

## Description
Ensures that if a certain iteration fails, the others are computed properly. Failed iterations are set to NA

![image](https://github.com/user-attachments/assets/99189ce4-51b4-4380-8a48-20507324766e)
