### PR TITLE
feat: save table on upload

### DIFF
--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -14,6 +14,8 @@ upload_table_preview_counts_ui <- function(id) {
 
 upload_table_preview_counts_server <- function(
     id,
+    create_raw_dir,
+    auth,
     uploaded,
     checked_matrix,
     checklist,
@@ -247,6 +249,22 @@ upload_table_preview_counts_server <- function(
           type = "error"
         )
         return()
+      }
+
+      # Save file
+      if (!is.null(raw_dir()) && dir.exists(raw_dir())) {
+        file.copy(
+          from = input$counts_csv$datapath,
+          to = paste0(raw_dir(), "/counts.csv"),
+          overwrite = TRUE
+        )
+      } else { # At first raw_dir will not exist, if the user deletes and uploads a different counts it will already exist
+        raw_dir(create_raw_dir(auth))
+        file.copy(
+          from = input$counts_csv$datapath,
+          to = paste0(raw_dir(), "/counts.csv"),
+          overwrite = TRUE
+        )
       }
 
       sel <- grep("count|expression|abundance", tolower(input$counts_csv$name))

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -280,6 +280,13 @@ upload_table_preview_samples_server <- function(
         return()
       }
 
+      # Save file
+      file.copy(
+        from = input$samples_csv$datapath,
+        to = paste0(raw_dir(), "/samples.csv"),
+        overwrite = TRUE
+      )
+
       uploaded$samples.csv <- playbase::read.as_matrix(input$samples_csv$datapath)
     })
 

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -203,17 +203,6 @@ UploadBoard <- function(id,
     ## ================== DATA LOADING OBSERVERS ===========================
     ## =====================================================================
 
-    ## ------------------------------------------------------------------
-    ## Observer for uploading data files using fileInput widget.
-    ##
-    ## Reads in the data files from the file names, checks and
-    ## puts in the reactive values object 'uploaded'. Then
-    ## uploaded should trigger the computePGX module.
-    ## ------------------------------------------------------------------
-
-
-    last_hash <- 1234
-
     create_raw_dir <- function(auth) {
       auth_id <- ifelse(!auth$email %in% c("", NA), auth$email, auth$username)
       prefix <- paste0("raw_", auth_id, "_")
@@ -242,12 +231,6 @@ UploadBoard <- function(id,
         ## Single matrix counts check
         ## --------------------------------------------------------
         df0 <- uploaded$counts.csv
-        if (!is.null(raw_dir()) && dir.exists(raw_dir())) {
-          write.csv(df0, file.path(raw_dir(), "counts.csv"), row.names = TRUE)
-        } else { # At first raw_dir will not exist, if the user deletes and uploads a different counts it will already exist
-          raw_dir(create_raw_dir(auth))
-          write.csv(df0, file.path(raw_dir(), "counts.csv"), row.names = TRUE)
-        }
         if (is.null(df0)) {
           return(NULL)
         }
@@ -369,12 +352,7 @@ UploadBoard <- function(id,
         df0 <- uploaded$samples.csv
         if (is.null(df0)) {
           return(list(status = "Missing samples.csv", matrix = NULL))
-        } else {
-          if (!is.null(raw_dir()) && dir.exists(raw_dir())) {
-            write.csv(df0, file.path(raw_dir(), "samples.csv"), row.names = TRUE)
-          }
         }
-
         ## Single matrix counts check
         res <- playbase::pgx.checkINPUT(df0, "SAMPLES")
 
@@ -1132,6 +1110,8 @@ UploadBoard <- function(id,
 
     upload_table_preview_counts_server(
       id = "counts_preview",
+      create_raw_dir = create_raw_dir,
+      auth = auth,
       uploaded = uploaded,
       checked_matrix = shiny::reactive(checked_counts()$matrix),
       checklist = checklist,


### PR DESCRIPTION
sometimes processing breaks the app, on those cases we do not grab the data, so we cannot reproduce and fix. this solves it.

We save the file on input change (user upload) rather than on the `uploaded$` reactive.