### PR TITLE
feat: volcano significance caps

### DIFF
--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -69,6 +69,7 @@ expression_plot_volcano_server <- function(id,
                                            genes_selected,
                                            labeltype = reactive("symbol"),
                                            watermark = FALSE,
+                                           pval_cap,
                                            pgx) {
   moduleServer(id, function(input, output, session) {
     # reactive function listening for changes in input
@@ -86,13 +87,15 @@ expression_plot_volcano_server <- function(id,
         probes = rownames(res), res, query = "symbol", fill_na = TRUE
       )
 
-      qval <- pmax(res$meta.q, 1e-20)
-      pval <- pmax(res$meta.p, 1e-20)
+      pval_cap <- pval_cap()
+
+      qval <- pmax(res$meta.q, pval_cap)
+      pval <- pmax(res$meta.p, pval_cap)
       x <- res$logFC
-      y <- -log10(qval + 1e-12)
+      y <- -log10(qval + pval_cap)
       ylab <- "Significance (-log10q)"
       if (show_pv()) {
-        y <- -log10(pval + 1e-12)
+        y <- -log10(pval + pval_cap)
         ylab <- "Significance (-log10p)"
       }
 

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -67,6 +67,7 @@ expression_plot_volcanoAll_server <- function(id,
                                               show_pv,
                                               genes_selected,
                                               labeltype = reactive("symbol"),
+                                              pval_cap,
                                               watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     ## reactive function listening for changes in input
@@ -126,6 +127,8 @@ expression_plot_volcanoAll_server <- function(id,
       pd <- plot_data()
       shiny::req(pd)
 
+      pval_cap <- pval_cap()
+
       # Call volcano plots
       all_plts <- playbase::plotlyVolcano_multi(
         FC = pd$F,
@@ -145,7 +148,8 @@ expression_plot_volcanoAll_server <- function(id,
         color_up_down = TRUE,
         highlight = pd$sel.genes,
         label = pd$lab.genes,
-        by_sig = FALSE
+        by_sig = FALSE,
+        pval_cap = pval_cap
       )
 
       return(all_plts)
@@ -193,7 +197,9 @@ expression_plot_volcanoAll_server <- function(id,
         )
       facet <- pivot.fc$facet
       x <- pivot.fc$fc
-      y <- -log10(pivot.qv$qv + 1e-12)
+
+      pval_cap <- pval_cap()
+      y <- -log10(pivot.qv$qv + pval_cap)
 
       playbase::ggVolcano(
         x,

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -68,6 +68,7 @@ expression_plot_volcanoMethods_server <- function(id,
                                                   show_pv,
                                                   genes_selected,
                                                   labeltype = reactive("symbol"),
+                                                  pval_cap,
                                                   watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     ## reactive function listening for changes in input
@@ -138,6 +139,8 @@ expression_plot_volcanoMethods_server <- function(id,
 
       label.names <- playbase::probe2symbol(rownames(mx), pgx$genes, labeltype(), fill_na = TRUE)
 
+      pval_cap <- pval_cap()
+
       # Call volcano plots
       all_plts <- playbase::plotlyVolcano_multi(
         FC = x,
@@ -157,7 +160,8 @@ expression_plot_volcanoMethods_server <- function(id,
         margin_l = margin_l,
         margin_b = margin_b,
         color_up_down = TRUE,
-        by_sig = FALSE
+        by_sig = FALSE,
+        pval_cap = pval_cap
       )
       return(all_plts)
     }
@@ -216,7 +220,9 @@ expression_plot_volcanoMethods_server <- function(id,
       facet <- fc$facet
       x <- fc$fc
       y <- qv$qv
-      y <- -log10(y + 1e-12)
+
+      pval_cap <- pval_cap()
+      y <- -log10(y + pval_cap)
 
       playbase::ggVolcano(
         x = x,

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -128,6 +128,16 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
       )
     })
 
+    pval_cap <- shiny::reactive({
+      pval_cap <- input$pval_cap
+      if (pval_cap == "Uncaped") {
+        pval_cap <- 1e-999
+      } else {
+        pval_cap <- as.numeric(input$pval_cap)
+      }
+      return(pval_cap)
+    })
+
     # functions #########
     comparison <- 1
     testmethods <- c("trend.limma")
@@ -353,12 +363,12 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
       features <- rownames(res)
 
       qval <- res[, grep("adj.P.Val|meta.q|qval|padj", colnames(res))[1]]
-      qval <- pmax(qval, 1e-20)
+      qval <- pmax(qval, pval_cap())
       pval <- res[, grep("pvalue|meta.p|pval|p_value", colnames(res))[1]]
-      pval <- pmax(pval, 1e-20)
+      pval <- pmax(pval, pval_cap())
 
       x <- res[, grep("logFC|meta.fx|fc", colnames(res))[1]]
-      y <- -log10(qval + 1e-12)
+      y <- -log10(qval + pval_cap())
       scaled.x <- scale(x, center = FALSE)
       scaled.y <- scale(y, center = FALSE)
 
@@ -427,6 +437,7 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
       genes_selected = genes_selected,
       labeltype = labeltype,
       watermark = WATERMARK,
+      pval_cap = pval_cap,
       pgx = pgx
     )
 
@@ -531,6 +542,7 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
       show_pv = shiny::reactive(input$show_pv),
       genes_selected = genes_selected,
       labeltype = labeltype,
+      pval_cap = pval_cap,
       watermark = WATERMARK
     )
 
@@ -545,6 +557,7 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
       show_pv = shiny::reactive(input$show_pv),
       genes_selected = genes_selected,
       labeltype = labeltype,
+      pval_cap = pval_cap,
       watermark = WATERMARK
     )
 

--- a/components/board.expression/R/expression_ui.R
+++ b/components/board.expression/R/expression_ui.R
@@ -60,6 +60,15 @@ ExpressionInputs <- function(id) {
             we perform the DE analysis using commonly accepted methods in the literature, including t-test (standard,
             Welch), limma (no trend, trend, voom), edgeR (QLF, LRT), and DESeq2 (Wald, LRT), and merge the results.",
           placement = "right", options = list(container = "body")
+        ),
+        withTooltip(
+          shiny::selectInput(
+            inputId = ns("pval_cap"),
+            label = "Significance cap",
+            choices = c("1e-12", "1e-20", "Uncaped")
+          ),
+          "Significance cap",
+          placement = "right", options = list(container = "body")
         )
       )
     )


### PR DESCRIPTION
From user feedback, need to uncap significance on volcano plots for better publication figures.

#### Before it was caped to 1e-12

![image](https://github.com/user-attachments/assets/f6ba541e-60b3-4bed-bdfe-4199bc131709)

#### Now we have a setting to uncap

![image](https://github.com/user-attachments/assets/2c5bd2bb-430e-4259-9588-e0ead40544e0)