### PR TITLE
Fix #1247: Cluster samples: Issue with gene/protein reference level on non-human data

### DIFF
--- a/components/board.clustering/R/clustering_plot_clustannot.R
+++ b/components/board.clustering/R/clustering_plot_clustannot.R
@@ -98,6 +98,7 @@ clustering_plot_clusterannot_server <- function(id,
         }
         ann.types <- setdiff(ann.types, "<all>") ## avoid slow...
         ann.types <- grep("^<", ann.types, invert = TRUE, value = TRUE) ## remove special groups
+        if (length(ann.types) == 0) ann.types <- "<all>" # bring back <all> is ann.types is empty
         sel <- ann.types[1]
         if ("H" %in% ann.types) sel <- "H"
         j <- grep("^transcription", ann.types, ignore.case = TRUE)

--- a/components/board.clustering/R/clustering_plot_clustannot.R
+++ b/components/board.clustering/R/clustering_plot_clustannot.R
@@ -92,7 +92,8 @@ clustering_plot_clusterannot_server <- function(id,
         }
         if (input$xann_level == "gene") {
           ann.types <- names(pgx$families)
-          cc <- sapply(pgx$families, function(g) length(intersect(g, rownames(pgx$X))))
+          genes <- playbase::probe2symbol(rownames(pgx$X), pgx$genes, "symbol", fill_na = TRUE)
+          cc <- sapply(pgx$families, function(g) length(intersect(toupper(g), toupper(genes))))
           ann.types <- ann.types[cc >= 3]
         }
         ann.types <- setdiff(ann.types, "<all>") ## avoid slow...

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -643,7 +643,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       ref <- pgx$X[, , drop = FALSE]
       if (ann.level == "gene" && ann.refset %in% names(pgx$families)) {
         gg <- pgx$families[[ann.refset]]
-        jj <- match(toupper(gg), toupper(pgx$genes$gene_name))
+        jj <- match(toupper(gg), toupper(pgx$genes$symbol))
         jj <- setdiff(jj, NA)
         pp <- rownames(pgx$genes)[jj]
         ref <- pgx$X[intersect(pp, rownames(pgx$X)), , drop = FALSE]


### PR DESCRIPTION
This closes #1247 

## Description
1. Match `pgx$families` and `pgx$X`, by symbol using `pgx$genes` translation of the rownames of X.
2. Use `<all>` is nothing else is available instead of always removing it.

## Results

CG data:

![image](https://github.com/user-attachments/assets/1dad0c0e-9c37-4e4d-884b-368cfedba65c)

Arabidopsis data: Note in this case we need to keep `<all>` as this dataset has only one family which corresponds to all genes.

![image](https://github.com/user-attachments/assets/74e47130-359f-4bc4-8845-8f26efcc8b9f)

Example data:

![image](https://github.com/user-attachments/assets/7699dcc4-d289-49c3-9dd3-72cfa756d437)
