### PR TITLE
Fix #1390: WGCNA error; fission data

### DIFF
--- a/components/board.wgcna/R/wgcna_server.R
+++ b/components/board.wgcna/R/wgcna_server.R
@@ -110,7 +110,7 @@ WgcnaBoard <- function(id, pgx, board_observers) {
         me <- sort(names(out$me.genes))
         shiny::updateSelectInput(session, "selected_module", choices = me,
                                  sel = me[1])
-        tt <- sort(colnames(out$datTraits))
+        tt <- sort(colnames(out$stats$foldChange))
         shiny::updateSelectInput(session, "selected_trait", choices = tt,
           selected = tt[1])
 


### PR DESCRIPTION
Cause of the error:

on playbase `pgx-wgcna.R`, when computing the gene stats (`wgcna.compute_geneStats`), we first compute `traitSignificance` and `GSPvalue` for all traits:

```
traitSignificance <- cor(datExpr, datTraits, use = "p")
GSPvalue <- WGCNA::corPvalueStudent(as.matrix(traitSignificance), nSamples)
```

however, we just compute `foldChange` and `foldChangePvalue` for binary traits:

```
is.binary <- apply(datTraits, 2, function(a) length(unique(a[!is.na(a)])) == 2)
  Y <- datTraits[, which(is.binary)]
  lm <- lapply(Y, function(y) {
    gx.limma(t(datExpr), y,
      lfc = 0, fdr = 1,
      sort.by = "none", verbose = 0
    )
  })
  foldChange <- sapply(lm, function(m) m$logFC)
  foldChangePvalue <- sapply(lm, function(m) m$P.Value)
```

because of this, there might be an imbalance in dimensions between those lists.

before, we allowed the user to select on the platform all traits:

```
tt <- sort(colnames(out$datTraits))
shiny::updateSelectInput(session, "selected_trait", choices = tt,
          selected = tt[1])
```

when selecting a trait, we call `playbase::wgcna.getGeneStats`, which does the following:

```
p2 <- c("traitSignificance", "GSPvalue", "foldChange", "foldChangePvalue")
tt.cols <- colnames(wgcna$stats[[p2[1]]])  
  if (!is.null(trait) && trait %in% tt.cols) {
    A2 <- sapply(wgcna$stats[p2], function(x) x[, trait])
    df <- cbind(df, A2)
  }
```

this assumes that on all elements `c("traitSignificance", "GSPvalue", "foldChange", "foldChangePvalue")` there are the same traits, which as we seen upwards is only the case for binary traits.

for those reasons, I updated the input list to only allow the user to select binary traits, which then works as expected:

![image](https://github.com/user-attachments/assets/1483a8a8-b0c7-497a-88a4-3923ba837c83)


