### PR TITLE
Comment out 'ngenes' options. Was there for a while. Not used. 

### DIFF
--- a/components/board.mofa/R/__init.R
+++ b/components/board.mofa/R/__init.R
@@ -14,114 +14,58 @@ MODULE.multiomics <- list(
 
   module_ui = function() {
     list(
-      bigdash::bigTabItem(   ## call this in app.R??
-        "mofa-tab",
-        MofaInputs("mofa"),
-        create_loader("mofa-loader")
-      ),
-      bigdash::bigTabItem(
-        "mgsea-tab",
-        MGseaInputs("mgsea"),
-        create_loader("mgsea-loader")
-      ),
-      bigdash::bigTabItem(
-        "snf-tab",
-        SNFInputs("snf"),
-        create_loader("snf-loader")
-      ),
-      bigdash::bigTabItem(
-        "lasagna-tab",
-        LasagnaInputs("lasagna"),
-        create_loader("lasagna-loader")
-      ),
-      bigdash::bigTabItem(
-        "deepnet-tab",
-        DeepNetInputs("deepnet"),
-        create_loader("deepnet-loader")
-      )
+      bigdash::bigTabItem("mofa-tab", MofaInputs("mofa"), create_loader("mofa-loader")),
+      bigdash::bigTabItem("mgsea-tab", MGseaInputs("mgsea"), create_loader("mgsea-loader")),
+      bigdash::bigTabItem("snf-tab", SNFInputs("snf"), create_loader("snf-loader")),
+      bigdash::bigTabItem("lasagna-tab", LasagnaInputs("lasagna"), create_loader("lasagna-loader")),
+      bigdash::bigTabItem("deepnet-tab", DeepNetInputs("deepnet"), create_loader("deepnet-loader"))
     )
   },
   module_ui2 = function() {
     list(
-      list(   ## call this in app.R??
-        "mofa-tab",
-        MofaUI("mofa")
-      ),
-      list(
-        "mgsea-tab",
-        MGseaUI("mgsea")
-      ),
-      list(
-        "snf-tab",
-        SNFUI("snf")
-      ),
-      list(
-        "lasagna-tab",
-        LasagnaUI("lasagna")
-      ),
-      list(
-        "deepnet-tab",
-        DeepNetUI("deepnet")
-      )
+      list("mofa-tab", MofaUI("mofa")),
+      list("mgsea-tab", MGseaUI("mgsea")),
+      list("snf-tab", SNFUI("snf")),
+      list("lasagna-tab", LasagnaUI("lasagna")),
+      list("deepnet-tab", DeepNetUI("deepnet"))
     )
   },
+
   module_server = function(PGX) {
     info("[SERVER] calling MofaBoard module")
-    MofaBoard("mofa", pgx = PGX
-    )
+    MofaBoard("mofa", pgx = PGX)
 
     info("[SERVER] calling MGseaBoard module")
-    MGseaBoard("mgsea", pgx = PGX
-    )
+    MGseaBoard("mgsea", pgx = PGX)
           
     info("[SERVER] calling SNFBoard module")
-    SNFBoard("snf", pgx = PGX
-    )
+    SNFBoard("snf", pgx = PGX)
 
     info("[SERVER] calling LasagnaBoard module")
-    LasagnaBoard("lasagna", pgx = PGX
-    )
+    LasagnaBoard("lasagna", pgx = PGX)
 
     info("[SERVER] calling DeepNetBoard module")
-    DeepNetBoard("deepnet", pgx = PGX
-    )
+    DeepNetBoard("deepnet", pgx = PGX)
   },
 
   module_help = function() {
     list(
-      bigdash::sidebarTabHelp(  ## call this function in app.R?
-        "mofa-tab",
-        "MOFA",
+      bigdash::sidebarTabHelp("mofa-tab", "MOFA",
         tspan("Multi-omics Factor Analysis (MOFA) is a multi-omics
-                  integration method based on matrix factorization.")
-      ),
-      bigdash::sidebarTabHelp(
-        "mgsea-tab",
-        "multiGSEA",
-        tspan("multiGSEA performs multi-omics integration on gene set level.")
-      ),
-      bigdash::sidebarTabHelp(
-        "snf-tab",
-        "SNF",
-        tspan("SNF clustering")
-      ),
-      bigdash::sidebarTabHelp(
-        "lasagna-tab",
-        "Lasagna",
-        tspan("LASAGNA is a stacked layer model for multi-omics integration where each layer corresponds to a datatype.")
-      ),
-      bigdash::sidebarTabHelp(
-        "deepnet-tab",
-        "DeepLearning",
-        tspan("Integration using DeepLearning")
-      )
-      ## bigdash::sidebarTabHelp(
-      ##   "mpcsf-tab",
-      ##   "multiPCSF",
-      ##   tspan("Perfom multiPCSF analysis")
-      ## )
+                  integration method based on matrix factorization.")),
+
+      bigdash::sidebarTabHelp("mgsea-tab", "multiGSEA",
+        tspan("multiGSEA performs multi-omics integration on gene set level.")),
+
+      bigdash::sidebarTabHelp("snf-tab", "SNF",
+        tspan("SNF clustering")),
+
+      bigdash::sidebarTabHelp("lasagna-tab", "Lasagna",
+        tspan("LASAGNA is a stacked layer model for multi-omics integration where each layer corresponds to a datatype.")),
+      
+      bigdash::sidebarTabHelp("deepnet-tab", "DeepLearning",
+        tspan("Integration using DeepLearning"))
     )
-  }
-  
+  }  
   
 )

--- a/components/board.mofa/R/board_snf_ui.R
+++ b/components/board.mofa/R/board_snf_ui.R
@@ -6,20 +6,19 @@
 SNFInputs <- function(id) {
   ns <- shiny::NS(id) ## namespace
   bigdash::tabSettings(
-    ## data set parameters
     bslib::accordion(
       id = ns("data_type_accordion"),
-      open = FALSE,
-      bslib::accordion_panel(
-        "Options",
-        icon = icon("cog", lib = "glyphicon"),
-        shiny::tagList(
-          shiny::selectInput(ns("ngenes"), tspan("Number genes:"),
-            choices = c(500, 1000, 2000, 4000, 8000),
-            selected = 1000
-          )
-        )
-      )
+      open = FALSE
+      ## bslib::accordion_panel(
+      ##   "Options",
+      ##   icon = icon("cog", lib = "glyphicon"),
+      ##   shiny::tagList(
+      ##     shiny::selectInput(ns("ngenes"), tspan("Number genes:"),
+      ##       choices = c(500, 1000, 2000, 4000, 8000),
+      ##       selected = 1000
+      ##     )
+      ##   )
+      ## )
     )
   )
 }
@@ -36,7 +35,6 @@ SNFUI <- function(id) {
     shiny::tabsetPanel(
       id = ns("tabs"),
 
-      ##----------------------------------------------------------------
       shiny::tabPanel(
         "SNF Clustering",
         bslib::layout_columns(
@@ -67,7 +65,6 @@ SNFUI <- function(id) {
                 info.text = "Clustering of SNF-integrated multi-omics data. Heatmap of normalized multi-omics data. The SNF clusters capture multi-omic features exhibiting similar behavior. Therefore, the heatmap is well versed to enable assessment of samples' clustering driven by multiple data types/modalities.",
                 info.methods = "Heatmap of normalized multi-omics data. Pearson correlation is used as similarity measure. The clustering and number of clusters was determined using the Louvain method.",
                 info.references = list(list("Wang B, Mezlini A, Demir F, Fiume M, Zu T, Brudno M, Haibe-Kains B, Goldenberg A (2014). “Similarity Network Fusion: a fast and effective method to aggregate multiple data types on a genome wide scale.” Nature Methods.", "https://www.nature.com/articles/nmeth.2810")),
-                ##caption = "Clustering of SNF-integrated multi-omics data. Heatmap of normalized multi-omics data. Samples' clustering is driven by Similarity Network Fusion (SNF) method. Euclidean distance is used as similarity measure.",
                 height = c("100%", TABLE_HEIGHT_MODAL),
                 width = c("auto", "100%")
               ),

--- a/components/board.mofa/R/plot_snf_graph.R
+++ b/components/board.mofa/R/plot_snf_graph.R
@@ -6,19 +6,13 @@
 mofa_plot_snfgraph_ui <- function(
     id,
     ...
-    ## title = "",
-    ## info.methods = "",
-    ## info.text = "",
-    ## caption = "",
-    ## label = "",
-    ## height = 400,
-    ## width = 400
     ) {
   ns <- shiny::NS(id)
 
   options <- tagList(
     shiny::selectInput(
-      ns("labeltype"), "Label type",
+      ns("labeltype"),
+      "Label type",
       choices = "none"
     ),
     shiny::sliderInput(ns("minrho"),"Edge threshold:",0,1,0.5,0.05)
@@ -28,13 +22,6 @@ mofa_plot_snfgraph_ui <- function(
     ns("plot"),
     options = options,
     download.fmt = c("png", "pdf", "svg"),
-    ## title = title,
-    ## label = label,
-    ## info.text = info.text,
-    ## info.methods = info.methods,
-    ## caption = caption,
-    ## height = height,
-    ## width = width
     ...
   )
 }
@@ -42,17 +29,17 @@ mofa_plot_snfgraph_ui <- function(
 mofa_plot_snfgraph_server <- function(id,
                                       mofa,
                                       watermark = FALSE) {
-  moduleServer(id, function(input, output, session) {
 
+  moduleServer(id, function(input, output, session) {
     
     observeEvent( mofa()$snf, {
       res <- mofa()
-      labeltypes <- c("<none>","<cluster>","<sample_id>",
-                      colnames(res$samples))      
+      labeltypes <- c("<none>","<cluster>","<sample_id>", colnames(res$samples))      
       shiny::updateSelectInput(
-        session, "labeltype", choices = labeltypes,
-        selected="<sample_id>" )
-                               
+        session, "labeltype",
+        choices = labeltypes,
+        selected="<sample_id>"
+      )
     })
     
     plot.RENDER <- function() {
@@ -62,27 +49,19 @@ mofa_plot_snfgraph_server <- function(id,
       shiny::req(input$labeltype)
       labeltype <- input$labeltype
       label <- NULL
-      if(labeltype == "<none>") {
-        label <- rep(" ", nrow(res$samples))
-      }
-      if(labeltype == "<cluster>") {
-        label <- snf$cluster
-      }
-      if(labeltype == "<sample_id>") {
-        label <- rownames(res$samples)
-      }
-      if(labeltype %in% colnames(res$samples)) {
-        label <- res$samples[,labeltype]
-      }
-
+      if(labeltype == "<none>") label <- rep(" ", nrow(res$samples))
+      if(labeltype == "<cluster>") label <- snf$cluster      
+      if(labeltype == "<sample_id>") label <- rownames(res$samples)
+      if(labeltype %in% colnames(res$samples)) label <- res$samples[,labeltype]
+      
       playbase::snf.plot_graph(
         snf,
         min.rho = input$minrho,
         q.edge = 0.01,
         vlabcex = 0.9, 
         plot = TRUE,
-        label = label)         
-      
+        label = label
+      )
     }
 
     PlotModuleServer(
@@ -92,7 +71,6 @@ mofa_plot_snfgraph_server <- function(id,
       res = c(80, 100),
       add.watermark = watermark
     )
-
     
   })
 }


### PR DESCRIPTION
Comment out 'ngenes' options. Was there for a while but unused. This also simplifies. Also polished code a bit, shortened unnecessarily numerous lines.