### PR TITLE
For datasets with many contrasts: limit contrasts displayed in volcanos for better visual

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -21,14 +21,9 @@ enrichment_plot_volcanoall_ui <- function(
       "Scale the volcano plots individually per method..",
       placement = "right", options = list(container = "body")
     ),
-    #withTooltip(
-    #  shiny::radioButtons(ns("enrch_volcanoall_subs"), "Subsample plot",
-    #   c("Yes", "No"), inline = TRUE, selected = "No"),
-    #  "Number of top genesets to consider for counting the gene frequency."
-    #),
     withTooltip(
       shiny::radioButtons(ns("n_contrasts"), "Number of contrasts shown:",
-        c("1", "4", "8", "all"), inline = TRUE, selected = "4"),
+        c("1", "4", "6", "all"), inline = TRUE, selected = "6"),
       "Number of contrasts shown in Volcano plots."
     )
   )

--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -16,16 +16,20 @@ enrichment_plot_volcanoall_ui <- function(
   ns <- shiny::NS(id)
 
   plot_options <- shiny::tagList(
-    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", FALSE),
+    withTooltip(
+      shiny::checkboxInput(ns("scale_per_method"), "Scale per method", FALSE),
       "Scale the volcano plots individually per method..",
       placement = "right", options = list(container = "body")
     ),
+    #withTooltip(
+    #  shiny::radioButtons(ns("enrch_volcanoall_subs"), "Subsample plot",
+    #   c("Yes", "No"), inline = TRUE, selected = "No"),
+    #  "Number of top genesets to consider for counting the gene frequency."
+    #),
     withTooltip(
-      shiny::radioButtons(ns("enrch_volcanoall_subs"), "Subsample plot",
-        c("Yes", "No"),
-        inline = TRUE, selected = "No"
-      ),
-      "Number of top genesets to consider for counting the gene frequency."
+      shiny::radioButtons(ns("n_contrasts"), "Number of contrasts shown:",
+        c("1", "4", "8", "all"), inline = TRUE, selected = "4"),
+      "Number of contrasts shown in Volcano plots."
     )
   )
 
@@ -49,6 +53,7 @@ enrichment_plot_volcanoall_ui <- function(
 
 enrichment_plot_volcanoall_server <- function(id,
                                               pgx,
+                                              gs_contrast,
                                               gs_features,
                                               gs_statmethod,
                                               gs_fdr,
@@ -56,14 +61,30 @@ enrichment_plot_volcanoall_server <- function(id,
                                               calcGsetMeta,
                                               gset_selected,
                                               watermark = FALSE) {
+
   moduleServer(id, function(input, output, session) {
+
     plot_data <- shiny::reactive({
       shiny::req(pgx$X)
       shiny::req(gs_features())
-
+      
       meta <- pgx$gset.meta$meta
       ctx <- names(meta)[!grepl("^IA:", names(meta))]
-      meta <- meta[ctx]
+
+      sel_ctx <- gs_contrast()
+      if (input$n_contrasts == "all") {
+        ctx1 <- ctx[1:length(ctx)]
+      } else if (input$n_contrasts == "1") {
+        ctx1 <- sel_ctx
+      } else {
+        nn <- as.numeric(input$n_contrasts) - 1
+        ctx1 <- ctx[which(ctx != sel_ctx)]
+        ctx1 <- ctx1[c(1:nn)]
+        ctx1 <- ctx1[!is.na(ctx1)]
+        ctx1 <- unique(c(sel_ctx, ctx1))
+      }
+      
+      meta <- meta[ctx1]
       gsmethod <- colnames(meta[[1]]$fc)
       gsmethod <- gs_statmethod()
       if (is.null(gsmethod) || length(gsmethod) == 0) {

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -505,6 +505,7 @@ EnrichmentBoard <- function(id, pgx,
     enrichment_plot_volcanoall_server(
       "volcanoAll",
       pgx = pgx,
+      gs_contrast = shiny::reactive(input$gs_contrast),
       gs_features = shiny::reactive(input$gs_features),
       gs_statmethod = shiny::reactive(input$gs_statmethod),
       gs_fdr = shiny::reactive(input$gs_fdr),


### PR DESCRIPTION
GeneSets > Geneset enrichment > Volcano by comparison > Volcano plots for all contrasts.

In case of many contrasts, (typically for scRNAseq but also large bulk data), the Volcanos are very messy. Furthermore, the "Contrast:" selected in the drop-down menu on the right pulled the genesets for that contrast in the table, but may not be very visible in Volcano plot when there are many contrasts. Here 2 changes:
1.  Added plot option to allow user to choose how many contrasts to visualize;
2.  Ensured that the selected contrast in the drop-down menu is always displayed.

I also removed the previous plot option "enrch_volcanoall_subs" which was unused.

Visual is now clean as per default.

