### PR TITLE
Hide similarity experiment if not available

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -782,6 +782,7 @@ app_server <- function(input, output, session) {
     tabRequire(PGX, session, "wordcloud-tab", "wordcloud", TRUE)
     tabRequire(PGX, session, "cell-tab", "deconv", TRUE)
     tabRequireTS(PGX, session, "timeseries-tab", TRUE)
+    tabRequire(PGX, session, "cmap-tab", "connectivity", TRUE)
     gset_tabs <- c("enrich-tab", "pathway-tab", "isect-tab", "sig-tab")
     for (tab_i in gset_tabs) {
       tabRequire(PGX, session, tab_i, "gsetX", TRUE)


### PR DESCRIPTION
Use `tabRequire` to not display similarity experiment tab if not available on the pgx