### PR TITLE
Select metadata variables to retain

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -1189,6 +1189,7 @@ UploadBoard <- function(id,
 
     upload_table_preview_samples_server(
       "samples_preview",
+      orig_sample_matrix = uploaded$samples.csv,
       uploaded,
       checklist = checklist,
       scrollY = "calc(50vh - 140px)",


### PR DESCRIPTION
When uploading samples, select metadata variable to retain for further analyses. Part of OPG enhancement to handle public data retrieval and processing.  For your review, see Slack first about a question. Thanks!