### PR TITLE
fix: qc-bc with 2 samples

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -172,7 +172,7 @@ upload_module_normalization_server <- function(
           }
         }
         pos <- NULL
-        if (NCOL(X) > 1) {
+        if (NCOL(X) > 2) {
           pos <- irlba::irlba(X, nv = 2)$v
           rownames(pos) <- colnames(X)
         }
@@ -204,6 +204,7 @@ upload_module_normalization_server <- function(
             cx <- list(X = X1, impX1 = impX1)
           }
         } else {
+          shiny::req(nrow(samples) > 2)
           m <- input$bec_method
           mm <- unique(c("uncorrected", m))
           pars <- playbase::get_model_parameters(X1, samples, pheno = NULL, contrasts)
@@ -569,6 +570,7 @@ upload_module_normalization_server <- function(
 
       ## sample outlier scores
       plot_outliers <- function() {
+        shiny::validate(shiny::need(nrow(r_samples()) > 2, "Outlier detection requires at least 3 samples."))
         res <- results_outlier_methods()
         z0 <- as.numeric(input$outlier_threshold)
         zscore <- res$z.outlier
@@ -597,6 +599,7 @@ upload_module_normalization_server <- function(
       }
 
       plot_correction <- function() {
+        shiny::validate(shiny::need(nrow(r_samples()) > 2, "Batch-effect correction requires at least 3 samples."))
         if (input$batchcorrect) {
           plot_before_after()
         } else {
@@ -709,6 +712,9 @@ upload_module_normalization_server <- function(
           X <- r_counts()
           samples <- r_samples()
           contrasts <- r_contrasts()
+          if (nrow(samples) < 3) {
+            return(NULL)
+          }
           pars <- playbase::get_model_parameters(
             X,
             samples,


### PR DESCRIPTION
QC/BC was crashing with 2 samples dataset.

Bypass batch correction and outlier detection on such cases, as they make no sense to use on a 2 samples dataset.

![image](https://github.com/user-attachments/assets/bde1de11-8275-45b3-bdc8-c6d6b3c6dee0)
