### PR TITLE
Use impX on TimeSeries

### DIFF
--- a/components/board.timeseries/R/board_server.R
+++ b/components/board.timeseries/R/board_server.R
@@ -84,7 +84,7 @@ TimeSeriesBoard <- function(id,
       shiny::req(input$timevar)
       ##shiny::req(input$knn)
       
-      X <- pgx$X
+      X <- if(is.null(pgx$impX)) pgx$X else pgx$impX
       sdx <- matrixStats::rowSds(X, na.rm = TRUE)
       if (any(sdx == 0)) X <- X + runif(length(X), 0, 1e-5)
 

--- a/components/board.timeseries/R/module_features.R
+++ b/components/board.timeseries/R/module_features.R
@@ -117,7 +117,7 @@ TimeSeriesBoard.features_server <- function(id,
       genes <- table_module$rownames_all()
       genes <- head(genes, 16)
 
-      expr  <- pgx$X[genes,,drop=FALSE]
+      expr  <- if(is.null(pgx$impX)) pgx$X[genes,,drop=FALSE] else pgx$impX[genes,,drop=FALSE]
       time <- pgx$samples[,sel.timevar]
 
       ct <- contrast()


### PR DESCRIPTION
By using X, we get some errors when there are missing on X:

- salmon-ENSOKI from opg-exampledata
### Before
![salmon-ENSOKI_timeseries_Clustering](https://github.com/user-attachments/assets/a66e7d67-5adb-484c-9192-dc51a3f27e7d)
![salmon-ENSOKI_timeseries_Statistics](https://github.com/user-attachments/assets/2a2148b8-2265-46a7-8477-cb344edb9ee9)

### After
By passing impX the boards look like this
![image](https://github.com/user-attachments/assets/ad8ff0fb-c050-4eb0-a408-763773d33638)
![image](https://github.com/user-attachments/assets/796415a9-b1e6-4742-a267-b24da2ea61f2)
