### PR TITLE
fix: correct internal naming of MO/metabolomics

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -105,9 +105,9 @@ UploadBoard <- function(id,
       shiny::updateSelectizeInput(session, "selected_organism", choices = all_species, server = TRUE)
 
       if (opt$ENABLE_MULTIOMICS) {
-        shiny::updateSelectizeInput(session, "selected_datatype", choices = c("RNA-seq", "mRNA microarray", "proteomics", "scRNA-seq", "metabolomics (beta)", "multi-omics (beta)"), selected = DEFAULTS$datatype)
+        shiny::updateSelectizeInput(session, "selected_datatype", choices = c("RNA-seq", "mRNA microarray", "proteomics", "scRNA-seq", "metabolomics (beta)" = "metabolomics", "multi-omics (beta)" = "multi-omics"), selected = DEFAULTS$datatype)
       } else {
-        shiny::updateSelectizeInput(session, "selected_datatype", choices = c("RNA-seq", "mRNA microarray", "proteomics", "scRNA-seq", "metabolomics (beta)"), selected = DEFAULTS$datatype)
+        shiny::updateSelectizeInput(session, "selected_datatype", choices = c("RNA-seq", "mRNA microarray", "proteomics", "scRNA-seq", "metabolomics (beta)" = "metabolomics"), selected = DEFAULTS$datatype)
       }
     })
     


### PR DESCRIPTION
Added the correct dictionary so we display that those options are beta but internally things like this: https://github.com/bigomics/omicsplayground/blob/devel/components/board.upload/R/upload_module_preview_counts.R#L89 work properly.

This was a bug introduced by me here: https://github.com/bigomics/omicsplayground/commit/edf51347b8a615f4487560466760634eb00b53ca