### PR TITLE
feat: remove npm if more than 100 samples

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -304,6 +304,10 @@ upload_module_normalization_server <- function(
         if (any(grepl("<none>", batch.pars))) batch.pars <- NULL
 
         methods <- c("ComBat", "limma", "RUV", "SVA", "NPM")
+        # Remove NPM if more than 100 samples
+        if (ncol(X0) > 100) {
+          methods <- methods[methods != "NPM"]
+        }
         xlist.init <- list("uncorrected" = X0, "normalized" = X1)
 
         shiny::withProgress(


### PR DESCRIPTION
Given AZ benchmarks, for the moment it is better to not offer NPM for more than 100 samples datasets.