### PR TITLE
fix: prevent recompute loophole

### DIFF
--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -559,7 +559,6 @@ loading_table_datasets_server <- function(id,
             load_uploaded_data <- shiny::reactiveVal(NULL)
             reload_pgxdir <- shiny::reactiveVal(0)
             recompute_pgx(pgx)
-            new_upload(new_upload() + 1)
 
             # bigdash.selectTab(session, "upload-tab")
             # shinyjs::runjs('$("[data-value=\'Upload\']").click();') # Should be Comparisons?


### PR DESCRIPTION
by triggering a new_upload() here we display the wizard, when we actually also do on a recompute_pgx observer, so there is no need to do it here, the other observer does the correct max datasets check before displaying the wizard