### PR TITLE
feat: more clear change name/descr text

### DIFF
--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -621,7 +621,8 @@ loading_table_datasets_server <- function(id,
     observeEvent(input$changename_pgx, {
       shinyalert::shinyalert(
         title = "Change name",
-        text = "Are you sure you want to change the name of your dataset?",
+        text = paste0("Are you sure you want to change the name of your dataset '",
+          getFilteredPGXINFO()[as.numeric(stringr::str_split(input$changename_pgx, "_row_")[[1]][2]), "dataset",], "'?"),
         showCancelButton = TRUE,
         cancelButtonText = "Cancel",
         confirmButtonText = "OK",
@@ -629,7 +630,8 @@ loading_table_datasets_server <- function(id,
           if (x) {
             shinyalert::shinyalert(
               title = "Enter new name",
-              text = "Please enter a new name for your dataset:",
+              text = paste0("Rename your dataset '",
+                getFilteredPGXINFO()[as.numeric(stringr::str_split(input$changename_pgx, "_row_")[[1]][2]), "dataset",], "' as:"),
               type = "input",
               showCancelButton = TRUE,
               callbackR = function(new_name) {
@@ -659,7 +661,8 @@ loading_table_datasets_server <- function(id,
     observeEvent(input$changedesc_pgx, {
       shinyalert::shinyalert(
         title = "Change description",
-        text = "Are you sure you want to change the description of your dataset?",
+        text = paste0("Are you sure you want to change the description of your dataset '",
+          getFilteredPGXINFO()[as.numeric(stringr::str_split(input$changedesc_pgx, "_row_")[[1]][2]), "dataset",], "'?"),
         showCancelButton = TRUE,
         cancelButtonText = "Cancel",
         confirmButtonText = "OK",
@@ -667,7 +670,8 @@ loading_table_datasets_server <- function(id,
           if (x) {
             shinyalert::shinyalert(
               title = "Enter new description",
-              text = "Please enter a new description for your dataset:",
+              text = paste0("Change the description of your dataset '",
+                getFilteredPGXINFO()[as.numeric(stringr::str_split(input$changedesc_pgx, "_row_")[[1]][2]), "dataset",], "' to:"),
               type = "input",
               showCancelButton = TRUE,
               callbackR = function(new_desc) {


### PR DESCRIPTION
From Murat suggestion, make text when changing the dataset name or description more clear:

- Name which dataset you are affecting

![image](https://github.com/user-attachments/assets/51b83cf5-d19c-4ab5-9b18-3919f8a1ec81)
![image](https://github.com/user-attachments/assets/b043ad69-86ba-42b1-a893-9235741275e4)
![image](https://github.com/user-attachments/assets/a04bc086-1b01-472e-8493-eee2cdd5f308)
![image](https://github.com/user-attachments/assets/6784d6dc-c36a-4462-bd5f-2ccc0346c2a5)
