### PR TITLE
fix: remove NAs

### DIFF
--- a/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
+++ b/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
@@ -108,7 +108,7 @@ singlecell_plot_crosstabPlot_server <- function(id,
       scores <- scores[, topsel]
 
       ## expected counts per stat level
-      kk.counts <- colSums(2**pgx$X[, kk, drop = FALSE]) ## approximate counts from log2X
+      kk.counts <- colSums(2**pgx$X[, kk, drop = FALSE], na.rm = TRUE) ## approximate counts from log2X
       grp.counts <- (t(scores / rowSums(scores)) %*% matrix(kk.counts, ncol = 1))[, 1]
 
       getProportionsTable <- function(pheno, is.gene = FALSE) {


### PR DESCRIPTION
From stress test data. Issue on single cell tab.

Related to having NA on the data, by setting na.rm=TRUE fixes

## Before
![image](https://github.com/user-attachments/assets/e7135776-50bc-4e26-a6e7-e24d5ad5b1fd)

## After
![image](https://github.com/user-attachments/assets/7dea9b25-5934-4510-aeed-c12ac2f194c8)
