### PR TITLE
Feat #1249: Cluster samples parallel: restrictive filter makes empty plot

### DIFF
--- a/components/board.clustering/R/clustering_plot_table_parcoord.R
+++ b/components/board.clustering/R/clustering_plot_table_parcoord.R
@@ -153,6 +153,10 @@ clustering_plot_table_parcoord_server <- function(id,
     parcoord.RENDER <- function() {
       pc <- plot_data()
       zx <- pc$mat
+      shiny::validate(shiny::need(
+        !all(is.na(zx)),
+        "Filter is too restrictive. Please change 'Filter samples:'."
+      ))
       ## build dimensions
       dimensions <- list()
       for (i in 1:ncol(zx)) {


### PR DESCRIPTION
This closes #1249 

## Description
Placed a shiny validator to let the user know the filtering is too restrictive instead of displaying an empty plot.

![image](https://github.com/user-attachments/assets/195678fc-74a0-40af-8c6a-6c3973c07588)
