### PR TITLE
add full/compact y-axis option for GSEA plot (fix for #1526)

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -42,7 +42,7 @@ enrichment_plot_top_enrich_gsets_ui <- function(
       shiny::checkboxInput(
         ns("full_yaxis"),
         "Show full y-axis",
-        TRUE
+        FALSE
       ),
       "Show full range on y-axis"
     )

--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -37,6 +37,14 @@ enrichment_plot_top_enrich_gsets_ui <- function(
         TRUE
       ),
       "Display labels on the plot."
+    ),
+    withTooltip(
+      shiny::checkboxInput(
+        ns("full_yaxis"),
+        "Show full y-axis",
+        TRUE
+      ),
+      "Show full range on y-axis"
     )
   )
 
@@ -181,7 +189,8 @@ enrichment_plot_top_enrich_gsets_server <- function(id,
             xlab = "Rank in ordered dataset",
             ylab = "Rank metric",
             ticklen = 0.25,
-            yth = ifelse(input$label_features, 1, 999), ## threshold for which points get label
+            yth = ifelse(input$label_features, 0.1, 999), ## threshold for which points get label
+            yq = ifelse(input$full_yaxis, 0, 0.01),  ## limits for y-range
             cbar.width = 32,
             tooltips = NULL,
             cex.text = cex.text,


### PR DESCRIPTION
Fix for issue #1526

- add full/compact y-axis option for GSEA plot. See screenshots.
- Also lowered label threshold 1 -> 0.10


<img width="1214" height="664" alt="image" src="https://github.com/user-attachments/assets/0ec83f3e-235d-40a0-92ce-1a4d0b1655ef" />
<img width="1214" height="664" alt="image" src="https://github.com/user-attachments/assets/eccef422-7335-4705-a2af-248e0ba5b5d5" />
