### PR TITLE
fix: avoid filtering non-existent samples

### DIFF
--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -149,9 +149,9 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       samples <- colnames(pgx$X)
 
       if (!is.null(input$data_samplefilter)) {
-        samples <- playbase::selectSamplesFromSelectedLevels(
-          pgx$Y, input$data_samplefilter
-        )
+        samples <- tryCatch({playbase::selectSamplesFromSelectedLevels(
+          pgx$samples, input$data_samplefilter
+        )}, error = function(w) {NULL})
       }
       # validate samples
       validate(need(length(samples) > 0, "No samples remaining after filtering."))


### PR DESCRIPTION
on dataset change, pgx$samples gets updated before data_samplefilter, which triggeres a temporary error coming from here. tryCatch it to avoid this transient error + hubspot tickets