### PR TITLE
feat: per-user data archive

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -199,6 +199,29 @@ LoadingBoard <- function(id,
       )
     }
 
+    shiny::observeEvent(auth, {
+      pgx_archive_dir <- file.path(auth$user_dir, "data_archive")
+      enable_archive_tabpanel <- dir.exists(pgx_archive_dir)
+
+      if (enable_archive_tabpanel) {
+        pgxtable_archive <- loading_table_datasets_public_server(
+          id = "pgxtable_archive",
+          pgx_public_dir = pgx_archive_dir,
+          reload_pgxdir_public = reload_pgxdir_public,
+          auth = auth,
+          reload_pgxdir = reload_pgxdir
+        )
+
+        loading_tsne_server(
+          id = "tsne_archive",
+          pgx.dir = reactive(pgx_archive_dir),
+          info.table = reactive(pgxtable_archive$data()),
+          r_selected = reactive(pgxtable_archive$rows_all()),
+          watermark = WATERMARK
+        )
+      }
+    })
+
     ## -----------------------------------------------------------------------------
     ## Description
     ## -----------------------------------------------------------------------------

--- a/components/board.loading/R/loading_table_datasets_public.R
+++ b/components/board.loading/R/loading_table_datasets_public.R
@@ -187,7 +187,7 @@ loading_table_datasets_public_server <- function(id,
       DT::datatable(
         df,
         class = "compact hover",
-        rownames = TRUE,
+        rownames = FALSE,
         editable = FALSE,
         extensions = c("Scroller"),
         plugins = "scrollResize",

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -119,6 +119,49 @@ LoadingUI <- function(id) {
     )
   ) ## end of Public tabPanel
 
+  archive_tabpanel <- shiny::tabPanel(
+    "Data archive",
+    bslib::layout_columns(
+      col_widths = 12,
+      height = "calc(100vh - 181px)",
+      bs_alert("This panel shows all <b>Archived datasets</b>. You can select a archived dataset and click <b>Import Dataset</b> to copy that dataset to your library for further analysis. The <b>Signature t-SNE</b> shows similarity clustering of fold-change signatures using t-SNE.", translate = FALSE, html = TRUE),
+      bslib::layout_columns(
+        col_widths = c(8, 4),
+        height = "calc(100vh - 181px)",
+        loading_table_datasets_public_ui(
+          ns("pgxtable_archive"),
+          title = "Archived datasets",
+          info.text = "This table shows available datasets within the platform that have been archived. For each dataset, it reports a brief description as well as the total number of samples, genes, gene sets (or pathways), corresponding phenotypes and the creation date.",
+          caption = "Table with archived datasets available in the platform.",
+          ##height = c("calc(100vh - 330px)", 700),
+          height = c("100%", 700),
+          width = c("100%", "100%")
+        ),
+        loading_tsne_ui(
+          ns("tsne_archive"),
+          title = "Signature t-SNE",
+          info.text = "Scatter plot displaying the t-SNE clustering of the available contrasts. Each dot corresponds to a specific comparison.",
+          info.methods = "t-SNE is a non-linear dimensionality reduction method that enables visualization of high-dimensional data in a low-dimensional space, typically 2D or 3D. Unlike linear dimensionality reduction techniques like PCA, t-SNE may separate data that is not linearly separable. Signatures/datasets that are clustered closer together, are more similar. Performed using the Rtsne R package [1].",
+          info.references = list(
+            list(
+              "Krijthe JH (2015). Rtsne: T-Distributed Stochastic Neighbor Embedding using Barnes-Hut Implementation. R package version 0.17",
+              "https://doi.org/10.32614/CRAN.package.Rtsne"
+            )
+          ),
+          info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#clustering",
+          caption = "Similarity clustering of fold-change signatures colored by data sets using t-SNE.",
+          ##height = c("calc(100vh - 330px)", 700),
+          height = c("100%", 700),
+          width = c("auto", "100%")
+        )
+      ) ## end of 7fr-5fr
+    ),
+    info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/data/#archived-datasets",
+    caption = "Table with archived datasets available in the platform.",
+    height = "calc(100vh - 181px)",
+    width = "100%"
+  )
+
   ## ------------------------------------------------------------------------
 
   ## disable/hide public tabpanel if public folder does not exists
@@ -134,7 +177,8 @@ LoadingUI <- function(id) {
     shiny::tabsetPanel(
       id = ns("tabs"),
       user_tabpanel,
-      public_tabpanel
+      public_tabpanel,
+      archive_tabpanel
     )
   )
 }

--- a/components/board.loading/R/loading_utils.R
+++ b/components/board.loading/R/loading_utils.R
@@ -111,3 +111,8 @@ get_cro_emails <- function() {
   }
   cro_emails
 }
+
+get_pgxs_in_folder <- function(folder) {
+  pgxs <- dir(folder, pattern = ".*\\.pgx$")
+  length(pgxs)
+}


### PR DESCRIPTION
Per-user data archive:

- Enabled *when* the user data directory has a folder named "data_archive". This is handy because it will also work on enterprise setting.
- Archive limit is hard set to 100 datasets. On the future this can be per-user option.
- When a user "archives" a dataset, it gets deleted from the active datasets folder. If dataset is already archived it is not over-written.
