### PR TITLE
feat: labeltype to average rank plot

### DIFF
--- a/components/board.dataview/R/dataview_plot_averagerank.R
+++ b/components/board.dataview/R/dataview_plot_averagerank.R
@@ -33,6 +33,7 @@ dataview_plot_averagerank_server <- function(id,
                                              r.gene = reactive(""),
                                              r.samples = reactive(""),
                                              r.data_type = reactive("counts"),
+                                             labeltype,
                                              watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     plot_data <- shiny::reactive({
@@ -111,6 +112,9 @@ dataview_plot_averagerank_server <- function(id,
       if (length(ii) > 200) {
         ii <- c(1:200, seq(201, length(mean.fc), 10))
       }
+
+      # Translate gene to labeltype
+      gene <- playbase::probe2symbol(gene, pgx$genes, labeltype(), fill_na = TRUE)
 
       fig <-
         plotly::plot_ly(

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -183,6 +183,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       r.gene = reactive(input$search_gene),
       r.samples = selected_samples,
       r.data_type = reactive(input$data_type),
+      labeltype = labeltype,
       watermark = WATERMARK
     )
 


### PR DESCRIPTION
## Description
Adds the capability to change the gene name on the average rank plot based on labeltype.

![image](https://github.com/user-attachments/assets/79e361d6-dd3f-4223-8338-3b39bf96a555)
