### PR TITLE
Control MultiOmics

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -184,7 +184,8 @@ opt.default <- list(
   WATERMARK = TRUE,
   APACHE_COOKIE_PATH = OPG,
   ALLOW_CUSTOM_FC = FALSE,
-  DEVMODE = FALSE
+  DEVMODE = FALSE,
+  ENABLE_MULTIOMICS = FALSE
 )
 
 opt.file <- file.path(ETC, "OPTIONS")

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -506,6 +506,9 @@ loading_table_datasets_server <- function(id,
       if (!is.null(cro_emails)) {
         datasets_exceed_limits[df$creator %in% cro_emails] <- FALSE
       }
+      if (!auth$options$ENABLE_MULTIOMICS) { #multi-omics disabled, grey them out
+        datasets_exceed_limits <- datasets_exceed_limits | (df$datatype == "multi-omics")
+      }
 
       selectable_rows <- which(seq_len(nrow(df)) <= df_cap & !datasets_exceed_limits)
       if (length(selectable_rows) == 0) selectable_rows <- NULL

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -100,6 +100,12 @@ UploadBoard <- function(id,
       names(all_species) <- paste0(all_species," (",common_name,")")
       names(all_species)[all_species=="No organism"] <- "<custom organism>"
       shiny::updateSelectizeInput(session, "selected_organism", choices = all_species, server = TRUE)
+
+      if (opt$ENABLE_MULTIOMICS) {
+        shiny::updateSelectizeInput(session, "selected_datatype", choices = c("RNA-seq", "mRNA microarray", "proteomics", "scRNA-seq", "metabolomics (beta)", "multi-omics (beta)"), selected = DEFAULTS$datatype)
+      } else {
+        shiny::updateSelectizeInput(session, "selected_datatype", choices = c("RNA-seq", "mRNA microarray", "proteomics", "scRNA-seq", "metabolomics (beta)"), selected = DEFAULTS$datatype)
+      }
     })
     
     output$proteomics_subtype_ui <- shiny::renderUI({

--- a/components/board.upload/R/upload_ui.R
+++ b/components/board.upload/R/upload_ui.R
@@ -22,15 +22,7 @@ UploadUI <- function(id) {
           p("Data type:", style = "text-align: left; margin: 0 0 2px 0; font-weight: bold;"),
           shiny::selectInput(
             ns("selected_datatype"), NULL,
-            choices = c(
-              "RNA-seq",
-              "mRNA microarray",
-              "proteomics",
-              "scRNA-seq",
-              "metabolomics (beta)" = "metabolomics",
-              "multi-omics (beta)" = "multi-omics"
-            ),
-            selected = DEFAULTS$datatype,
+            choices = NULL,
             width = "400px"
           ),
           shiny::uiOutput(ns("proteomics_subtype_ui"))

--- a/components/modules/AuthenticationModule_functions.R
+++ b/components/modules/AuthenticationModule_functions.R
@@ -38,7 +38,7 @@ read_user_options <- function(user_dir) {
       "ENABLE_PUBLIC_SHARE", "ENABLE_UPLOAD", "ENABLE_USER_SHARE",
       "MAX_DATASETS", "MAX_SAMPLES", "MAX_COMPARISONS",
       "MAX_GENES", "MAX_GENESETS", "MAX_SHARED_QUEUE",
-      "TIMEOUT", "WATERMARK"
+      "TIMEOUT", "WATERMARK", "ENABLE_MULTIOMICS"
     )
     dbg("[read_user_options] 1 : names(user_opt) = ", names(user_opt))
     user_opt <- user_opt[which(names(user_opt) %in% ALLOWED_USER_OPTS)]
@@ -64,7 +64,7 @@ read_user_options_db <- function(email, user_database = NULL) {
       "ENABLE_PUBLIC_SHARE", "ENABLE_UPLOAD", "ENABLE_USER_SHARE",
       "MAX_DATASETS", "MAX_SAMPLES", "MAX_COMPARISONS",
       "MAX_GENES", "MAX_GENESETS", "MAX_SHARED_QUEUE",
-      "TIMEOUT", "WATERMARK"
+      "TIMEOUT", "WATERMARK", "ENABLE_MULTIOMICS"
     )
     dbg("[read_user_options] 1 : names(user_opt) = ", names(user_opt))
     user_opt <- user_opt[which(names(user_opt) %in% ALLOWED_USER_OPTS)]
@@ -76,7 +76,8 @@ read_user_options_db <- function(email, user_database = NULL) {
         ENABLE_PUBLIC_SHARE = as.logical(ENABLE_PUBLIC_SHARE),
         ENABLE_UPLOAD = as.logical(ENABLE_UPLOAD),
         ENABLE_USER_SHARE = as.logical(ENABLE_USER_SHARE),
-        WATERMARK = as.logical(WATERMARK)
+        WATERMARK = as.logical(WATERMARK),
+        ENABLE_MULTIOMICS = as.logical(ENABLE_MULTIOMICS)
       )
     for (opt_name in names(user_opt)) {
       new_opt[[opt_name]] <- user_opt[[opt_name]]


### PR DESCRIPTION
Feature: ability to control if MultiOmics is enabled for a user:

- Set MultiOmics default as FALSE
- Read MultiOmics option from DB and OPTIONS file
- If MultiOmics is disabled
  - Disable MultiOmics data upload
  - Grey out any MultiOmics datasets on your library