### PR TITLE
fix: maintain datatype on recompute

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -698,7 +698,9 @@ UploadBoard <- function(id,
 
     observeEvent(recompute_pgx(), {
       req(!is.null(recompute_pgx()))
-      upload_datatype(recompute_pgx()$datatype)
+      if (!is.null(recompute_pgx()$datatype) && recompute_pgx()$datatype != "") {
+        upload_datatype(recompute_pgx()$datatype)
+      }
       bigdash.selectTab(session, selected = "upload-tab")
       shinyjs::delay(250, {
         new_upload(new_upload() + 1)

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -698,6 +698,7 @@ UploadBoard <- function(id,
 
     observeEvent(recompute_pgx(), {
       req(!is.null(recompute_pgx()))
+      upload_datatype(recompute_pgx()$datatype)
       bigdash.selectTab(session, selected = "upload-tab")
       shinyjs::delay(250, {
         new_upload(new_upload() + 1)


### PR DESCRIPTION
Data type was not maintained when recomputing a dataset; e.g. recomputing a proteomics dataset showed rna-seq upload (with rna-seq options/defaults) and then the recomputed dataset was rna-seq.

 This PR fixes it.