### PR TITLE
Fix #1533: subscript out of bound in TimeSeries

### DIFF
--- a/components/board.timeseries/R/module_features.R
+++ b/components/board.timeseries/R/module_features.R
@@ -152,8 +152,12 @@ TimeSeriesBoard.features_server <- function(id,
       kstats.full[, "meta.p"] <- apply(kstats.full[, sel, drop = FALSE], 1, function(x) x[which.max(x)])
       sel <- grep("^q[.]*", colnames(kstats.full))
       kstats.full[, "meta.q"] <- apply(kstats.full[, sel, drop = FALSE], 1, function(x) x[which.max(x)])
-      kstats <- kstats.full[, c("meta.fx", "meta.p", "meta.q", "avg.0", "avg.1")]
-      colnames(kstats) <- c("log2FC", "p.value", "q.value", "avg.0", "avg.1")
+      cols <- c("meta.fx", "meta.p", "meta.q", "avg.0", "avg.1")
+      cols <- intersect(cols, colnames(kstats.full))
+      kstats <- kstats.full[, cols]
+      col_mapping <- c("meta.fx" = "log2FC", "meta.p" = "p.value", "meta.q" = "q.value", "avg.0" = "avg.0", "avg.1" = "avg.1")
+      new_names <- col_mapping[cols]
+      colnames(kstats) <- new_names
 
       ik <- paste0("IA:", k)
       if (ik %in% names(pgx$gx.meta$meta)) {


### PR DESCRIPTION
Closes #1533 

On old pgx columns `avg.0` and `avg.1` are not present; by intersecting with available columns the rest of the module works; the feature table will be missing those two columns though.

