### PR TITLE
Fix #1425: Compare signatures 2 errors

### DIFF
--- a/components/board.intersection/R/intersection_plot_scatterplot_pairs.R
+++ b/components/board.intersection/R/intersection_plot_scatterplot_pairs.R
@@ -79,6 +79,7 @@ intersection_scatterplot_pairs_server <- function(id,
       data <- plot_data()
       df <- data[[1]]
       sel.genes <- data[[2]]
+      shiny::req(sel.genes)
       ## resort selection so that selected genes are drawn last to avoid
       ## covering them up.
       is.sel <- (rownames(df) %in% sel.genes)

--- a/components/board.intersection/R/intersection_plot_table_venn_diagram.R
+++ b/components/board.intersection/R/intersection_plot_table_venn_diagram.R
@@ -98,6 +98,7 @@ intersection_plot_venn_diagram_server <- function(id,
     venndiagram.RENDER <- function() {
       data <- plot_data()
       dt1 <- data[[1]]
+      shiny::req(dt1)
       plot_names <- data[[2]]
 
       label <- colnames(dt1)


### PR DESCRIPTION
This closes #1425 

Seems that errors where caused by not properly requiring complete data.

Works fine locally now, also temporary error does not appear anymore.

![Screenshot from 2025-05-15 16-16-10](https://github.com/user-attachments/assets/770033c3-51f0-4f36-94aa-23af9feb1476)

