### PR TITLE
Devel close message

### DIFF
--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -68,6 +68,8 @@ app_ui <- function(x) {
         ##    gtag2, ## Google Tag Manager???
         shiny::tags$head(shiny::tags$script(src = "custom/temp.js")),
         shiny::tags$head(shiny::tags$script(src = "static/copy-info-helper.js")),
+        shiny::tags$script(src = "custom/close-message.js"
+  ),
         shiny::tags$head(shiny::tags$script(src = "static/add-tick-helper.js")),
         shiny::tags$head(shiny::tags$script(src = "custom/dropdown-helper.js")),
         shiny::tags$head(shiny::tags$link(rel = "stylesheet", href = "custom/styles.min.css")),

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -68,8 +68,7 @@ app_ui <- function(x) {
         ##    gtag2, ## Google Tag Manager???
         shiny::tags$head(shiny::tags$script(src = "custom/temp.js")),
         shiny::tags$head(shiny::tags$script(src = "static/copy-info-helper.js")),
-        shiny::tags$script(src = "custom/close-message.js"
-  ),
+        shiny::tags$script(src = "custom/close-message.js"),
         shiny::tags$head(shiny::tags$script(src = "static/add-tick-helper.js")),
         shiny::tags$head(shiny::tags$script(src = "custom/dropdown-helper.js")),
         shiny::tags$head(shiny::tags$link(rel = "stylesheet", href = "custom/styles.min.css")),

--- a/components/app/R/www/close-message.js
+++ b/components/app/R/www/close-message.js
@@ -7,8 +7,8 @@ Shiny.addCustomMessageHandler('warnOnExit', function(message) {
 // Before the user closes the tab
 window.addEventListener('beforeunload', function (e) {
 if (shouldWarnOnExit) {
-        var confirmationMessage = 'Dataset computation is running. Are you sure you want to leave? Leaving will cancel the computation.';
-        (e || window.event).returnValue = confirmationMessage; // For older browsers
-        return confirmationMessage; // For modern browsers
+        var confirmationMessage = 'Dataset computation is running. Are you sure you want to leave? Leaving will cancel the computation.'; // Wont be displayed on modern browsers
+        (e || window.event).returnValue = confirmationMessage;
+        return confirmationMessage;
     }
 });

--- a/components/app/R/www/close-message.js
+++ b/components/app/R/www/close-message.js
@@ -1,0 +1,14 @@
+var shouldWarnOnExit = false;
+
+Shiny.addCustomMessageHandler('warnOnExit', function(message) {
+    shouldWarnOnExit = message;
+});
+
+// Before the user closes the tab
+window.addEventListener('beforeunload', function (e) {
+if (shouldWarnOnExit) {
+        var confirmationMessage = 'Dataset computation is running. Are you sure you want to leave? Leaving will cancel the computation.';
+        (e || window.event).returnValue = confirmationMessage; // For older browsers
+        return confirmationMessage; // For modern browsers
+    }
+});

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -953,6 +953,7 @@ upload_module_computepgx_server <- function(
           stderr = c(),
           stdout = c()
         )
+        session$sendCustomMessage("warnOnExit", TRUE)
 
         ## append to process list
         PROCESS_LIST <<- c(PROCESS_LIST, list(new.job))
@@ -1100,6 +1101,7 @@ upload_module_computepgx_server <- function(
 
       # Function to execute when the process is completed successfully
       on_process_completed <- function(raw_dir, nr) {
+        session$sendCustomMessage("warnOnExit", FALSE)
         dbg("[computePGX:on_process_completed] process", nr, "completed!")
         process_counter(process_counter() - 1)
 


### PR DESCRIPTION
From office conversation:

- Display a warning message when computation is in progress and user closes tab/browser.
- Make sure this only happens while data is *actually* being computed.

Before: (compute in progress)
[Screencast from 2025-04-22 17-42-29.webm](https://github.com/user-attachments/assets/61eb5485-4ada-4e34-86cb-854f454da8c8)

After: (no compute in progress)
[Screencast from 2025-04-22 17-32-25.webm](https://github.com/user-attachments/assets/b65a3d0c-eee8-41fb-be99-b37012fab3ce)

After: (compute in progress)
[Screencast from 2025-04-22 17-40-40.webm](https://github.com/user-attachments/assets/73b5b977-4dd2-4e28-b1bc-48c6dffb9105)

Regarding the contents of the message: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event

> Only show a generic browser-specified string in the displayed dialog. This cannot be controlled by the webpage code.