### PR TITLE
Fix #1228: Expression > Correlation: Multiple errors

### DIFF
--- a/components/board.correlation/R/correlation_plot_barplot.R
+++ b/components/board.correlation/R/correlation_plot_barplot.R
@@ -90,7 +90,7 @@ correlation_plot_barplot_server <- function(id,
       sel <- intersect(sel, rownames(R))
       sel <- head(sel, NTOP)
       rho <- R[sel, "cor"]
-      if (length(sel) == 1) names(rho) <- rownames(R)[sel]
+      if (length(sel) == 1) names(rho) <- sel
 
       prho <- df$pcor
       names(prho) <- playbase::probe2symbol(rownames(df), pgx$genes, labeltype(), fill_na = TRUE)

--- a/components/board.correlation/R/correlation_plot_scattercorr.R
+++ b/components/board.correlation/R/correlation_plot_scattercorr.R
@@ -97,7 +97,7 @@ correlation_plot_scattercorr_server <- function(id,
 
       if (length(rho) == 1) names(rho) <- rownames(R)[1]
       pp <- unique(c(this.gene, names(rho)))
-      X <- pgx$X[pp, ]
+      X <- pgx$X[pp, , drop = FALSE]
 
       names(rho) <- playbase::probe2symbol(names(rho), pgx$genes, labeltype(), fill_na = TRUE)
       this.gene <- playbase::probe2symbol(this.gene, pgx$genes, labeltype(), fill_na = TRUE)


### PR DESCRIPTION
This closes #1228 

## Description
Two simple fixes, `drop = FALSE` and select correct string to assign.

![image](https://github.com/user-attachments/assets/48e3af2e-80d1-410e-9773-978d0f647b16)
