### PR TITLE
Fix dupgene heatmap (issue #1523 and #1524)

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -338,18 +338,19 @@ clustering_plot_splitmap_server <- function(id,
         }
         tooltips <- sapply(rownames(X), getInfo)
         labeled_features <- NULL
-        symbol <- playbase::probe2symbol(rownames(X), pgx$genes, labeltype(), fill_na = TRUE)
-        rownames(X) <- playbase::make_unique(symbol)
-        names(tooltips) <- rownames(X)
+        symbol <- playbase::probe2symbol(rownames(X), pgx$genes, labeltype(), fill_na=TRUE)
+        rownames(X) <- symbol 
       } else {
         aa <- gsub("_", " ", rownames(X)) ## just geneset names
         tooltips <- sapply(aa, function(x) {
           playbase::breakstring2(x, 50, brk = "<br>")
         })
-        names(tooltips) <- rownames(X)
       }
       shiny::showNotification("Rendering iHeatmap...")
 
+      #rownames(X) <- playbase::make_unique(rownames(X))  ## important
+      #names(tooltips) <- rownames(X)
+      
       if (sample_cor) idx = NULL else idx = splity
       plt <- playbase::pgx.splitHeatmapFromMatrix(
         X = X,

--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -330,14 +330,16 @@ clustering_plot_splitmap_server <- function(id,
       if (hm_level() == "gene") {
         getInfo <- function(g) {
           aa <- paste0(
-            "<b>", pgx$genes[g, "gene_name"], "</b>. ",
+            "<b>", pgx$genes[g, "feature"], "</b> ",
+            "(", pgx$genes[g, "symbol"], "): ",
             pgx$genes[g, "gene_title"], "."
           )
           playbase::breakstring2(aa, 50, brk = "<br>")
         }
         tooltips <- sapply(rownames(X), getInfo)
         labeled_features <- NULL
-        rownames(X) <- playbase::probe2symbol(rownames(X), pgx$genes, labeltype(), fill_na = TRUE)
+        symbol <- playbase::probe2symbol(rownames(X), pgx$genes, labeltype(), fill_na = TRUE)
+        rownames(X) <- playbase::make_unique(symbol)
         names(tooltips) <- rownames(X)
       } else {
         aa <- gsub("_", " ", rownames(X)) ## just geneset names

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -228,23 +228,21 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         } else if (ft %in% names(pgx$families)) {
           pp <- playbase::map_probes( pgx$genes, pgx$families[[ft]])
         } else if (ft == "<custom>" && ft != "") {
-          message("[getFilteredMatrix] selecting for <custom> features")
           customfeatures <- input$hm_customfeatures
           gg1 <- strsplit(customfeatures, split = "[, ;\n\t]")[[1]]
-          is.regx <- grepl("[*.?\\[]", gg1[1])
-          if (length(gg1) == 1 && is.regx) {
+          is.regex <- grepl("[*?\\[]", gg1[1])
+          if (length(gg1) == 1 && is.regex) {
             gg1 <- grep(gg1, genes, ignore.case = TRUE, value = TRUE)
           }
           # heatmap does not like single gene
           shiny::validate(shiny::need(
-            length(gg1) > 1 && !is.regx,
+            length(gg1) > 1 && !is.regex,
             tspan("Please input more than 1 gene.", js = FALSE)
           ))
           
           ## build index idx that determines groups/cluster of genes. 
           idx <- NULL
           if (any(grepl("^---", gg1))) {
-            message("[getFilteredMatrix] <custom> groups detected")
             idx <- list()
             kk <- c(1, grep("^---", gg1), length(gg1) + 1)
             i=1
@@ -441,7 +439,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         topmode <- "sd"
       }
       if(splitby == "contrast") {
-        topmode <- "marker"
+        # topmode <- "marker"  ## really?
       }
 
       addsplitgene <- function(gg) {


### PR DESCRIPTION
Fix for issue #1523 and #1524
- Update playbase to handle duplicated names (add make_unique_ws, hc.order on index)
- Handle 'dot' in names (as in ensembl) not as regex. Now (ensemble) features can be used for selecting custom genes.