### PR TITLE
fix: set NA to 0

### DIFF
--- a/components/board.pcsf/R/pcsf_panel_gene.R
+++ b/components/board.pcsf/R/pcsf_panel_gene.R
@@ -371,6 +371,7 @@ pcsf_genepanel_server <- function(id,
       i=1
       for(i in 1:ncol(F)) {
         fx <- F[,i]        
+        fx[is.na(fx)] <- 0 # NA no size no color
         playbase::plotPCSF(
           graph,
           plotlib = "igraph",

--- a/components/board.pcsf/R/pcsf_panel_geneset.R
+++ b/components/board.pcsf/R/pcsf_panel_geneset.R
@@ -348,6 +348,7 @@ pcsf_gsetpanel_server <- function(id,
       i=1
       for(i in 1:ncol(F)) {
         fx <- F[,i]
+        fx[is.na(fx)] <- 0 # NA no size no color
         playbase::plotPCSF(
           graph,
           sizeby = fx,


### PR DESCRIPTION
From stress test data

On `fx`, which is used to control size and color contains NAs; that errors. By setting them to 0 we actually "hide" them (as size 0 is not plotted) and avoid the error

## Before
![image](https://github.com/user-attachments/assets/d13ad209-e17f-497f-b6be-a34ec6467a9d)

## After
![image](https://github.com/user-attachments/assets/e892dfab-6788-433f-996b-6df24622f809)

### Future

Clearly this graph needs to be controlled when there are so many contrasts, I have not done it at the moment due to time contstraints.