### PR TITLE
Fix #1332: column annotation on static heatmap not responding to 'show phenotypes'

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -174,6 +174,14 @@ clustering_plot_splitmap_server <- function(id,
 
       show_colnames <- (cex1 > 0)
 
+      # Select annot to display (user input)
+      sel <- selected_phenotypes()
+      if (length(sel) == 0) {
+        annot <- NULL
+      } else {
+        annot <- annot[, sel, drop = FALSE]
+      }
+
 
 #      show_legend <- show_colnames <- TRUE
 #      show_legend <- input$hm_legend


### PR DESCRIPTION
This closes #1332 

Subset the annot table with the selected phenotype(s).

![image](https://github.com/user-attachments/assets/83e84416-a5f4-481b-897d-241775e865c1)
