### PR TITLE
Fix #1220: Data upload: need finite 'xlim' values (missing values)

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -307,6 +307,11 @@ upload_module_normalization_server <- function(
           shiny::validate(shiny::need(!is.null(X), "no data. please upload."))
           shiny::validate(shiny::need(!is.null(nrow(X)), "no data. please upload."))
 
+          nmissing1 <- sum(is.na(X))
+          if (nmissing1 > 0) {
+            X <- playbase::imputeMissing(X, method = "SVD2")
+          }
+
           out <- playbase::detectOutlierSamples(X, plot = FALSE)
 
           nb <- min(30, dim(X) / 5)


### PR DESCRIPTION
This closes #1220 

## Description
Do the same we do on `results_correction_methods`, if NAs, impute; otherwise PCA returns full NAs

![image](https://github.com/user-attachments/assets/264ff324-bde5-4759-9316-9727e030409e)
