### PR TITLE
Fix #1508: compute fx.col later

### DIFF
--- a/components/board.expression/R/expression_table_genetable.R
+++ b/components/board.expression/R/expression_table_genetable.R
@@ -107,8 +107,6 @@ expression_table_genetable_server <- function(id,
 
       numeric.cols <- which(sapply(df, is.numeric))
       numeric.cols <- colnames(df)[numeric.cols]
-      fx.col <- grep("fc|fx|mean.diff|logfc|foldchange", tolower(colnames(df)))[1]
-      fx <- df[, fx.col]
       
       comp <- comp()
       samples <- colnames(pgx$counts)
@@ -119,6 +117,8 @@ expression_table_genetable_server <- function(id,
       jj <- which(!colnames(df) %in% c("symbol", "pct.missingness"))
       cl <- c("symbol", "pct.missingness", colnames(df)[jj]) 
       df <- df[, cl, drop = FALSE]
+      fx.col <- grep("fc|fx|mean.diff|logfc|foldchange", tolower(colnames(df)))[1]
+      fx <- df[, fx.col]
       
       DT::datatable(
         df,


### PR DESCRIPTION
This closes #1508 

Compute fx.col later, otherwise with the columns added it is wrong.

<img width="3148" height="2096" alt="image" src="https://github.com/user-attachments/assets/69c37ae2-b924-4431-80c0-883140433aed" />
