### PR TITLE
Fix #1317: Volcano plot not available as csv in v3.5.1+master241218

### DIFF
--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -205,7 +205,7 @@ expression_plot_volcano_server <- function(id,
       dt <- plot_data()
       df <- data.frame(dt$x, dt$y)
       colnames(df) <- c("x", "y")
-      rownames(df) <- dt$symbols
+      rownames(df) <- make.unique(dt$symbols)
       return(df)
     }
 


### PR DESCRIPTION
This closes #1317 

There was an issue with the row.names we were setting on the download csv not being unique. Make sure they always are (we use symbol, which seems in this mouse data got 4 collisions).