### PR TITLE
improve wgcna: add networktype and tomtype

### DIFF
--- a/components/board.wgcna/R/wgcna_plot_MTrelationships.R
+++ b/components/board.wgcna/R/wgcna_plot_MTrelationships.R
@@ -32,7 +32,6 @@ wgcna_plot_MTrelationships_ui <- function(
 
 wgcna_plot_MTrelationships_server <- function(id,
                                               wgcna.compute,
-                                              labels2rainbow,
                                               watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     moduleTrait.RENDER <- function() {
@@ -40,7 +39,7 @@ wgcna_plot_MTrelationships_server <- function(id,
       net <- out$net
       datExpr <- out$datExpr
       datTraits <- out$datTraits
-      moduleColors <- labels2rainbow(out$net)
+      moduleColors <- playbase::labels2rainbow(out$net)
       MEs <- out$net$MEs
 
       ## Define numbers of genes and samples
@@ -68,12 +67,10 @@ wgcna_plot_MTrelationships_server <- function(id,
       sel2 <- sort(head(order(-colMeans(pmax(moduleTraitCor, 0), na.rm = TRUE)), 40)) ## conditions
       sel1 <- sort(head(order(-rowMeans(pmax(moduleTraitCor[, sel2], 0), na.rm = TRUE)), 12)) ## eigenv
 
-      message("[moduleTrait.RENDER] sel1 = ", paste(sel1, collapse = " "))
-      message("[moduleTrait.RENDER] sel2 = ", paste(sel2, collapse = " "))
 
       par(mar = c(3, 12, 1.6, 1.5))
       ## Display the correlation values within a heatmap plot
-      labeledHeatmap(
+      WGCNA::labeledHeatmap(
         Matrix = t(moduleTraitCor[sel1, sel2]),
         yLabels = colnames(out$datTraits)[sel2],
         xLabels = colnames(MEs)[sel1],

--- a/components/board.wgcna/R/wgcna_plot_TOMheatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_TOMheatmap.R
@@ -27,81 +27,27 @@ wgcna_plot_TOMheatmap_ui <- function(
 
 wgcna_plot_TOMheatmap_server <- function(id,
                                          wgcna.compute,
-                                         labels2rainbow,
                                          power,
+                                         tomtype,
+                                         networktype,
                                          watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
-    TOMplot.RENDER <- shiny::reactive({
+
+    TOMplot.RENDER <- function() {
+      shiny::req(power())
+      shiny::req(networktype())
+      shiny::req(tomtype())      
+
       out <- wgcna.compute()
-      net <- out$net
-      datExpr <- out$datExpr
-      geneTree <- net$dendrograms[[1]]
-      moduleColors <- labels2rainbow(out$net)
-      MEs <- out$net$MEs
 
-      ## Calculate topological overlap anew: this could be done
-      ## more efficiently by saving the TOM calculated during
-      ## module detection, but let us do it again here.
-
-
-      power <- as.numeric(power())
-      dissTOM <- 1 - TOMsimilarityFromExpr(datExpr, power = power)
-      rownames(dissTOM) <- colnames(dissTOM) <- colnames(datExpr)
-
-      nSelect <- 999999
-      nSelect <- 400
-      ## For reproducibility, we set the random seed
-      set.seed(10)
-      select <- head(1:ncol(dissTOM), nSelect)
-      selectTOM <- dissTOM[select, select]
-      ## There’s no simple way of restricting a clustering tree
-      ## to a subset of genes, so we must re-cluster.
-      #
-      selectTree <- hclust(as.dist(selectTOM), method = "average")
-      selectColors <- moduleColors[select]
-      ## Taking the dissimilarity to a power, say 10, makes the plot
-      ## more informative by effectively changing the color palette;
-      ## setting the diagonal to NA also improves the clarity of the
-      ## plot
-      plotDiss <- selectTOM^7
-      diag(plotDiss) <- NA
-      myheatcol <- gplots::colorpanel(250, "red", "orange", "lemonchiffon")
-      myheatcol <- gplots::colorpanel(250, "lemonchiffon", "orange", "red")
-
-      par(oma = c(2, 0, 0, 0))
-      plotly::layout(
-        matrix(c(
-          0, 0, 5, 0,
-          0, 0, 2, 0,
-          4, 1, 3, 6
-        ), nr = 3, byrow = T),
-        widths = c(2.3, 0.5, 10, 1.8),
-        heights = c(2.3, 0.5, 10)
-      )
-
-      WGCNA::TOMplot(
-        plotDiss, selectTree, selectColors,
-        col = myheatcol,
-        setLayout = FALSE,
-        main = NULL
-      )
-
-      ## add color legend
-      frame()
-      me.names <- colnames(MEs)
-      me.nr <- as.integer(sub("ME", "", me.names))
-      ii <- order(me.nr)
-      label.colors <- labels2rainbow(net)
-      me.colors <- label.colors[!duplicated(names(label.colors))]
-      me.colors <- me.colors[as.character(me.nr)]
-
-      legend(-0.1, 1,
-        legend = me.names[ii], fill = me.colors[ii],
-        cex = 1.2, bty = "n", x.intersp = 0.5
-      )
-      p <- grDevices::recordPlot()
-      p
-    })
+      playbase::plotTOMfromResults(
+        out,
+        power = as.numeric(power()),
+        tomtype = tomtype(),
+        networktype = networktype(),
+        nSelect = 1000
+      ) 
+    }
 
     PlotModuleServer(
       "plot",

--- a/components/board.wgcna/R/wgcna_plot_gdendogram.R
+++ b/components/board.wgcna/R/wgcna_plot_gdendogram.R
@@ -22,17 +22,32 @@ wgcna_plot_gdendogram_ui <- function(id, label, info.text, caption, height, widt
 
 wgcna_plot_gdendogram_server <- function(id,
                                          wgcna.compute,
-                                         labels2rainbow,
+                                         power,
+                                         networktype,
+                                         tomtype,
                                          watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
-    geneDendro.RENDER <- shiny::reactive({
+
+    geneDendro.RENDER <- function() {
+#      shiny::req(power())
+#      shiny::req(networktype())
+#      shiny::req(tomtype())      
+
       out <- wgcna.compute()
       net <- out$net
 
+      ## playbase::plotDendroFromResults(
+      ##   out,
+      ##   power = as.numeric(power()),
+      ##   networktype = networktype(),
+      ##   tomtype = tomtype(),
+      ##   nSelect = 1000
+      ## ) 
+          
       ## Convert labels to colors for plotting
-      mergedColors <- labels2rainbow(net)
+      mergedColors <- playbase::labels2rainbow(net)
       ## Plot the dendrogram and the module colors underneath
-      plotDendroAndColors(
+      WGCNA::plotDendroAndColors(
         dendro = net$dendrograms[[1]],
         colors = mergedColors[net$blockGenes[[1]]],
         dendroLabels = FALSE, hang = 0.03,
@@ -40,9 +55,8 @@ wgcna_plot_gdendogram_server <- function(id,
         marAll = c(0.2, 5, 0.4, 0.2),
         main = NULL
       )
-      p <- grDevices::recordPlot()
-      p
-    })
+
+    }
 
     PlotModuleServer(
       "plot",

--- a/components/board.wgcna/R/wgcna_plot_s_independence.R
+++ b/components/board.wgcna/R/wgcna_plot_s_independence.R
@@ -31,11 +31,20 @@ wgcna_plot_s_independence_server <- function(id,
   moduleServer(id, function(input, output, session) {
     topologyPlots.RENDER <- shiny::reactive({
       out <- wgcna.compute()
+      shiny::req(out)
 
+      networktype <- out$networktype
+      if(is.null(networktype)) networktype <- "signed"
+      
       ## Choose a set of soft-thresholding powers
       powers <- c(c(1:10), seq(from = 12, to = 20, by = 2))
       ## Call the network topology analysis function
-      sft <- pickSoftThreshold(out$datExpr, powerVector = powers, verbose = 5)
+      sft <- WGCNA::pickSoftThreshold(
+        out$datExpr,
+        powerVector = powers,
+        networkType = networktype,
+        verbose = 5
+      )
 
       ## Plot the results:
       par(mfrow = c(1, 2), mar = c(3.3, 3, 1, 1), mgp = c(2, 0.8, 0))

--- a/components/board.wgcna/R/wgcna_ui.R
+++ b/components/board.wgcna/R/wgcna_ui.R
@@ -10,14 +10,11 @@ WgcnaInputs <- function(id) {
 
     ## data set parameters
     shiny::selectInput(ns("selected_module"), "select module", choices = NULL),
-    shiny::actionButton(ns("compute"), "Compute!",
-      icon = icon("running"),
-      class = "btn-outline-primary"
-    ),
     shiny::br(),
     shiny::br(),
-    shiny::actionLink(ns("options"), "Options", icon = icon("cog", lib = "glyphicon")),
-    shiny::br(), br(), br(),
+    shiny::br(),    
+    shiny::actionLink(ns("options"), "Recompute", icon = icon("cog", lib = "glyphicon")),
+    shiny::br(), 
     shiny::conditionalPanel(
       "input.options % 2 == 1",
       ns = ns,
@@ -26,16 +23,23 @@ WgcnaInputs <- function(id) {
           choices = c(500, 1000, 2000, 4000, 8000),
           selected = 1000
         ),
-        shiny::selectInput(ns("minmodsize"), "Min. module size",
-          choices = c(10, 30, 100, 250),
-          selected = 30
+        shiny::selectInput(ns("networktype"), "Network type",
+          choices = c("unsigned","signed","signed hybrid"), selected = "signed"
         ),
-        shiny::selectInput(ns("power"), "Power", c(2, 4, 6, 10), selected = 6),
-        shiny::selectInput(ns("deepsplit"), "deepsplit", 0:4, selected = 2),
-        shiny::selectInput(ns("cutheight"), "Merge cut height",
-          choices = c(0.05, 0.10, 0.25, 0.5, 0.9, 0.999),
-          selected = 0.25
-        )
+        shiny::selectInput(ns("tomtype"), "TOM type",
+          choices = c("signed","unsigned","signed Nowick","none"), selected = "signed"
+        ),
+        shiny::sliderInput(ns("power"), "Power", 1, 20, 6),
+        shiny::sliderInput(ns("deepsplit"), "Deepsplit", 0, 4, 2),        
+        shiny::selectInput(ns("minmodsize"), "Min. module size",
+          choices = c(10, 20, 50, 100),  selected = 20
+        ),
+        shiny::br(),
+        shiny::actionButton(
+          ns("compute"), "Recompute!",
+          icon = icon("running"),
+          class = "btn-outline-primary"
+        )        
       )
     )
   )


### PR DESCRIPTION
Improving/simplifying WGCNA:
1. Add network type
2. Add Tom-types

NOTE: needs same PR on playbase