### PR TITLE
fix: add datasetname as meta information

### DIFF
--- a/components/modules/DatasetReport.R
+++ b/components/modules/DatasetReport.R
@@ -240,6 +240,7 @@ DatasetReportServer <- function(
                   "-P", paste0("pgxdir:", pgx_path),
                   "-P", paste0("comparison:", ct),
                   "-P", paste0("dataset:", sel_dataset),
+                  "-M", paste0("dataset:", sel_dataset),
                   "-M", paste0("user:", user),
                   "-M", paste0("title:", ct)
                 ),


### PR DESCRIPTION
otherwise it is not displayed on the comparison report properly (it always says example-data.pgx)

# Using `newparams` dataset:

## Before
![image](https://github.com/user-attachments/assets/00389ef7-360e-4103-a30a-f81d6e075d19)

## After
![image](https://github.com/user-attachments/assets/2860a54b-6fbe-417b-ad90-79e02171f852)
