### PR TITLE
fix: handle multiple genes with same symbol

### DIFF
--- a/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
+++ b/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
@@ -118,6 +118,10 @@ singlecell_plot_crosstabPlot_server <- function(id,
           X <- playbase::rename_by(pgx$X, pgx$genes, "symbol")
           pheno <- pgx$genes[pheno, ]$symbol
           gx <- X[which(xgene == pheno), kk, drop = FALSE]
+          # Handle case where multiple genes have same symbol, happens easily on weird species
+          if (nrow(gx) > 1) {
+            gx <- colMeans(gx, na.rm = TRUE)
+          }
           gx.highTH <- mean(gx, na.rm = TRUE)
           y <- paste(pheno, c("low", "high"))[1 + 1 * (gx >= gx.highTH)]
           table(y)


### PR DESCRIPTION
Issue from customer dataset (salmon):

on 

```
gx <- X[which(xgene == pheno), kk, drop = FALSE]
```

we assume that this will yield a 1 row table, which in alternative species (non human/mouse) is not always the case, by `colMean` `gx` in the case it has more than one row we solve the issue

### Before
<img width="1106" height="1454" alt="image" src="https://github.com/user-attachments/assets/4899be4c-c7c0-4e5e-8243-42a3ddb7c5bc" />

### After
<img width="1106" height="1454" alt="image" src="https://github.com/user-attachments/assets/6038f17e-4f09-474f-b264-532a9ffd3090" />

