### PR TITLE
Fix #1355: Upload edge case crash

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -49,6 +49,7 @@ upload_module_normalization_server <- function(
         counts <- r_counts()
         samples <- r_samples()        
         contrasts <- r_contrasts()
+        shiny::req(dim(contrasts))
         
         counts[which(is.nan(counts))] <- NA
         counts[which(is.infinite(counts))] <- NA


### PR DESCRIPTION
This closes #1355 

On second upload, contrast at this stage is NULL however the code downstream is triggered b/c some inputs have initialized values