### PR TITLE
style: aspect ratio on editor hidden if not selected

### DIFF
--- a/components/ui/ui-EditorContent.R
+++ b/components/ui/ui-EditorContent.R
@@ -53,8 +53,12 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
 
           bslib::accordion_panel(
             "Aspect Ratio",
-            checkboxInput(ns_parent("aspect_ratio_checkbox"), "Custom Aspect Ratio", value = FALSE),
-            numericInput(ns_parent("aspect_ratio"), "Aspect Ratio", value = 0.5, min = 0.1, max = 10)
+            checkboxInput(ns_parent("aspect_ratio_checkbox"), "Custom aspect ratio", value = FALSE),
+            conditionalPanel(
+              condition = "input.aspect_ratio_checkbox",
+              numericInput(ns_parent("aspect_ratio"), NULL, value = 0.5, min = 0.1, max = 10),
+              ns = ns_parent
+            )
           ),
 
           # Additional Settings


### PR DESCRIPTION
Closes #1518 

<img width="1472" height="1194" alt="image" src="https://github.com/user-attachments/assets/e4332bb9-11b5-48c4-824a-2ae414aa7833" />

<img width="1472" height="1194" alt="image" src="https://github.com/user-attachments/assets/6eeefa4c-0817-4016-8c72-ef388ed693a3" />
