### PR TITLE
Heatmap impX

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -338,6 +338,7 @@ clustering_plot_splitmap_server <- function(id,
         tooltips <- sapply(rownames(X), getInfo)
         labeled_features <- NULL
         rownames(X) <- playbase::probe2symbol(rownames(X), pgx$genes, labeltype(), fill_na = TRUE)
+        names(tooltips) <- rownames(X)
       } else {
         aa <- gsub("_", " ", rownames(X)) ## just geneset names
         tooltips <- sapply(aa, function(x) {

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -294,7 +294,11 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
         }
         jj <- match(toupper(gg), toupper(genes))
         pp <- rownames(pgx$X)[jj]
-        zx <- pgx$X[pp, , drop = FALSE]
+        if (is.null(pgx$impX)) {
+          zx <- pgx$X[pp, , drop = FALSE]
+        } else {
+          zx <- pgx$impX[pp, , drop = FALSE]
+        }
         if (!is.null(idx)) {
           idx <- idx[gg]
           names(idx) <- rownames(zx)


### PR DESCRIPTION
From stress test data.

- Fix NA issue by using impX when available
- Fixed the rownames on the tooltip, which prevented labels from appearing properly in some cases (e.g. on the stress test data).

## Before
![image](https://github.com/user-attachments/assets/6ae6597b-af68-4f30-a749-042415158d0d)

## Before (tooltip)
![image](https://github.com/user-attachments/assets/298f4f87-e809-4521-ba87-28aacbe69ec8)


## After

![image](https://github.com/user-attachments/assets/d5b6f36e-5a76-471d-96c1-79e67c179d3b)
![image](https://github.com/user-attachments/assets/751de612-37df-4861-a529-a97d980cbbae)
