### PR TITLE
Fix #1384: wrong gene/feature higlighted in MA plot

### DIFF
--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -95,7 +95,7 @@ expression_plot_maplot_server <- function(id,
       symbols <- rownames(res)
 
       names <- ifelse(is.na(res$gene_title), rownames(res), res$gene_title)
-      label.names <- pgx$genes$gene_name  ## this is reactive, user-selected
+      label.names <- pgx$genes[rownames(res),]$gene_name  ## this is reactive, user-selected
 
       plot_data <- list(
         x = x,


### PR DESCRIPTION
This closes #1384

During devel of 4.0 labeltype switch at some point got unified using pgx$genes$gene_name(https://github.com/bigomics/omicsplayground/commit/bf913bd33eaf3c86519351c1dbe55b230735c38c)

However, here, we need to make sure that `label.names` is ordered the same as `res (and has same length):

![image](https://github.com/user-attachments/assets/33fbb870-c168-4936-aa96-a4fcd34b2ef4)
