### PR TITLE
Request #1492: option to disable labels in GSEA plot

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -29,6 +29,17 @@ enrichment_plot_top_enrich_gsets_ui <- function(
     width) {
   ns <- shiny::NS(id)
 
+  options <- shiny::tagList(
+    withTooltip(
+      shiny::checkboxInput(
+        ns("label_features"),
+        "Display labels on the plot",
+        TRUE
+      ),
+      "Display labels on the plot."
+    )
+  )
+
   PlotModuleUI(
     id = ns("plotmodule"),
     plotlib = "plotly",
@@ -41,6 +52,7 @@ enrichment_plot_top_enrich_gsets_ui <- function(
     info.extra_link = info.extra_link,
     height = height,
     width = width,
+    options = options,
     download.fmt = c("png", "pdf", "svg")
   )
 }
@@ -169,7 +181,7 @@ enrichment_plot_top_enrich_gsets_server <- function(id,
             xlab = "Rank in ordered dataset",
             ylab = "Rank metric",
             ticklen = 0.25,
-            yth = 1, ## threshold for which points get label
+            yth = ifelse(input$label_features, 1, 999), ## threshold for which points get label
             cbar.width = 32,
             tooltips = NULL,
             cex.text = cex.text,


### PR DESCRIPTION
This closes #1492 

Added selector (defaults to TRUE)

<img width="1156" height="648" alt="image" src="https://github.com/user-attachments/assets/86b724bc-69a1-449a-9496-e01f084c4b1d" />
<img width="1156" height="648" alt="image" src="https://github.com/user-attachments/assets/dbff2431-4c10-4d84-a857-fffba89d9a0d" />
