### PR TITLE
Scatterplot pairs: use pairwise to compute `r`

### DIFF
--- a/components/board.intersection/R/intersection_plot_scatterplot_pairs.R
+++ b/components/board.intersection/R/intersection_plot_scatterplot_pairs.R
@@ -125,7 +125,7 @@ intersection_scatterplot_pairs_server <- function(id,
         ## Single pairs plot
         ## ----------------------------------------------------
 
-        rho <- cor(df[, 1], df[, 2])
+        rho <- cor(df[, 1], df[, 2], use = "pairwise")
         annot.rho <- list(
           text = paste("r=", round(rho, 4)),
           font = list(size = 14),
@@ -184,7 +184,7 @@ intersection_scatterplot_pairs_server <- function(id,
         dimensions <- lapply(colnames(df), function(a) list(label = a, values = df[, a]))
 
         ## compute correlations
-        rho <- cor(df)
+        rho <- cor(df, use = "pairwise")
         rho.text <- paste("r=", as.vector(round(rho, digits = 3)))
         n <- ncol(df)
 


### PR DESCRIPTION
Some datasets (example: salmon-ENSOKI from opg-exampledata) have some NaNs on the matrix used to compute `r` on the scatterplot pairs.

Use `pairwise` correlation to not get NA correlation.

### Before
![salmon-ENSOKI_intersection_Pairwise_scatter](https://github.com/user-attachments/assets/69ee3567-e4d9-4042-ba69-a47a5f419e73)


### After
![image](https://github.com/user-attachments/assets/94c33de6-c9e4-47a4-af29-7e5f6e5d8b7a)
