### PR TITLE
pca error - 1 phenotype samples file

### DIFF
--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -98,7 +98,7 @@ clustering_plot_clustpca_server <- function(id,
     create_plot <- function(pgx, pos, method, colvar, shapevar, label, cex) {
       do3d <- (ncol(pos) == 3)
       sel <- rownames(pos)
-      df <- cbind(pos, pgx$samples[sel, ])
+      df <- cbind(pos, pgx$samples[sel, , drop = FALSE])
 
       textvar <- NULL
       if (colvar %in% colnames(df)) {


### PR DESCRIPTION
from celegans-wormbase dataset, which only has 1 phenotype, `drop = FALSE` is needed

![image](https://github.com/user-attachments/assets/d689465c-177c-45bb-a52e-e50a6bc5a3b0)

after fix:

![image](https://github.com/user-attachments/assets/dc9ea118-5006-409a-b31a-34675842a1bc)
