### PR TITLE
Fix #1244: Genset enrichment: subscript out of bounds (temp error)

### DIFF
--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -402,6 +402,7 @@ EnrichmentBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$
 
       ## in multi-mode we select *common* genes
       ns <- length(gs)
+      shiny::req(gs)
       gmt1 <- pgx$GMT[, gs, drop = FALSE]
       genes <- rownames(gmt1)[which(Matrix::rowSums(gmt1 != 0) == ns)]
       # check which columns are in pgx$genes


### PR DESCRIPTION
This closes #1244

## Description
`shiny::req` prevents error on geneset collection change

[Screencast from 2024-10-29 14-01-13.webm](https://github.com/user-attachments/assets/3a3de344-1e4a-46c5-ba61-ceddca36185b)
