### PR TITLE
Fix #1270: Reactome activation matrix: must provide matrix

### DIFF
--- a/components/board.pathway/R/pathway_plot_reactome_actmap.R
+++ b/components/board.pathway/R/pathway_plot_reactome_actmap.R
@@ -122,6 +122,9 @@ functional_plot_reactome_actmap_server <- function(id,
 
       plot_RENDER <- function() {
         res <- plot_data()
+        shiny::validate(shiny::need(
+          !is.null(res), "Enrichment table is too small to plot an activation matrix."
+        ))
 
         playbase::pgx.plotActivation(
           pgx,

--- a/components/board.pathway/R/pathway_plot_reactome_graph.R
+++ b/components/board.pathway/R/pathway_plot_reactome_graph.R
@@ -103,7 +103,7 @@ functional_plot_reactome_graph_server <- function(id,
         fc <- fc[which(!duplicated(names(fc)) & names(fc) != "")]
 
         sel.row <- reactome_table$rows_selected()
-        if (is.null(sel.row) || length(sel.row) == 0) {
+        if (is.null(sel.row) || length(sel.row) == 0 || nrow(df) == 0) {
           return(NULL.IMG)
         }
 

--- a/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
+++ b/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
@@ -123,9 +123,10 @@ functional_plot_wikipathway_actmap_server <- function(id,
 
       plot_RENDER <- function() {
         res <- plot_data()
-        if (is.null(res) || nrow(res) == 0) {
-          return(NULL)
-        }
+
+        shiny::validate(shiny::need(
+          !is.null(res), "Enrichment table is too small to plot an activation matrix."
+        ))
 
         playbase::pgx.plotActivation(
           pgx,


### PR DESCRIPTION
This closes #1270

Added a shiny validate/need. Now when the activation matrix is `NULL` we display the following message:

![image](https://github.com/user-attachments/assets/e649de85-b3bf-437e-be1b-e10eaff176c5)

## Also, added fix for ticket 32854931669
When filtering a table to 0 rows `sel.row` is still 1 while `df` has 0 rows, add a check to avoid this transient error.



