### PR TITLE
Fix #1274: Sample QC: subscript out of bounds

### DIFF
--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -98,7 +98,7 @@ clustering_plot_clustpca_server <- function(id,
     create_plot <- function(pgx, pos, method, colvar, shapevar, label, cex) {
       do3d <- (ncol(pos) == 3)
       sel <- rownames(pos)
-      df <- cbind(pos, pgx$Y[sel, ])
+      df <- cbind(pos, pgx$samples[sel, ])
 
       textvar <- NULL
       if (colvar %in% colnames(df)) colvar <- factor(df[, colvar])

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -384,8 +384,9 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
 
         ## align
         ss <- names(total.counts)
-        prop.counts <- prop.counts[, ss, drop = FALSE]
-        counts <- counts[, ss, drop = FALSE]
+        ss2 <- match(ss, colnames(prop.counts))
+        prop.counts <- prop.counts[, ss2, drop = FALSE]
+        counts <- counts[, ss2, drop = FALSE]
         if (any(pgx$X[, samples, drop = FALSE] < 0, na.rm = TRUE)) {
           offset <- 1e-6
         } else {


### PR DESCRIPTION
This closes #1274 

This issue comes from the group by having empty group "". All is OK but subsetting a data frame using column names fails, therefore we can match the indexes and properly display the grouping.

![image](https://github.com/user-attachments/assets/0b687e5f-013a-4fdc-858f-ecd41ee9f1b7)
