### PR TITLE
Fix #1272: Drug conn: incorrect number of dimensions

### DIFF
--- a/components/board.drugconnectivity/R/drugconnectivity_server.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_server.R
@@ -71,7 +71,11 @@ DrugConnectivityBoard <- function(id, pgx) {
       pv <- round(dr$P[, contr], 4)
       qv <- round(dr$Q[, contr], 4)
       drug <- rownames(dr$X)
-      stats <- dr$stats[, contr]
+      if (is.null(ncol(dr$stats))) {
+        stats <- dr$stats
+      } else {
+        stats <- dr$stats[, contr]
+      }
       annot <- dr$annot
       nes[is.na(nes)] <- 0
       qv[is.na(qv)] <- 1


### PR DESCRIPTION
This closes #1272 

Seems that stats is a vector when there is just one contrast available, handle this case.

![image](https://github.com/user-attachments/assets/a8c61e9a-b5f5-48a9-b6cb-805f03a0a19a)
