### PR TITLE
fix: declar lato for pdf render on ggplot

### DIFF
--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -891,6 +891,8 @@ PlotModuleServer <- function(id,
                   htmlwidgets::saveWidget(p, HTMLFILE)
                   webshot2::webshot(url = HTMLFILE, file = PDFFILE, vwidth = pdf.width * 100, vheight = pdf.height * 100)
                 } else if (plotlib %in% c("ggplot", "ggplot2")) {
+                  sysfonts::font_add_google("lato")
+                  showtext::showtext_auto()
                   p <- func()
                   pdf(PDFFILE, width = pdf.width, height = pdf.height, pointsize = pdf.pointsize)
                   print(p)


### PR DESCRIPTION
Some ggplots (volcano for example) use lato font to match the platform.

However, when plotting it to pdf, it complains that the font is not available, so we have to manually add it for pdf to work fine.