### PR TITLE
Fix #1257: Dataview: combination of filters yield errors

### DIFF
--- a/components/board.dataview/R/dataview_plot_boxplot.R
+++ b/components/board.dataview/R/dataview_plot_boxplot.R
@@ -80,10 +80,10 @@ dataview_plot_boxplot_server <- function(id, parent.input, getCountsTable, r.dat
         ylab <- "Abundance (log2)"
       }
 
-      df <- res$counts[, ]
+      df <- res$counts[, , drop = FALSE]
       if (nrow(df) > 1000) {
         sel <- sample(nrow(df), 1000)
-        df <- df[sel, ]
+        df <- df[sel, , drop = FALSE]
       }
       long.df <- reshape2::melt(df)
       colnames(long.df) <- c("gene", "sample", "value")

--- a/components/board.dataview/R/dataview_plot_correlation.R
+++ b/components/board.dataview/R/dataview_plot_correlation.R
@@ -70,7 +70,7 @@ dataview_plot_correlation_server <- function(id,
       jj <- c(head(order(-rho), n / 2), tail(order(-rho), n / 2))
       top.rho <- rho[jj]
 
-      gx1 <- sqrt(rowSums(pgx$X[names(top.rho), samples]**2, na.rm = TRUE))
+      gx1 <- sqrt(rowSums(pgx$X[names(top.rho), samples, drop = FALSE]**2, na.rm = TRUE))
       gx1 <- (gx1 / max(gx1))
       klr1 <- omics_pal_c(palette = "brand_blue")(16)[1 + round(15 * gx1)]
       klr1[which(is.na(klr1))] <- unname(omics_colors("mid_grey"))

--- a/components/board.dataview/R/dataview_plot_histogram.R
+++ b/components/board.dataview/R/dataview_plot_histogram.R
@@ -85,7 +85,7 @@ dataview_plot_histogram_server <- function(id, getCountsTable, watermark = FALSE
       smoothen <- function(y) {
         loess(y ~ mid, data.frame(mid = hist$mid, y = y), span = 0.25)$fitted
       }
-      y.smooth <- apply(hist[, 3:ncol(hist)], 2, smoothen)
+      y.smooth <- apply(hist[, 3:ncol(hist), drop = FALSE], 2, smoothen)
 
       df <- data.frame(
         x = rep(hist$mids, ncol(hist) - 2),

--- a/components/board.dataview/R/dataview_plot_tsneplot.R
+++ b/components/board.dataview/R/dataview_plot_tsneplot.R
@@ -87,7 +87,7 @@ dataview_plot_tsne_server <- function(id,
         }
       }
 
-      pos <- pgx$tsne2d[samples, ]
+      pos <- pgx$tsne2d[samples, , drop = FALSE]
 
       fc1 <- tanh(0.99 * scale(gx)[, 1])
       fc1 <- tanh(0.99 * scale(gx, center = FALSE)[, 1])

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -356,6 +356,10 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         summed.counts <- t(sapply(gset, function(f) {
           Matrix::colSums(counts[which(gg %in% f), , drop = FALSE], na.rm = TRUE)
         }))
+        if (length(total.counts) == 1) {
+          summed.counts <- t(summed.counts)
+          colnames(summed.counts) <- colnames(counts)
+        }
         prop.counts <- 100 * t(t(summed.counts) / total.counts)
 
         ## N. of detected features per sample or group AZ


### PR DESCRIPTION
This closes #1257 

## Description
Certain filtering can result in 1 sample to be subsetted, therefore we need to make sure the subsetting still is a data frame for the `rowSums` to work.

![image](https://github.com/user-attachments/assets/1da8fcce-f01b-4505-a94c-6d4fcc7fa35e)
