### PR TITLE
Enable Olink NPX

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -250,7 +250,7 @@ upload_module_normalization_server <- function(
           out <- playbase::detectOutlierSamples(X, plot = FALSE)
 
           scaledX <- playbase::double_center_scale_fast(X)
-          corX <- cor(t(scaledX))
+          corX <- HiClimR::fastCor(t(scaledX), optBLAS = TRUE)
 
           ## standard dim reduction methods
           pos <- list()

--- a/components/board.upload/R/upload_ui.R
+++ b/components/board.upload/R/upload_ui.R
@@ -32,9 +32,9 @@ UploadUI <- function(id) {
             ),
             selected = DEFAULTS$datatype,
             width = "400px"
-          )
+          ),
+          shiny::uiOutput(ns("proteomics_subtype_ui"))
         ),
-        ## shiny::uiOutput(ns("probe_type_ui")),
         div(
           p("Organism:", style = "text-align: left; margin: 0 0 2px 0; font-weight: bold;"),
           shiny::selectInput(


### PR DESCRIPTION
Enhancement: enable upload and analysis of Olink NPX proteomics data. Attempted to achieve this by minimum code changes. Needs https://github.com/bigomics/playbase/pull/293

If proteomics datatype is selected, a dropdown menu will ask selection of MS vs Olink.
<img width="579" height="468" alt="image" src="https://github.com/user-attachments/assets/e56bb4c0-635d-4e6d-86db-55ef16ab70ec" />

This very first PR allows upload of Olink NPX data format that strictly conform with the Olink standard format (validated by OlinkAnalyze R package). We could allow more flexibility afterwards.

No need to upload samples.csv. This PR includes automatic detection of Olink NPX format and generation of samples metadata from there. We could allow more flexibility afterwards.

If Olink NPX is detected, normalization is set to FALSE (NPX are log2 and normalized). Will be up to user to re-change that.