### PR TITLE
Multiple enhancements in GeneSet Enrichment modules: display enrichment score per method, p-values, q-values. 

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -40,6 +40,7 @@ enrichment_plot_volcano_server <- function(id,
                                            gset_selected,
                                            gs_fdr,
                                            gs_lfc,
+                                           show_pv,
                                            subplot.MAR,
                                            geneDetails,
                                            watermark = FALSE) {
@@ -50,21 +51,22 @@ enrichment_plot_volcano_server <- function(id,
 
       shiny::req(pgx$X)
       shiny::validate(shiny::need(!is.null(gset_selected()), tspan("Please select a geneset.", js = FALSE)))
-
+      
       comp <- 1
       gs <- 1
       comp <- gs_contrast()
       shiny::req(pgx$X)
-
+      
       gxmethods <- selected_gxmethods() ## from module-expression
       shiny::req(gxmethods)
 
       gx.meta <- pgx$gx.meta$meta[[comp]]
+      meta.p <- apply(gx.meta$p[, gxmethods, drop = FALSE], 1, max) ## max p-value
       meta.q <- apply(gx.meta$q[, gxmethods, drop = FALSE], 1, max) ## max q-value
-      limma1 <- data.frame(meta.fx = gx.meta$meta.fx, meta.q = meta.q)
+      limma1 <- data.frame(meta.fx = gx.meta$meta.fx, meta.q = meta.q, meta.p = meta.p)
       gx.annot <- pgx$genes[rownames(gx.meta), c("gene_name", "gene_title")]
       limma <- cbind(gx.annot, limma1)
-
+      
       gset <- geneDetails()$feature
 
       gset <- playbase::probe2symbol(gset, pgx$genes, "gene_name")
@@ -77,32 +79,45 @@ enrichment_plot_volcano_server <- function(id,
       fc.genes <- as.character(limma[, grep("^gene$|gene_name", colnames(limma))])
       fx <- limma[, grep("logFC|meta.fx|fc", colnames(limma))[1]]
       qval <- limma[, grep("^q|adj.P.Val|meta.q|qval|padj", colnames(limma))[1]]
+      pval <- limma[, grep("^p|P.Val|Pvalue|meta.p|pval", colnames(limma))[1]]
 
       qval <- pmax(qval, 1e-12) ## prevent q=0
       qval[which(is.na(qval))] <- 1
-      xlim <- c(-1, 1) * max(abs(fx), na.rm = TRUE)
-      ylim <- c(0, 12)
-      ylim <- c(0, max(12, 1.1 * max(-log10(qval), na.rm = TRUE)))
+      pval <- pmax(pval, 1e-12) ## prevent p=0
+      pval[which(is.na(pval))] <- 1
 
       lfc <- 0.20
       lfc <- as.numeric(gs_lfc())
 
+      xlim <- c(-1, 1) * max(abs(fx), na.rm = TRUE)
+      ylim <- c(0, 12)
+      
+      y <- -log10(qval)
+      ylab <- "Significance (-log10q)"
+      ylim <- c(0, max(12, 1.1 * max(-log10(qval), na.rm = TRUE)))
+
+      if (show_pv()) {
+        y <- -log10(pval)
+        ylab <- "Significance (-log10p)"
+        ylim <- c(0, max(12, 1.1 * max(-log10(pval), na.rm = TRUE)))
+      }
+      
       return(list(
         x = fx,
-        y = -log10(qval),
+        y = y,
         fc.genes = fc.genes,
         sel.genes = sel.genes,
         lab.cex = 1,
         fdr = fdr,
-        lfc = lfc
+        lfc = lfc,
+        ylab = ylab
       ))
     })
 
     plotly.RENDER <- function(marker.size = 3, lab.cex = 1) {
       pd <- plot_data()
       shiny::req(pd)
-
-      playbase::plotlyVolcano(
+      playbase::plotlyVolcano( ## in use
         x = pd[["x"]],
         y = pd[["y"]],
         names = pd[["fc.genes"]],
@@ -115,24 +130,20 @@ enrichment_plot_volcano_server <- function(id,
         psig = pd[["fdr"]],
         lfc = pd[["lfc"]],
         xlab = "Effect size (log2FC)",
-        ylab = "Significance (-log10q)",
+        ylab = pd[["ylab"]],
         marker.size = marker.size,
         displayModeBar = FALSE,
         showlegend = FALSE,
         color_up_down = TRUE
       ) %>%
-        plotly::layout(
-          margin = list(l = 0, r = 0, t = 0, b = 0)
-        )
+        plotly::layout(margin = list(l = 0, r = 0, t = 0, b = 0))
     }
 
     plotly.RENDER2 <- function() {
       plotly.RENDER(marker.size = 8, lab.cex = 1.5) %>%
         plotly::layout(
           font = list(size = 18),
-          legend = list(
-            font = list(size = 18)
-          )
+          legend = list(font = list(size = 18))
         )
     }
 
@@ -151,7 +162,7 @@ enrichment_plot_volcano_server <- function(id,
         psig = pd[["fdr"]],
         lfc = pd[["lfc"]],
         xlab = "Effect size (log2FC)",
-        ylab = "Significance (-log10q)",
+        ylab = pd[["ylab"]],
         marker.size = 1,
         showlegend = FALSE
       )
@@ -171,7 +182,7 @@ enrichment_plot_volcano_server <- function(id,
         psig = pd[["fdr"]],
         lfc = pd[["lfc"]],
         xlab = "Effect size (log2FC)",
-        ylab = "Significance (-log10q)",
+        ylab = pd[["ylab"]],
         marker.size = 2,
         label.cex = 6,
         axis.text.size = 24,

--- a/components/board.enrichment/R/enrichment_plot_volcanomethods.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanomethods.R
@@ -17,7 +17,7 @@ enrichment_plot_volcanomethods_ui <- function(
 
 
   plot_options <- shiny::tagList(
-    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "scale per method", TRUE),
+    withTooltip(shiny::checkboxInput(ns("scale_per_method"), "Scale per method", TRUE),
       "Scale the volcano plots individually per method..",
       placement = "right", options = list(container = "body")
     )
@@ -47,6 +47,7 @@ enrichment_plot_volcanomethods_server <- function(id,
                                                   gs_contrast,
                                                   gs_fdr,
                                                   gs_lfc,
+                                                  show_pv,
                                                   gset_selected,
                                                   watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
@@ -56,11 +57,13 @@ enrichment_plot_volcanomethods_server <- function(id,
       cmp <- gs_contrast()
       mx <- pgx$gset.meta$meta[[cmp]]
       FC <- unclass(mx$fc)
+      P <- unclass(mx$p)
       Q <- unclass(mx$q)
-      rownames(Q) <- rownames(FC) <- rownames(mx)
+      rownames(P) <- rownames(Q) <- rownames(FC) <- rownames(mx)
       FC[which(is.infinite(FC))] <- NA
+      P[which(is.na(P))] <- 1
       Q[which(is.na(Q))] <- 1
-
+      
       fdr <- as.numeric(gs_fdr())
       lfc <- as.numeric(gs_lfc())
       gset_collections <- playbase::pgx.getGeneSetCollections(
@@ -69,12 +72,20 @@ enrichment_plot_volcanomethods_server <- function(id,
       sel.gsets <- gset_collections[[gs_features()]]
       nlq <- -log10(1e-99 + unlist(Q))
 
+      S <- Q
+      title_y <- "Significance (-log10q)"
+      if (show_pv()) {
+        S <- P
+        title_y <- "Significance (-log10p)"
+      }
+      
       pd <- list(
         FC = FC,
-        Q = Q,
+        S = S,
         sel.gsets = sel.gsets,
         fdr = fdr,
         lfc = lfc,
+        title_y = title_y,
         gset_selected = gset_selected()
       )
       pd
@@ -90,21 +101,22 @@ enrichment_plot_volcanomethods_server <- function(id,
       lfc <- pd[["lfc"]]
       highlight <- pd[["gset_selected"]]
       label <- pd[["gset_selected"]]
+      title_y <- pd[["title_y"]]
       ## meta tables
       F <- pd$FC
-      Q <- pd$Q
+      S <- pd$S
       sel.gsets <- pd$sel.gsets
       rm(pd)
       # Call volcano plots
       all_plts <- playbase::plotlyVolcano_multi(
         FC = F,
-        Q = Q,
+        Q = S,
         fdr = fdr,
         lfc = lfc,
         cex = cex,
         names = rownames(F),
-        title_y = "significance (-log10q)",
-        title_x = "effect size (log2FC)",
+        title_x = "Effect size (log2FC)",
+        title_y = title_y,
         share_axis = !input$scale_per_method,
         yrange = yrange,
         n_rows = n_rows,
@@ -140,8 +152,8 @@ enrichment_plot_volcanomethods_server <- function(id,
       shiny::req(pd)
 
       fc <- pd[["FC"]]
-      qv <- pd[["Q"]]
-
+      sig <- pd[["S"]] ## can be q or p value
+      
       gene_names <- rep(rownames(fc), each = ncol(fc))
       fc <- data.frame(fc) %>%
         tidyr::pivot_longer(
@@ -149,15 +161,15 @@ enrichment_plot_volcanomethods_server <- function(id,
           names_to = "facet", # Name of the new column for timepoints
           values_to = "fc"
         )
-      qv <- data.frame(qv) %>%
+      sig <- data.frame(sig) %>%
         tidyr::pivot_longer(
           cols = everything(), # Select all columns to pivot
           names_to = "facet", # Name of the new column for timepoints
-          values_to = "qv"
+          values_to = "sig"
         )
       facet <- fc$facet
       x <- fc$fc
-      y <- qv$qv
+      y <- sig$sig
       y <- -log10(y + 1e-12)
 
       playbase::ggVolcano(
@@ -171,7 +183,7 @@ enrichment_plot_volcanomethods_server <- function(id,
         lfc = pd[["lfc"]],
         psig = pd[["fdr"]],
         xlab = "Effect size (log2FC)",
-        ylab = "Significance (-log10p)",
+        ylab = pd[["title_y"]],
         marker.size = 1.2,
         showlegend = FALSE,
         title = NULL

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -533,6 +533,7 @@ EnrichmentBoard <- function(id, pgx,
       gs_statmethod = shiny::reactive(input$gs_statmethod),
       gs_fdr = shiny::reactive(input$gs_fdr),
       gs_lfc = shiny::reactive(input$gs_lfc),
+      show_pv = shiny::reactive(input$show_pv),
       calcGsetMeta = calcGsetMeta,
       gset_selected = gset_selected,
       watermark = WATERMARK

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -69,7 +69,7 @@ EnrichmentBoard <- function(id, pgx,
         selected = sel2
       )
     })
-
+    
     shiny::observe({
       shiny::req(pgx$X)
       gset_collections <- playbase::pgx.getGeneSetCollections(gsets = rownames(pgx$gsetX))
@@ -82,6 +82,24 @@ EnrichmentBoard <- function(id, pgx,
       shiny::updateSelectInput(session, "gs_features", choices = gsets.groups, selected = sel)
     })
 
+    shiny::observe({
+      if (isTRUE(input$show_pv)) {
+        shinyalert::shinyalert(
+          title = "",
+          text = "WARNING: Nominal p-values are NOT corrected for multiple testing. We do not advice their use.",
+          type = "warning"
+        )
+      }
+    })
+
+    shiny::observeEvent(input$show_pv, {
+      shiny::updateSelectInput(
+        session,
+        "gs_fdr",
+        label = if (input$show_pv) "P-value" else "FDR"
+      )
+    })
+      
     ## ================================================================================
     ## ========================= REACTIVE FUNCTIONS ===================================
     ## ================================================================================
@@ -133,6 +151,7 @@ EnrichmentBoard <- function(id, pgx,
     }
 
     getFullGeneSetTable <- shiny::reactive({
+
       shiny::req(pgx$X)
       shiny::req(input$gs_contrast)
       shiny::req(input$gs_features)
@@ -140,17 +159,17 @@ EnrichmentBoard <- function(id, pgx,
       gene_symbols <- pgx$genes[rownames(pgx$gx.meta$meta[[comp]]), "symbol"]
       names(gene_symbols) <- rownames(pgx$gx.meta$meta[[comp]])
 
-      if (!(comp %in% names(pgx$gset.meta$meta))) {
+      if (!(comp %in% names(pgx$gset.meta$meta)))
         return(NULL)
-      }
+      
       mx <- pgx$gset.meta$meta[[comp]]
       
       outputs <- NULL
       gsmethod <- colnames(unclass(mx$fc))
       gsmethod <- input$gs_statmethod
-      if (is.null(gsmethod) || length(gsmethod) == 0) {
+
+      if (is.null(gsmethod) || length(gsmethod) == 0)
         return(NULL)
-      }
 
       lfc <- as.numeric(input$gs_lfc)
       fdr <- as.numeric(input$gs_fdr)
@@ -168,13 +187,12 @@ EnrichmentBoard <- function(id, pgx,
       rpt <- NULL
       
       if (is.null(outputs) || length(gsmethod) > 1) {
-        ## show meta-statistics table (multiple methods)
         pv <- unclass(mx$p)[, gsmethod, drop = FALSE]
         qv <- unclass(mx$q)[, gsmethod, drop = FALSE]
-        fx <- unclass(mx$fc)[, gsmethod, drop = FALSE]
-
-        ## !!!! Because the methods have all very difference "fold-change" !!!!
-        ## estimators, we use the meta.fx (average of all genes in gset)
+        scores <- unclass(mx$fc)[, gsmethod, drop = FALSE]
+        
+        ## Methods have all very difference "fold-change" estimators.
+        ## We use the meta.fx (average of all genes in gset)
         fx <- do.call(cbind, rep(list(mx$meta.fx), length(gsmethod)))
         colnames(fx) <- gsmethod
 
@@ -199,7 +217,6 @@ EnrichmentBoard <- function(id, pgx,
         
         ## ---------- report *average* group expression FOLD CHANGE
         ## THIS SHOULD BETTER GO DIRECTLY WHEN CALCULATING GSET TESTS
-        ##
         s1 <- names(which(pgx$model.parameters$exp.matrix[, comp] > 0))
         s0 <- names(which(pgx$model.parameters$exp.matrix[, comp] < 0))
         
@@ -257,21 +274,27 @@ EnrichmentBoard <- function(id, pgx,
             AveExpr1 = AveExpr1[gs]
           )
         }
-
-        ## add extra p/q value columns
+        
+        ## add extra score, p/q value columns
+        colnames(pv) <- paste0("p.", colnames(pv))
+        colnames(scores) <- paste0("score.", colnames(scores))
         jj <- match(gs, rownames(mx))
-        rpt <- cbind(rpt, q = qv[jj, ])
+        rpt <- cbind(rpt, q = qv[jj, , drop = FALSE],
+          pv[jj, , drop = FALSE], scores[jj, , drop = FALSE])
 
-        #
+        if (length(gsmethod) == 1)
+          colnames(rpt)[colnames(rpt) == gsmethod] <- paste0("q.", gsmethod)
+
       } else {
         ## show original table (single method)
         rpt <- outputs[[gsmethod]]
       }
-
+      
       rpt <- rpt[order(rpt$meta.q, -rpt$logFC), ] ## positive
-      rpt <- data.frame(rpt)
-
+      rpt <- data.frame(rpt)      
+      
       return(rpt)
+
     })
 
     getFilteredGeneSetTable <- shiny::reactive({
@@ -284,7 +307,8 @@ EnrichmentBoard <- function(id, pgx,
       }
 
       res <- getFullGeneSetTable()
-
+      
+      
       ## just show significant genes
       if (!input$gs_showall && nrow(res) > 0) {
         lfc <- as.numeric(input$gs_lfc)
@@ -308,10 +332,14 @@ EnrichmentBoard <- function(id, pgx,
         res <- res[order(-fx), , drop = FALSE]
       }
 
+      if (!input$show_pv)
+        res <- res[, -grep("^p.", colnames(res)), drop = FALSE]
+      
       res <- data.frame(res)
 
       if (nrow(res) == 0) {
-        shiny::validate(shiny::need(nrow(res) > 0, tspan("No genesets passed the statistical thresholds. Please update the thresholds on the settings sidebar.", js = FALSE)))
+        shiny::validate(shiny::need(nrow(res) > 0,
+          tspan("No genesets passed the statistical thresholds. Please update the thresholds on the settings sidebar.", js = FALSE)))
         return(NULL)
       }
       return(res)
@@ -330,7 +358,6 @@ EnrichmentBoard <- function(id, pgx,
 
     metaFC <- shiny::reactive({
       req(pgx$X)
-      #
       metaFC <- sapply(pgx$gset.meta$meta, function(m) m$meta.fx)
       rownames(metaFC) <- rownames(pgx$gset.meta$meta[[1]])
       metaFC
@@ -342,12 +369,9 @@ EnrichmentBoard <- function(id, pgx,
 
     gset_selected <- shiny::reactive({
       i <- as.integer(gseatable$rows_selected())
-      if (is.null(i) || length(i) == 0) {
-        return(NULL)
-      }
+      if (is.null(i) || length(i) == 0) return(NULL)
       rpt <- getFilteredGeneSetTable()
       gs <- rownames(rpt)[i]
-
       return(gs)
     })
 
@@ -358,9 +382,7 @@ EnrichmentBoard <- function(id, pgx,
       comp <- 1
       comp <- input$gs_contrast
       gs <- gset_selected()
-      if (is.null(gs) || length(gs) == 0) {
-        return(NULL)
-      }
+      if (is.null(gs) || length(gs) == 0) return(NULL)
 
       mx <- pgx$gx.meta$meta[[comp]]
       gxmethods <- selected_gxmethods() ## from module-expression
@@ -390,9 +412,9 @@ EnrichmentBoard <- function(id, pgx,
       genes <- cbind(genes, limma1)
       genes <- genes[which(!is.na(genes$fc) & !is.na(rownames(genes))), , drop = FALSE]
 
-      if (nrow(genes) > 0) {
+      if (nrow(genes) > 0)
         genes <- genes[order(-abs(genes$fc)), , drop = FALSE]
-      }
+      
       return(genes)
     })
 
@@ -450,6 +472,7 @@ EnrichmentBoard <- function(id, pgx,
       gset_selected = gset_selected,
       gs_fdr = shiny::reactive(input$gs_fdr),
       gs_lfc = shiny::reactive(input$gs_lfc),
+      show_pv = shiny::reactive(input$show_pv),
       subplot.MAR = subplot.MAR,
       geneDetails = geneDetails,
       watermark = WATERMARK
@@ -544,7 +567,7 @@ EnrichmentBoard <- function(id, pgx,
     )
 
     # Gene set enrichment for all contrasts
-
+    
     enrichment_table_gset_enrich_all_contrasts_server(
       "fctable",
       pgx = pgx,

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -548,6 +548,7 @@ EnrichmentBoard <- function(id, pgx,
       gs_contrast = shiny::reactive(input$gs_contrast),
       gs_fdr = shiny::reactive(input$gs_fdr),
       gs_lfc = shiny::reactive(input$gs_lfc),
+      show_pv = shiny::reactive(input$show_pv),
       gset_selected = gset_selected,
       watermark = WATERMARK
     )

--- a/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
+++ b/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
@@ -13,8 +13,12 @@ enrichment_table_enrichment_analysis_ui <- function(
   ns <- shiny::NS(id)
 
   gseatable_opts <- shiny::tagList(
-    withTooltip(shiny::checkboxInput(ns("gs_showqvalues"), "show indivivual q-values", FALSE),
-      "Show all q-values of each individual statistical method in the table.",
+    withTooltip(shiny::checkboxInput(ns("gs_showqvalues"), "Show individual q-values", FALSE),
+      "Show q-values of each statistical method in the table.",
+      placement = "top", options = list(container = "body")
+    ),
+    withTooltip(shiny::checkboxInput(ns("show_scores"), "Show method-specific score", FALSE),
+      "Show enrichment score of each statistical method in the table.",
       placement = "top", options = list(container = "body")
     )
   )
@@ -46,14 +50,11 @@ enrichment_table_enrichment_analysis_server <- function(id,
     })
 
     gseatable.RENDER <- function() {
+
       rpt <- table_data()
 
-      if (is.null(rpt)) {
-        return(NULL)
-      }
-      if (nrow(rpt) == 0) {
-        return(NULL)
-      }
+      if (is.null(rpt)) return(NULL)
+      if (nrow(rpt) == 0) return(NULL)
 
       if ("GS" %in% colnames(rpt)) rpt$GS <- playbase::shortstring(rpt$GS, 72)
       if ("size" %in% colnames(rpt)) rpt$size <- as.integer(rpt$size)
@@ -61,15 +62,18 @@ enrichment_table_enrichment_analysis_server <- function(id,
       fx <- NULL
       fx.col <- grep("score|fx|fc|sign|NES|logFC", colnames(rpt))[1]
       if (length(fx.col) > 0) fx <- rpt[, fx.col]
-
+      
       jj <- which(sapply(rpt, function(col) is.numeric(col) && !is.integer(col)))
       if (length(jj) > 0) rpt[, jj] <- round(rpt[, jj], digits = 4)
       jj <- which(sapply(rpt, is.character) | sapply(rpt, is.factor))
       if (length(jj) > 0) rpt[, jj] <- apply(rpt[, jj, drop = FALSE], 2, playbase::shortstring, 100)
-      if (!input$gs_showqvalues) {
-        rpt <- rpt[, grep("^q[.]|^q$", colnames(rpt), invert = TRUE)]
-      }
 
+      if (!input$gs_showqvalues)
+        rpt <- rpt[, grep("^q[.]|^q$", colnames(rpt), invert = TRUE)]
+      
+      if (!input$show_scores)
+        rpt <- rpt [, -grep("^score.", colnames(rpt)), drop = FALSE]
+      
       ## wrap genesets names with known links.
       GS_link <- playbase::wrapHyperLink(
         rep_len("<i class='fa-solid fa-arrow-up-right-from-square weblink'></i>", nrow(rpt)),

--- a/components/board.enrichment/R/enrichment_ui.R
+++ b/components/board.enrichment/R/enrichment_ui.R
@@ -25,7 +25,7 @@ EnrichmentInputs <- function(id) {
         shiny::selectInput(ns("gs_lfc"), "logFC",
           choices = c(0, 0.05, 0.1, 0.2, 0.5, 1, 2), selected = 0
         ),
-        "Set the logarithmic fold change (logFC) threshold.",
+        "Set the logarithmic fold change (log2FC) threshold.",
         placement = "top"
       )
     ),
@@ -38,16 +38,20 @@ EnrichmentInputs <- function(id) {
         icon = icon("cog", lib = "glyphicon"),
         shiny::tagList(
           withTooltip(shiny::checkboxInput(ns("gs_showall"), tspan("Show all genesets"), FALSE),
-            "Enbale significant genes filtering. Display only significant genesets in the table.",
+            "Display all genesets in the table.",
+            placement = "top", options = list(container = "body")
+          ),
+          withTooltip(shiny::checkboxInput(ns("gs_top10"), tspan("Top10 genesets"), FALSE),
+            "Display only top 10 differentially enriched  (+ and -) genesets.",
+            placement = "top", options = list(container = "body")
+          ),
+          withTooltip(shiny::checkboxInput(ns("show_pv"), "Show p-values", FALSE),
+            "Show gset p-values in the table. WARNING: nominal p-values are NOT corrected for multiple testing errors. We do not advice their use.",
             placement = "top", options = list(container = "body")
           ),
           withTooltip(shiny::checkboxGroupInput(ns("gs_statmethod"), "Statistical methods:", choices = NULL),
             "Select a method or multiple methos for the statistical test.",
             placement = "right", options = list(container = "body")
-          ),
-          withTooltip(shiny::checkboxInput(ns("gs_top10"), tspan("top 10 gene sets"), FALSE),
-            "Display only top 10 differentially enirhced gene sets (positively and negatively) in the enrihcment analysis table.",
-                placement = "top", options = list(container = "body")
           )
         )
       )

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -84,7 +84,7 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
           shinyalert::shinyalert(
             title = "",
             text = "WARNING: Nominal p-values are NOT corrected for multiple testing. We do not advice their use.",
-            type = ""
+            type = "warning"
           )
         }
       }


### PR DESCRIPTION
Multiple enhancements for Genesets enrichment module:
1:   Optionally display metric (score) of each geneset enrichment method in enrichment table.  (ps: Existing client requested such feature)
2:   Reorganized the "Options" menu
3.  Added option "Show p-values" to (i) show p-values in enrichment table and (ii) show -log10(p-values) in Enrichment Volcano plot. "FDR" label also gets updated when "Show p-values" is selected.   