### PR TITLE
Fix #1278: Cell profile phenotypes: 'list' object cannot be coerced to type 'double'

### DIFF
--- a/components/board.singlecell/R/singlecell_plot_phenoplot.R
+++ b/components/board.singlecell/R/singlecell_plot_phenoplot.R
@@ -85,7 +85,7 @@ singlecell_plot_phenoplot_server <- function(id,
 
       sel <- pd[["sel"]]
       pheno <- pd[["pheno"]]
-      Y <- pd[["pgx"]]$Y
+      Y <- pd[["pgx"]]$samples
       pos <- pd[["pos"]]
 
       cex1 <- 1.2 * c(1.8, 1.3, 0.8, 0.5)[cut(nrow(pos), breaks = c(-1, 40, 200, 1000, 1e10))]
@@ -160,16 +160,21 @@ singlecell_plot_phenoplot_server <- function(id,
       if (length(plt) > 4) nr <- 3
       if (length(plt) > 6) nr <- 4
       if (length(plt) > 12) nr <- 5
-      fig <- plotly::subplot(
-        plt,
-        nrows = nr,
-        #
-        margin = c(0.01, 0.01, 0.01, 0.045)
-      ) %>%
-        plotly_default() %>%
-        plotly::layout(
-          margin = list(l = 10, r = 10, b = 10, t = 20) # lrbt
-        )
+      if (length(plt) > 1) {
+        fig <- plotly::subplot(
+          plt,
+          nrows = nr,
+          #
+          margin = c(0.01, 0.01, 0.01, 0.045)
+        ) %>%
+          plotly_default() %>%
+          plotly::layout(
+            margin = list(l = 10, r = 10, b = 10, t = 20) # lrbt
+          )
+      } else {
+        fig <- plt[[1]] %>%
+          plotly_default()
+      }
       return(fig)
     }
 


### PR DESCRIPTION
This closes #1278 

When there is just 1 phenotype, passing the plot list through the subplot function crashes, just plot a single instance. Also now uses `samples` instead of `Y`.

![image](https://github.com/user-attachments/assets/a3176811-ee4e-4711-8b54-b34f20686131)


