### PR TITLE
feat: send to the plot editor the modal or regular plot info

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -400,7 +400,8 @@ PlotModuleUI <- function(id,
           title = title,
           size = "fullscreen",
           footer = NULL,
-          popupfigUI()
+          popupfigUI(),
+          track_open = TRUE
         )
       ),
       if (cards) {
@@ -578,7 +579,11 @@ PlotModuleServer <- function(id,
         })
       } else {
         output$editor_frame <- renderUI({
-          plot <- func()
+          if (input$plotPopup_is_open) {
+            plot <- func2()
+          } else {
+            plot <- func()
+          }
           if (exists("csvFunc") && is.function(csvFunc)) {
             plot_data_csv <- csvFunc()
             if (inherits(plot_data_csv, "list")) {

--- a/components/ui/ui-modalUI.R
+++ b/components/ui/ui-modalUI.R
@@ -63,6 +63,7 @@ modalUI <- function(
     title,
     ...,
     size = c("default", "sm", "lg", "xl", "fullscreen"),
+    track_open = FALSE,
     footer = tags$div(
       class = "modal-footer",
       tags$button(
@@ -82,7 +83,7 @@ modalUI <- function(
     ""
   )
 
-  tags$div(
+  modal <- tags$div(
     class = "modal fade",
     id = id,
     tabindex = "-1",
@@ -113,6 +114,23 @@ modalUI <- function(
       )
     )
   )
+
+  if (track_open) {
+    tagList(
+      modal,
+      tags$script(sprintf(
+        "$('#%s').on('shown.bs.modal hidden.bs.modal', function(e) {
+          console.log('Modal event:', e.type, 'for modal:', '%s');
+          Shiny.setInputValue('%s_is_open', e.type === 'shown');
+        });",
+        id,
+        id,
+        id
+      ))
+    )
+  } else {
+    modal
+  }
 }
 
 modalDialog2 <- function(


### PR DESCRIPTION
Before, if the user opened the plot editor, it always sent the "regular" plot information. With this enhancement, we send the modal info if the user triggers the editor from the modal.

## Before
### Module expression, open plot editor from modal

![image](https://github.com/user-attachments/assets/ac8b13e3-68c4-49ea-80a3-781fcdc631bf)

## After
### Module expression, open plot editor from modal

![image](https://github.com/user-attachments/assets/d4df084f-6195-45fa-85ec-79323600366a)