### PR TITLE
Add message instead of error if samplefilters gives no samples

### DIFF
--- a/components/board.dataview/R/dataview_plot_abundance.R
+++ b/components/board.dataview/R/dataview_plot_abundance.R
@@ -31,15 +31,16 @@ dataview_plot_abundance_ui <- function(
 
 dataview_plot_abundance_server <- function(id,
                                            getCountsTable,
+                                           r.samples = reactive(""),
                                            watermark = FALSE) {
+
   moduleServer(id, function(input, output, session) {
-    ## extract data from pgx object
+
     plot_data <- shiny::reactive({
       res <- getCountsTable()
+      samples <- r.samples()
       shiny::req(res)
-      res <- list(
-        prop.counts = res$prop.counts
-      )
+      res <- list(prop.counts = res$prop.counts)
       res
     })
 

--- a/components/board.dataview/R/dataview_plot_boxplot.R
+++ b/components/board.dataview/R/dataview_plot_boxplot.R
@@ -25,23 +25,25 @@ dataview_plot_boxplot_ui <- function(
   )
 }
 
-dataview_plot_boxplot_server <- function(id, parent.input, getCountsTable, r.data_type, watermark = FALSE) {
+dataview_plot_boxplot_server <- function(id,
+                                         parent.input,
+                                         getCountsTable,
+                                         r.samples = reactive(""),
+                                         r.data_type,
+                                         watermark = FALSE) {
+
   moduleServer(id, function(input, output, session) {
-    ## extract data from pgx object
     plot_data <- shiny::reactive({
       res <- getCountsTable()
-      req(res)
-
-      list(
-        counts = res$log2counts,
-        sample = colnames(res$log2counts)
-      )
+      samples <- r.samples()
+      shiny::req(res)
+      list(counts = res$log2counts, sample = colnames(res$log2counts))
     })
 
     plot.RENDER <- function() {
       res <- plot_data()
       shiny::req(res)
-
+      
       par(mar = c(8, 4, 1, 2), mgp = c(2.2, 0.8, 0))
       ## ---- xlab ------ ###
       xaxt <- "l"
@@ -115,8 +117,6 @@ dataview_plot_boxplot_server <- function(id, parent.input, getCountsTable, r.dat
       func = plotly.RENDER,
       func2 = modal_plotly.RENDER,
       csvFunc = plot_data, ##  *** downloadable data as CSV
-
-
       res = c(90, 170), ## resolution of plots
       pdf.width = 6, pdf.height = 6,
       add.watermark = watermark

--- a/components/board.dataview/R/dataview_plot_genetypes.R
+++ b/components/board.dataview/R/dataview_plot_genetypes.R
@@ -29,11 +29,13 @@ dataview_plot_genetypes_ui <- function(
 
 dataview_plot_genetypes_server <- function(id,
                                            getCountsTable,
+                                           r.samples = reactive(""),
                                            watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     ## extract data from pgx object
     plot_data <- shiny::reactive({
       res <- getCountsTable()
+      samples <- r.samples()
       shiny::req(res)
       res <- list(
         prop.counts = res$prop.counts,

--- a/components/board.dataview/R/dataview_plot_histogram.R
+++ b/components/board.dataview/R/dataview_plot_histogram.R
@@ -27,8 +27,13 @@ dataview_plot_histogram_ui <- function(
   )
 }
 
-dataview_plot_histogram_server <- function(id, getCountsTable, watermark = FALSE) {
+dataview_plot_histogram_server <- function(id,
+                                           getCountsTable,
+                                           r.samples = reactive(""),
+                                           watermark = FALSE) {
+
   moduleServer(id, function(input, output, session) {
+
     .gx.histogram <- function(gx, n = 1000, main = "", ylim = NULL, plot = TRUE) {
       jj <- 1:nrow(gx)
       if (length(jj) > n) jj <- sample(jj, n, replace = TRUE)
@@ -57,12 +62,10 @@ dataview_plot_histogram_server <- function(id, getCountsTable, watermark = FALSE
     ## extract data from pgx object
     plot_data <- shiny::reactive({
       res <- getCountsTable()
+      samples <- r.samples()
       shiny::req(res)
       hh <- .gx.histogram(gx = res$log2counts, n = 2000, plot = FALSE)
-      pdata <- list(
-        histogram = hh,
-        log2counts = res$log2counts
-      )
+      pdata <- list(histogram = hh, log2counts = res$log2counts)
       pdata
     })
 

--- a/components/board.dataview/R/dataview_plot_totalcounts.R
+++ b/components/board.dataview/R/dataview_plot_totalcounts.R
@@ -17,10 +17,7 @@ dataview_plot_totalcounts_ui <- function(
     shiny::radioButtons(
       inputId = ns("sampleqc_plottype"),
       label = "Plot type",
-      choices = c(
-        "Total abundance",
-        "Number of detected features"
-      )
+      choices = c("Total abundance", "Number of detected features")
     )
   )
 
@@ -41,13 +38,16 @@ dataview_plot_totalcounts_ui <- function(
 dataview_plot_totalcounts_server <- function(id,
                                              getCountStatistics,
                                              r.data_type,
+                                             r.samples = reactive(""),
                                              r.data_groupby = reactive(""),
                                              watermark = FALSE) {
+
   moduleServer(id, function(input, output, session) {
+
     plot_data <- shiny::reactive({
       data_groupby <- r.data_groupby()
       data_type <- r.data_type()
-
+      samples <- r.samples()
       tbl <- getCountStatistics()
       req(tbl)
 
@@ -62,11 +62,6 @@ dataview_plot_totalcounts_server <- function(id,
       }
 
       sampleqc_plottype <- input$sampleqc_plottype
-
-      ## ylab <- paste0("total ", type, logtype)
-      ## if (data_groupby != "<ungrouped>") {
-      ##   ylab <- paste0("average total ", type, logtype)
-      ## }
 
       if (sampleqc_plottype == "Total abundance") {
         ylab <- paste0("Total ", type)

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -131,9 +131,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
               pgx$samples, input$data_samplefilter
             )
           },
-          error = function(w) {
-            NULL
-          }
+          error = function(w) { NULL }
         )
       }
       # validate samples
@@ -200,6 +198,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
     dataview_plot_totalcounts_server(
       "counts_total",
       getCountStatistics,
+      r.samples = selected_samples,
       r.data_type = reactive(input$data_type),
       watermark = WATERMARK
     )
@@ -208,6 +207,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
       "counts_boxplot",
       input,
       getCountStatistics,
+      r.samples = selected_samples,
       r.data_type = reactive(input$data_type),
       watermark = WATERMARK
     )
@@ -215,18 +215,21 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
     dataview_plot_histogram_server(
       "counts_histplot",
       getCountStatistics,
+      r.samples = selected_samples,
       watermark = WATERMARK
     )
 
     dataview_plot_abundance_server(
       "counts_abundance",
       getCountStatistics,
+      r.samples = selected_samples,
       watermark = WATERMARK
     )
 
     dataview_plot_genetypes_server(
       "counts_genetypes",
       getCountStatistics,
+      r.samples = selected_samples,
       watermark = WATERMARK
     )
 
@@ -275,15 +278,9 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
     ## ========================= FUNCTIONS ============================================
     ## ================================================================================
 
-    ##    getCountStatistics <- reactiveVal()
-    ##    observeEvent(
     getCountStatistics <- eventReactive(
       {
-        list(
-          pgx$X,
-          input$data_groupby,
-          input$data_samplefilter
-        )
+        list(pgx$X, input$data_groupby, input$data_samplefilter)
       },
       {
         shiny::req(pgx$X, pgx$Y, pgx$samples)
@@ -294,6 +291,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
         samples <- colnames(pgx$X)
         samples <- playbase::selectSamplesFromSelectedLevels(pgx$Y, input$data_samplefilter)
         nsamples <- length(samples)
+        if (nsamples == 0) return(NULL)
         counts <- pgx$counts[, samples, drop = FALSE]
 
         grpvar <- input$data_groupby


### PR DESCRIPTION
Data view >> SampleQC: If sample filters resulted in 0 samples, we had many errors:
![Screenshot from 2025-05-23 17-30-21](https://github.com/user-attachments/assets/ac5ebcbe-2431-456c-a98a-95a21d7b88bd)


Let's change as we usually do:
![Screenshot from 2025-05-23 17-11-46](https://github.com/user-attachments/assets/5e4da6cd-9a00-4498-8a86-889b80bb3835)
