### PR TITLE
fix: align X/counts for old datasets

### DIFF
--- a/components/board.dataview/R/dataview_table_rawdata.R
+++ b/components/board.dataview/R/dataview_table_rawdata.R
@@ -63,7 +63,7 @@ dataview_table_rawdata_server <- function(id,
       }
 
       logx <- parse_sample(pgx$X)
-      if (data_type == "counts") {
+      if (data_scale == "counts") {
         # So old datasets work (they can be missaligned)
         jj <- which(rownames(pgx$X) %in% rownames(pgx$counts))
         dt <- pgx$counts[rownames(pgx$X)[jj], ]

--- a/components/board.dataview/R/dataview_table_rawdata.R
+++ b/components/board.dataview/R/dataview_table_rawdata.R
@@ -63,8 +63,12 @@ dataview_table_rawdata_server <- function(id,
       }
 
       logx <- parse_sample(pgx$X)
-      if (data_scale == "counts") {
-        x <- parse_sample(pgx$counts)
+      if (data_type == "counts") {
+        # So old datasets work (they can be missaligned)
+        jj <- which(rownames(pgx$X) %in% rownames(pgx$counts))
+        dt <- pgx$counts[rownames(pgx$X)[jj], ]
+        ##
+        x <- parse_sample(dt)
       } else {
         x <- logx
       }


### PR DESCRIPTION
old datasets can be missaligned on X/counts; this can cause problem when displaying the counts (on dataview), by forcefully aligning them, we should avoid that (error found on client dataset)