### PR TITLE
gsva fails on markers plot with missings

### DIFF
--- a/components/board.signature/R/signature_plot_markers.R
+++ b/components/board.signature/R/signature_plot_markers.R
@@ -175,7 +175,7 @@ signature_plot_markers_server <- function(id,
         gc()
       }
       
-      if (is.null(X)) X <- pgx$X
+      if (is.null(X)) X <- pgx$impX
       xsymbol <- pgx$genes[rownames(X), "symbol"]
       X <- playbase::rowmean(X, xsymbol)
       y <- 1 * (rownames(X) %in% this.gset)

--- a/components/board.signature/R/signature_plot_markers.R
+++ b/components/board.signature/R/signature_plot_markers.R
@@ -175,7 +175,7 @@ signature_plot_markers_server <- function(id,
         gc()
       }
       
-      if (is.null(X)) X <- pgx$impX
+      if (is.null(X)) X <- if(is.null(pgx$impX)) pgx$X else pgx$impX
       xsymbol <- pgx$genes[rownames(X), "symbol"]
       X <- playbase::rowmean(X, xsymbol)
       y <- 1 * (rownames(X) %in% this.gset)


### PR DESCRIPTION
Use opg-exampledata trout-uniprot pgx file to reproduce.

GSVA was giving an error due to NaNs (NA) values on X. As discussed solved it with impX.

### Before
![trout-uniprot_signature_Markers](https://github.com/user-attachments/assets/9a4a8726-800e-4844-90bd-c7fb5dac76d5)


### After
![image](https://github.com/user-attachments/assets/4452815a-d299-480f-88f2-50e8172a4f74)
