### PR TITLE
feat: keep fc na genes + remove alpha sorting

### DIFF
--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -87,9 +87,8 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature"),
         # X should be labelled as features, so rownames(counts) and rownames(x) shoud match (???)
         features <- rownames(pgx$X)
         fc2 <- rowMeans(playbase::pgx.getMetaFoldChangeMatrix(pgx)$fc**2, na.rm = TRUE)
-        features <- intersect(names(sort(-fc2)), features) ## most var gene??
+        features <- intersect(names(sort(-fc2, na.last = TRUE)), features) ## most var gene??
         sel.feature <- features[1]
-        features <- sort(features)
         i <- match(sel.feature, features)
         features <- c(features[i], features[-i])
         if (length(features) > 1000) {


### PR DESCRIPTION
From client feedback

- Keep NAs when doing the sorting of `fc2`
- Remove the alphabetical sorting, after merging by most variable genes, makes no sense to sort back to alphabetical