### PR TITLE
Rework heatmap and heatmap editor

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -35,6 +35,7 @@ clustering_plot_splitmap_ui <- function(
       ),
       "Show gene-sample heatmap or sample-sample correlation plot."
     ),
+    shiny::hr(),
     withTooltip(
       shiny::radioButtons(
         ns("hm_scale"), "Row scaling:",
@@ -44,6 +45,7 @@ clustering_plot_splitmap_ui <- function(
       "Show relative (i.e. mean-centered), absolute expression values or batch-mean-centered.",
       placement = "right", options = list(container = "body")
     ),
+    shiny::hr(),    
     withTooltip(
       shiny::checkboxInput(
         ns("show_legend"), "show legend",
@@ -54,7 +56,13 @@ clustering_plot_splitmap_ui <- function(
       shiny::checkboxInput(
         ns("show_rownames"), "show row names",
         value = TRUE
-      ), "Show or hide the rownames (features)."
+      ), "Show or hide the row names (features)."
+    ),    
+    withTooltip(
+      shiny::checkboxInput(
+        ns("show_colnames"), "show column names",
+        value = TRUE
+      ), "Show or hide the column names (samples)."
     )    
   )
 

--- a/components/ui/ui-EditorContent.R
+++ b/components/ui/ui-EditorContent.R
@@ -4,6 +4,7 @@
 ##
 
 getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards = FALSE, outputFunc = NULL, width.2 = NULL, height.2 = NULL) {
+
   # Default editor content
   volcano_content <- shiny::div(
     class = "popup-modal",
@@ -45,10 +46,14 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
           bslib::accordion_panel(
             "Margins",
             checkboxInput(ns_parent("margin_checkbox"), "Custom Margins", value = FALSE),
-            numericInput(ns_parent("margin_left"), "Left", value = 10),
-            numericInput(ns_parent("margin_right"), "Right", value = 10),
-            numericInput(ns_parent("margin_top"), "Top", value = 10),
-            numericInput(ns_parent("margin_bottom"), "Bottom", value = 10)
+            conditionalPanel(
+              condition = "input.margin_checkbox==true",
+              ns = ns_parent,
+              numericInput(ns_parent("margin_left"), "Left", value = 10),
+              numericInput(ns_parent("margin_right"), "Right", value = 10),
+              numericInput(ns_parent("margin_top"), "Top", value = 10),
+              numericInput(ns_parent("margin_bottom"), "Bottom", value = 10)
+            )
           ),
 
           bslib::accordion_panel(
@@ -100,31 +105,31 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
             "General",
             shiny::checkboxInput(
               ns_parent("show_legend"),
-              "Show Legend",
+              "Show legend",
               value = TRUE
             ),
             shiny::checkboxInput(
               ns_parent("show_colnames"),
-              "Show Column Names",
+              "Show column names",
               value = TRUE
             ),
             shiny::numericInput(
               ns_parent("column_names_rot"),
-              "Column Names Rotation",
+              "Column names rotation",
               value = 45,
               min = 0,
               max = 90
             ),
-            shiny::numericInput(
-              ns_parent("num_rownames"),
-              "Max Number of Row Names",
-              value = 50,
-              min = 0,
-              max = 1000
-            ),
+            ## shiny::numericInput(
+            ##   ns_parent("num_rownames"),
+            ##   "Max number of row names",
+            ##   value = 50,
+            ##   min = 0,
+            ##   max = 1000
+            ## ),
             shiny::numericInput(
               ns_parent("rownames_width"),
-              "Row Names Width",
+              "Row names width",
               value = 40,
               min = 10,
               max = 200
@@ -140,14 +145,14 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
             )
           ),
           # Clustering Options
-          bslib::accordion_panel(
-            "Dendograms",
-            bslib::layout_column_wrap(
-              width = 1/2,
-              checkboxInput(ns_parent("cluster_rows"), "Rows", value = TRUE),
-              checkboxInput(ns_parent("cluster_cols"), "Columns", value = TRUE)
-            )
-          ),
+          ## bslib::accordion_panel(
+          ##   "Dendograms",
+          ##   bslib::layout_column_wrap(
+          ##     width = 1/2,
+          ##     checkboxInput(ns_parent("cluster_rows"), "Rows", value = TRUE),
+          ##     checkboxInput(ns_parent("cluster_cols"), "Columns", value = TRUE)
+          ##   )
+          ## ),
           # Color Scheme
           bslib::accordion_panel(
             "Color Scheme",
@@ -170,11 +175,15 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
           # Margins
           bslib::accordion_panel(
             "Margins",
-            checkboxInput(ns_parent("margin_checkbox"), "Custom Margins", value = FALSE),
-            numericInput(ns_parent("margin_left"), "Left", value = 10),
-            numericInput(ns_parent("margin_right"), "Right", value = 10),
-            numericInput(ns_parent("margin_top"), "Top", value = 10),
-            numericInput(ns_parent("margin_bottom"), "Bottom", value = 10)
+            checkboxInput(ns_parent("margin_checkbox"), "Custom margins", value = FALSE),
+            conditionalPanel(
+              condition = "input.margin_checkbox==true",
+              ns = ns_parent,
+              numericInput(ns_parent("margin_left"), "Left", value = 10),
+              numericInput(ns_parent("margin_right"), "Right", value = 10),
+              numericInput(ns_parent("margin_top"), "Top", value = 10),
+              numericInput(ns_parent("margin_bottom"), "Bottom", value = 10)
+            )
           )
         ),
         shiny::div(

--- a/components/ui/ui-EditorContent.R
+++ b/components/ui/ui-EditorContent.R
@@ -101,17 +101,26 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
         bslib::accordion(
           id = ns("plot_options_accordion"),
           # Basic Options
+          ## bslib::accordion_panel(
+          ##   "General",
+          ##   shiny::checkboxInput(
+          ##     ns_parent("show_legend"),
+          ##     "Show legend",
+          ##     value = TRUE
+          ##   ),
+          ##   shiny::checkboxInput(
+          ##     ns_parent("show_colnames"),
+          ##     "Show column names",
+          ##     value = TRUE
+          ##   ),
+          ## ),
+          # Text Sizes
           bslib::accordion_panel(
-            "General",
-            shiny::checkboxInput(
-              ns_parent("show_legend"),
-              "Show legend",
-              value = TRUE
-            ),
-            shiny::checkboxInput(
-              ns_parent("show_colnames"),
-              "Show column names",
-              value = TRUE
+            "Labels",
+            bslib::layout_column_wrap(
+              width = 1/2,
+              numericInput(ns_parent("label_size"), "Label size:", value = 10),
+              numericInput(ns_parent("annot_cex"), "Annotation size:", value = 12)
             ),
             shiny::numericInput(
               ns_parent("column_names_rot"),
@@ -133,16 +142,7 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
               value = 40,
               min = 10,
               max = 200
-            )
-          ),
-          # Text Sizes
-          bslib::accordion_panel(
-            "Text Sizes",
-            bslib::layout_column_wrap(
-              width = 1/2,
-              numericInput(ns_parent("label_size"), "Labels", value = 8),
-              numericInput(ns_parent("annot_cex"), "Annotation", value = 10)
-            )
+            )            
           ),
           # Clustering Options
           ## bslib::accordion_panel(


### PR DESCRIPTION
Rework of heatmap and editor:
- Labels were not seen if user selects (or inputs) more than 50 genes (this was noted by AZ@irb). Instead of auto-hiding, replaced with explicit show_rownames option.
- input$num_rownames and input$hm_ntop are confusing. Removing num_rownames.
- Dendrogram checkbox do nothing (in Editor);
- show_legend duplicated in hamburger and editor. Remove from Editor. 

NOTE1:  Editor does not work for dynamic heatmap (plotly)? 
NOTE2:  If permanent, commented out code in ui-EditorContent.R can be removed
NOTE3:  we need some rules of what to put in editor and what in the hamburger menu. 
NOTE4:  previously there was a choice option dynamic/static in the zoomed plot. It does not appear in most cases on my browser. Please check.