### PR TITLE
Fix gsea enplot for composite feature (proteins) ID

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_compare.R
+++ b/components/board.enrichment/R/enrichment_plot_compare.R
@@ -80,6 +80,11 @@ enrichment_plot_compare_server <- function(id,
 
           gs1 <- playbase::breakstring(gset, 28, 50, force = FALSE)
           cmp <- paste0(gset, "\n@", cmp)
+
+          names(rnk0) <- unlist(lapply(names(rnk0), function(x) {
+            x0 = strsplit(x, "_")[[1]]
+            return(x0[length(x0)])
+          }))
           
           playbase::gsea.enplot(
             rnk0,
@@ -108,6 +113,11 @@ enrichment_plot_compare_server <- function(id,
 
           gs1 <- playbase::breakstring(gset, 28, 50, force = FALSE)
           cmp <- paste0(gset, "\n@", cmp)
+
+          names(rnk0) <- unlist(lapply(names(rnk0), function(x) {
+            x0 = strsplit(x, "_")[[1]]
+            return(x0[length(x0)])
+          }))
 
           playbase::gsea.enplot(
             rnk0,


### PR DESCRIPTION
Bugs from Ugent, Belgium: bug in gsea.enplot in GeneSets >> Geneset Enrichment >> Enrichment by comparison. 
Could not show genes (and black vertical bars) in plot due to presence of composite feature ID. This solves it. 
