### PR TITLE
fix: mismatch between pp and rnaX rows

### DIFF
--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -236,6 +236,7 @@ EnrichmentBoard <- function(id, pgx, selected_gxmethods = reactive(colnames(pgx$
             pp <- intersect(rownames(pgx$GMT), names(fc))
           }
 
+          pp <- intersect(pp, rownames(rnaX))
           G <- Matrix::t(pgx$GMT[pp, jj] != 0)
           ngenes <- Matrix::rowSums(G, na.rm = TRUE)
           meta.fc <- pgx$gset.meta$meta[[comp]]$meta.fx


### PR DESCRIPTION
Dataset from Hubspot ticket #107207429322

Missmatch between pp and rownames of rnaX, where pp contains rows that do not exist on rnaX, causing errors all across geneset enrichment tabs.