### PR TITLE
feat: ensure WP table is always complete

### DIFF
--- a/components/board.pathway/R/pathway_server.R
+++ b/components/board.pathway/R/pathway_server.R
@@ -225,6 +225,10 @@ PathwayBoard <- function(id,
 
       ## select those with ID
       jj <- which(!is.na(wp.ids) & !duplicated(wp.ids))
+      # Remove ID not in meta matrix
+      jj <- jj[wp.gsets[jj] %in% rownames(pgx$gset.meta$meta[[comparison]])]
+      # Remove ID with no logFC on meta matrix
+      jj <- jj[!is.na(pgx$gset.meta$meta[[comparison]][wp.gsets[jj],]$meta.fx)]
       wp.gsets <- wp.gsets[jj]
       wp.ids <- wp.ids[jj]
 


### PR DESCRIPTION
From client feedback.

With this PR I make sure the table we display to the users is complete. Quite an edge case.