### PR TITLE
Limit available datasets with contrasts

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -383,11 +383,8 @@ LoadingBoard <- function(id,
       nsamples <- sum(as.integer(pgx_info$nsamples), na.rm = TRUE)
       FC.file <- file.path(auth$user_dir, "datasets-allFC.csv")
       if (file.exists(FC.file)) {
-        contrast_names <- read.csv(FC.file, nrows = 1, header = TRUE, check.names = FALSE) |> colnames()
-        data_names <- gsub("^\\[|\\].*", "", contrast_names[-1])
-        pgx.files <- pgxtable$data()$dataset
-        data_names <- data_names[data_names %in% pgx.files]
-        ncontrasts <- length(data_names)
+        contrasts <- get_contrasts_from_user(auth)
+        ncontrasts <- sum(contrasts, na.rm = TRUE)
         return(
           paste(ndatasets, "Data sets &nbsp;&nbsp;&nbsp;", nsamples, "Samples &nbsp;&nbsp;&nbsp;", ncontrasts, "Comparisons")
         )

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -400,12 +400,16 @@ loading_table_datasets_server <- function(id,
         df_cap <- nrow(df)
       }
 
+      # Detect out of limits datasets (downgraded user might have uploaded more datasets in the past, but now they are not allowed)
       datasets_exceed_limits <- rep(FALSE, nrow(df))
       if (!is.null(auth$options$MAX_GENES)) {
         datasets_exceed_limits <- datasets_exceed_limits | (df$ngenes > auth$options$MAX_GENES)
       }
       if (!is.null(auth$options$MAX_SAMPLES)) {
         datasets_exceed_limits <- datasets_exceed_limits | (df$nsamples > auth$options$MAX_SAMPLES)
+      }
+      if (!is.null(auth$options$MAX_COMPARISONS)) {
+        datasets_exceed_limits <- datasets_exceed_limits | (get_contrasts_from_user(auth) > auth$options$MAX_COMPARISONS)
       }
 
       selectable_rows <- which(seq_len(nrow(df)) <= df_cap & !datasets_exceed_limits)
@@ -416,10 +420,6 @@ loading_table_datasets_server <- function(id,
         class = "compact hover",
         rownames = menus,
         escape = FALSE,
-        # editable = list(
-        #   target = "cell",
-        #   disable = list(columns = c(1, 3:ncol(df)))
-        # ),
         extensions = c("Scroller"),
         plugins = "scrollResize",
         selection = list(mode = "single", target = "row", selected = if(length(selectable_rows) > 0) selectable_rows[1] else NULL, selectable = selectable_rows),

--- a/components/board.loading/R/loading_utils.R
+++ b/components/board.loading/R/loading_utils.R
@@ -87,3 +87,17 @@ andothers <- function(s, split = " ", n = 8) {
   n2 <- setdiff(length(s1), n)
   paste(paste(head(s1, n), collapse = " "), "(+", n2, "others)")
 }
+
+get_contrasts_from_user <- function(auth) {
+  FC.file <- file.path(auth$user_dir, "datasets-allFC.csv")
+  if (file.exists(FC.file)) {
+    contrast_names <- read.csv(FC.file, nrows = 1, header = TRUE, check.names = FALSE) |> colnames()
+    dataset_names <- gsub(".*\\[(.*?)\\].*", "\\1", contrast_names)
+    dataset_counts <- table(dataset_names)
+    result <- as.vector(dataset_counts)
+    names(result) <- names(dataset_counts)
+    return(result)
+  } else {
+    return(NULL)
+  }
+}


### PR DESCRIPTION
On devel: Currently we limit datasets available by max_genes, max_samples and max_datasets.

1. Created function to retrieve contrasts on a user folder
2. Use function of (1) to compute number of contrasts of an user (which we display on dataset load)
3. Use function of (1) to limit the datasets the user can load (e.g. for a downgraded user) by max_comparisons

To test, change OPTIONS MAX_COMPARISONS and check that datasets with less contrasts are not available:

![image](https://github.com/user-attachments/assets/5801ee6c-a748-450b-9bbe-adc9559ddba4)


