### PR TITLE
Unify timevars

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -781,6 +781,7 @@ app_server <- function(input, output, session) {
     tabRequire(PGX, session, "drug-tab", "drugs", TRUE)
     tabRequire(PGX, session, "wordcloud-tab", "wordcloud", TRUE)
     tabRequire(PGX, session, "cell-tab", "deconv", TRUE)
+    tabRequireTS(PGX, session, "timeseries-tab", TRUE)
     gset_tabs <- c("enrich-tab", "pathway-tab", "isect-tab", "sig-tab")
     for (tab_i in gset_tabs) {
       tabRequire(PGX, session, tab_i, "gsetX", TRUE)

--- a/components/app/R/utils/utils.R
+++ b/components/app/R/utils/utils.R
@@ -116,6 +116,16 @@ tabRequire <- function(pgx, session, tabname, slot, enable = TRUE) {
   }
 }
 
+tabRequireTS <- function(pgx, session, tabname, enable = TRUE) {
+  time.vars <- playbase::get_timevars()
+  found.time.var <- grep(time.vars, colnames(pgx$samples), ignore.case = TRUE)
+  if(length(found.time.var) > 0 && enable) {
+    bigdash.showTab(session, tabname)
+  } else {
+    bigdash.hideTab(session, tabname)
+  }
+}
+
 fileRequire <- function(file, tabname, subtab) {
   file1 <- playbase::search_path(c(FILES, FILESX), file)
   has.file <- !is.null(file1) && file.exists(file1)

--- a/components/board.timeseries/R/board_server.R
+++ b/components/board.timeseries/R/board_server.R
@@ -62,7 +62,7 @@ TimeSeriesBoard <- function(id,
 
       ## set time variable
       vars <- sort(colnames(pgx$samples))
-      timevars <- unique( c(grep("time|second|minute|day|week|month|year", vars, value=TRUE, ignore.case=TRUE), vars))
+      timevars <- unique( c(grep(playbase::get_timevars(), vars, value=TRUE, ignore.case=TRUE), vars))
       shiny::updateSelectInput(session, "timevar", choices=timevars, selected=timevars[1])
 
       ## set available contrasts

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -440,8 +440,8 @@ upload_module_computepgx_server <- function(
         colnames(Y) <- tolower(colnames(Y))
         Contrasts <- Contrasts[rownames(Y), , drop = FALSE]
         
-        time.var <- c("minute", "hour", "day", "week", "month", "year", "age", "time")
-        sel.time <- intersect(time.var, colnames(Y))
+        time.var <- playbase::get_timevars()
+        sel.time <- grep(time.var, colnames(Y), ignore.case = TRUE)
 
         if (length(sel.time) && length(unique(Y[, sel.time[1]]))>1) {
           


### PR DESCRIPTION
Additional: make sure we set ignore case to TRUE

Linked to https://github.com/bigomics/playbase/pull/249

Also on this PR

Hide TS tab when the samples file of the pgx does not have a time variable. For that I have created an auxiliary `tabRequireTS` function, which mimics the already available `tabRequire`.