### PR TITLE
Use symbol on gsea comp

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_compare.R
+++ b/components/board.enrichment/R/enrichment_plot_compare.R
@@ -86,6 +86,8 @@ enrichment_plot_compare_server <- function(id,
             return(x0[length(x0)])
           }))
 
+          rnk0 <- playbase::rename_by(rnk0, pgx$genes)
+
           playbase::gsea.enplot(
             rnk0,
             genes,


### PR DESCRIPTION
On species other than human/mouse (found issue on arabidopsis and dmelanogaster-flybase), we should use symbol on `rnk0`, otherwise, there is a missmatch.

![image](https://github.com/user-attachments/assets/2c209b50-6aad-4844-9d69-035b3e81faf5)

After fix:

![image](https://github.com/user-attachments/assets/d4105161-11e3-4342-ba0e-e3faa9208f42)
