### PR TITLE
fix: must check on colnames

### DIFF
--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -201,7 +201,7 @@ upload_table_preview_samples_server <- function(
       hilight2 <- colnames(X)
       if (ncol(X) > 100) hilight2 <- NULL
       shiny::validate(shiny::need(
-        any(rownames(X) %in% names(y)),
+        any(colnames(X) %in% names(y)),
         "No matches between samples and counts."
       ))
       playbase::pgx.dimPlot(

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -201,7 +201,7 @@ upload_table_preview_samples_server <- function(
       hilight2 <- colnames(X)
       if (ncol(X) > 100) hilight2 <- NULL
       shiny::validate(shiny::need(
-        any(colnames(X) %in% names(y)),
+        any(colnames(X) %in% rownames(Y)),
         "No matches between samples and counts."
       ))
       playbase::pgx.dimPlot(


### PR DESCRIPTION
this PR contained an error, the match is between colnames and names, not rownames! this still fixes the original issue while working properly on correct data

with example-data

## Before

![image](https://github.com/user-attachments/assets/a5730e67-85d0-4331-a340-f7d40855d5c1)

## After

![image](https://github.com/user-attachments/assets/35658632-ef71-48e4-b7c0-56b91a1153cc)
