### PR TITLE
fix-geneselection

### DIFF
--- a/components/board.dataview/R/dataview_plot_averagerank.R
+++ b/components/board.dataview/R/dataview_plot_averagerank.R
@@ -66,6 +66,9 @@ dataview_plot_averagerank_server <- function(id,
       }
 
       sel <- which(sub(".*:", "", names(mean.fc)) == gene)
+      if (is.null(sel) || length(sel) == 0) {
+        sel <- which(names(mean.fc) == gene)
+      }
 
       pd <- list(
         df = data.frame(mean.fc = mean.fc),


### PR DESCRIPTION
HS ticket: 51647256784.

I just found out an error in the average rank plot. Caused by the feature names eg: ENSMUSG00000094569.1:cdna:Trbd2:TR_D_gene:1.

error due to 'sel' being null 