### PR TITLE
Fix #1254: Upload histogram not deterministic

### DIFF
--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -186,6 +186,8 @@ upload_table_preview_counts_server <- function(
       counts <- checked_matrix()
       shiny::req(counts)
       xx <- log2(1 + counts)
+      # Add seed to make it deterministic
+      set.seed(123)
       if (nrow(xx) > 1000) xx <- xx[sample(1:nrow(xx), 1000), , drop = FALSE]
       suppressWarnings(dc <- data.table::melt(xx))
       dc$value[dc$value == 0] <- NA


### PR DESCRIPTION
This closes #1254

## Description
Added a seed to make the sample function act deterministically.

Again, uploading the example data: 

### Session 1
![image](https://github.com/user-attachments/assets/e84bd749-70c5-42b0-aa32-3f1a1d70deea)

### Session 2
![image](https://github.com/user-attachments/assets/d62418e2-83fd-4f75-b654-88c9e7c4057e)
