### PR TITLE
feat: attach contrast name on diff expr plots/tables

### DIFF
--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -174,7 +174,8 @@ expression_plot_maplot_server <- function(id,
       csvFunc = plot_data_csv, ##  *** downloadable data as CSV
       res = c(80, 95), ## resolution of plots
       pdf.width = 6, pdf.height = 6,
-      add.watermark = watermark
+      add.watermark = watermark,
+      download.contrast.name = gx_contrast
     )
   }) ## end of moduleServer
 }

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -225,7 +225,8 @@ expression_plot_volcano_server <- function(id,
         pdf.width = 10,
         pdf.height = 8,
         add.watermark = watermark,
-        card = x$card
+        card = x$card,
+        download.contrast.name = comp1
       )
     })
   }) ## end of moduleServer

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -268,7 +268,8 @@ expression_plot_volcanoMethods_server <- function(id,
         pdf.width = 12,
         pdf.height = 5,
         add.watermark = watermark,
-        card = x$card
+        card = x$card,
+        download.contrast.name = comp
       )
     })
   }) ## end of moduleServer

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -598,7 +598,8 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       organism = pgx$organism,
       show_pv = shiny::reactive(input$show_pv),
       height = c(tabH - 10, 700),
-      scrollY = "200px"
+      scrollY = "200px",
+      cont = shiny::reactive(input$gx_contrast)
     )
 
     gsettable <- expression_table_gsettable_server(

--- a/components/board.expression/R/expression_table_genetable.R
+++ b/components/board.expression/R/expression_table_genetable.R
@@ -51,6 +51,7 @@ expression_table_genetable_server <- function(id,
                                               show_pv,
                                               height,
                                               scrollY,
+                                              cont,
                                               watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
@@ -155,7 +156,8 @@ expression_table_genetable_server <- function(id,
       func = table.RENDER,
       func2 = table.RENDER_modal,
       csvFunc = table_csv,
-      selector = "single"
+      selector = "single",
+      download.contrast.name = cont
     )
 
     return(genetable)

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -666,7 +666,13 @@ PlotModuleServer <- function(id,
 
       if (do.png && is.null(download.png)) {
         download.png <- shiny::downloadHandler(
-          filename = paste0(filename, ".png"),
+          filename = shiny::reactive({
+            if (!is.null(download.contrast.name)) {
+              paste0(paste0(filename, "-", download.contrast.name()), ".png")
+            } else {
+              paste0(filename, ".png")
+            }
+          }),
           content = function(file) {
             png.width <- input$pdf_width * 80
             png.height <- input$pdf_height * 80
@@ -764,7 +770,13 @@ PlotModuleServer <- function(id,
 
       if (do.pdf && is.null(download.pdf)) {
         download.pdf <- shiny::downloadHandler(
-          filename = paste0(filename, ".pdf"),
+          filename = shiny::reactive({
+            if (!is.null(download.contrast.name)) {
+              paste0(paste0(filename, "-", download.contrast.name()), ".pdf")
+            } else {
+              paste0(filename, ".pdf")
+            }
+          }),
           content = function(file) {
             pdf.width <- input$pdf_width
             pdf.height <- input$pdf_height
@@ -969,7 +981,13 @@ PlotModuleServer <- function(id,
       # Excel download
       if (do.excel) {
         download.excel <- shiny::downloadHandler(
-          filename = paste0(filename, ".xlsx"),
+          filename = shiny::reactive({
+            if (!is.null(download.contrast.name)) {
+              paste0(paste0(filename, "-", download.contrast.name()), ".xlsx")
+            } else {
+              paste0(filename, ".xlsx")
+            }
+          }),
           content = function(file) {
             shiny::withProgress({
               data <- csvFunc()

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -473,6 +473,7 @@ PlotModuleServer <- function(id,
                              download.csv = NULL,
                              download.excel = NULL,
                              download.obj = NULL,
+                             download.contrast.name = NULL,
                              pdf.width = 8,
                              pdf.height = 6,
                              pdf.pointsize = 12,
@@ -942,7 +943,13 @@ PlotModuleServer <- function(id,
       ## if(do.csv && is.null(download.csv) )  {
       if (do.csv) {
         download.csv <- shiny::downloadHandler(
-          filename = paste0(filename, ".csv"),
+          filename = shiny::reactive({
+            if (!is.null(download.contrast.name)) {
+              paste0(paste0(filename, "-", download.contrast.name()), ".csv")
+            } else {
+              paste0(filename, ".csv")
+            }
+          }),
           content = function(file) {
             shiny::withProgress(
               {

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -174,7 +174,8 @@ TableModuleServer <- function(id,
                               height = c(640, 800),
                               width = c("auto", 1400),
                               selector = c("none", "single", "multi", "key")[1],
-                              filename = "table") {
+                              filename = "table",
+                              download.contrast.name = NULL) {
   moduleServer(
     id,
     function(input, output, session) {
@@ -185,13 +186,16 @@ TableModuleServer <- function(id,
 
       # Downloader
       output$download <- shiny::downloadHandler(
-        filename = function() {
+        filename = shiny::reactive({
+          if (!is.null(download.contrast.name)) {
+            filename <- paste0(filename, "-", download.contrast.name())
+          }
           if (input$format == "CSV") {
             paste0(filename, ".csv")
           } else {
             paste0(filename, ".xlsx")
           }
-        },
+        }),
         content = function(file) {
           if (!is.null(csvFunc)) {
             dt <- csvFunc() ## data.frame or matrix


### PR DESCRIPTION
Added the option to attach a contrast name at the end of the filenames for plots and tables. Then on diff expr added it to the plots and tables that differ for each contrast.