### PR TITLE
fix: use symnol to get features in feature set

### DIFF
--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -323,11 +323,8 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature")
       # return sel_genes that are not zero
       sel_genes <- sel_genes[which(sel_genes > 0)]
 
-      # convert symbol to rownames (module is based on rownames)
-
-      ortholog_genes <- ifelse(is.na(pgx$genes$human_ortholog), pgx$genes$symbol, pgx$genes$human_ortholog)
-
-      matched_rownames <- rownames(pgx$genes[match(names(sel_genes), ortholog_genes), ])
+      # selection based on symbol
+      matched_rownames <- rownames(pgx$genes[match(names(sel_genes), pgx$genes$symbol), ])
       return(matched_rownames)
     })
 


### PR DESCRIPTION
Bug found by Axel. Ask me for the dataset to reproduce, although any non-human species potentially is affected.

### Bug

Selecting a geneset does not color the corresponding genes on the volcano

<img width="4818" height="2054" alt="image" src="https://github.com/user-attachments/assets/753990cd-97ac-40a9-8ba3-44d539e5d8b4" />

### Fix

This subsetting now uses symbol, not human_ortholog

<img width="4818" height="2054" alt="image" src="https://github.com/user-attachments/assets/d99b064a-73d5-4bb3-b09a-8aa31830d08d" />
