### PR TITLE
Fix #1214: Remove outliers not working as expected

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -131,8 +131,7 @@ upload_module_normalization_server <- function(
         if (input$remove_outliers) {
           threshold <- input$outlier_threshold
           dbg("[normalization_server:cleanX] Removing outliers: Threshold = ", threshold)
-          X_subset <- head(X[order(-matrixStats::rowSds(X)), ], 1000)
-          res <- playbase::detectOutlierSamples(X_subset, plot = FALSE)
+          res <- playbase::detectOutlierSamples(X, plot = FALSE)
           is.outlier <- (res$z.outlier > threshold)
           if (any(is.outlier) && !all(is.outlier)) {
             X <- X[, which(!is.outlier), drop = FALSE] ## also filter counts?
@@ -308,7 +307,6 @@ upload_module_normalization_server <- function(
           shiny::validate(shiny::need(!is.null(X), "no data. please upload."))
           shiny::validate(shiny::need(!is.null(nrow(X)), "no data. please upload."))
 
-          X <- head(X[order(-matrixStats::rowSds(X)), ], 1000)
           out <- playbase::detectOutlierSamples(X, plot = FALSE)
 
           nb <- min(30, dim(X) / 5)

--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -131,7 +131,8 @@ upload_module_normalization_server <- function(
         if (input$remove_outliers) {
           threshold <- input$outlier_threshold
           dbg("[normalization_server:cleanX] Removing outliers: Threshold = ", threshold)
-          res <- playbase::detectOutlierSamples(X, plot = FALSE)
+          X_subset <- head(X[order(-matrixStats::rowSds(X)), ], 1000)
+          res <- playbase::detectOutlierSamples(X_subset, plot = FALSE)
           is.outlier <- (res$z.outlier > threshold)
           if (any(is.outlier) && !all(is.outlier)) {
             X <- X[, which(!is.outlier), drop = FALSE] ## also filter counts?


### PR DESCRIPTION
This closes #1214 

## Description
This subseted matrix is the same matrix used to display the outliers plot, otherwise there is a mismatch between outliers on the plot and outliers at this stage. By doing the same subset we remove the outliers marked on the plot (expected behaviour).

This PR can be validated using example upload data and setting remove outliers threshold to 3. Before, no sample was removed, after this PR the correct sample will be removed.
