### PR TITLE
ignore "figure margins too large" error

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -1118,6 +1118,8 @@ app_server <- function(input, output, session) {
       err_traceback <- append(error$message, err_traceback)
     }
 
+    # Errors to ignore
+    if (error$message %in% c("figure margins too large")) return()
     # Get inputs to reproduce state
     board_inputs <- names(input)[grep(substr(input$nav, 1, nchar(input$nav) - 4), names(input))]
 

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -1119,7 +1119,7 @@ app_server <- function(input, output, session) {
     }
 
     # Errors to ignore
-    if (error$message %in% c("figure margins too large")) return()
+    if (error$message %in% c("figure margins too large", "invalid graphics state")) return()
     # Get inputs to reproduce state
     board_inputs <- names(input)[grep(substr(input$nav, 1, nchar(input$nav) - 4), names(input))]
 


### PR DESCRIPTION
avoid polluting hubspot