### PR TITLE
Fix #1286: Data upload: Remove outliers error on normalization plot

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -343,9 +343,9 @@ upload_module_normalization_server <- function(
         main.tt <- ifelse(input$normalize, norm_method(), "no normalization")
 
         if (input$norm_plottype == "boxplot") {
-          if (ncol(X0) > 40) {
-            jj <- sample(ncol(X0), 40)
-            ii <- rownames(X0) ## names!
+          if (ncol(X1) > 40) {
+            jj <- sample(ncol(X1), 40)
+            ii <- rownames(X1) ## names!
             ## just downsampling for boxplots
             if (length(ii) > 2000) ii <- sample(ii, 2000)
             X0 <- X0[ii, jj]


### PR DESCRIPTION
This closes #1286 

When removing outliers, they are removed on `X1` table, therefore if we subset using a samples of the columns in `X0`, we can potentially select columns that are not on `X1` which gives an error on the normalization plot.

![image](https://github.com/user-attachments/assets/81587a5d-18c4-42ab-96f1-6261aae723b1)


