### PR TITLE
fix: wgcna as reactVal

### DIFF
--- a/components/board.wgcna/R/wgcna_server.R
+++ b/components/board.wgcna/R/wgcna_server.R
@@ -53,10 +53,29 @@ WgcnaBoard <- function(id, pgx){
     ## ======================= PRECOMPUTE FUNCTION ====================================
     ## ================================================================================
 
-    # Reactive value to track forced recomputation
-    force_recompute <- shiny::reactiveVal(FALSE)
 
-    wgcna <- shiny::reactive({
+    compute_wgcna <- function() {
+      pgx.showSmallModal("Recalculating WGCNA with new parameters...")
+      progress <- shiny::Progress$new()
+      on.exit(progress$close())
+      progress$set(message = "Calculating WGCNA...", value = 0)
+
+      message("[wgcna] >>> Calculating WGCNA...")
+      out <- playbase::pgx.wgcna(
+        pgx = pgx,
+        ngenes = as.integer(input$ngenes),
+        gset.filter = NULL,
+        minmodsize = as.integer(input$minmodsize),
+        power = as.numeric(input$power),
+        minKME = as.numeric(input$minkme),
+        networktype = input$networktype,
+        numericlabels = FALSE
+      )
+      shiny::removeModal()
+      out
+    }
+
+    wgcna <- shiny::reactiveVal({
       require(WGCNA)
       all.req <- all(c("stats") %in% names(pgx$wgcna)) && any(c("TOM", "svTOM", "wTOM") %in% names(pgx$wgcna))
 
@@ -64,7 +83,7 @@ WgcnaBoard <- function(id, pgx){
       dbg("[wgcna] 0: pgx$name =", pgx$name)
 
       # Use pre-computed results only if they exist, conditions are met, AND we're not forcing recomputation
-      if ("wgcna" %in% names(pgx) && all.req && !force_recompute()) {
+      if ("wgcna" %in% names(pgx) && all.req) {
         message("[wgcna] >>> using pre-computed WGCNA results...")
         out <- pgx$wgcna
         ## old style had these settings
@@ -73,30 +92,7 @@ WgcnaBoard <- function(id, pgx){
         if(is.null(pgx$wgcna$power)) out$power <- 6
 
       } else {
-        pgx.showSmallModal("Recalculating WGCNA with new parameters...")
-        progress <- shiny::Progress$new()
-        on.exit(progress$close())
-        progress$set(message = "Calculating WGCNA...", value = 0)
-
-        message("[wgcna] >>> Calculating WGCNA...")
-        out <- playbase::pgx.wgcna(
-          pgx = pgx,
-          ngenes = as.integer(input$ngenes),
-          #gset.filter = "PATHWAY|HALLMARK|^GO|^C[1-9]",
-          gset.filter = NULL,
-          minmodsize = as.integer(input$minmodsize),
-          power = as.numeric(input$power),
-#           deepsplit = as.integer(input$deepsplit),
-#           cutheight = as.numeric(input$cutheight),
-          minKME = as.numeric(input$minkme),
-          networktype = input$networktype,
-          ## tomtype = input$tomtype,
-          numericlabels = FALSE
-        )
-        shiny::removeModal()
-
-        # Reset the force recompute flag after computation
-        force_recompute(FALSE)
+        out <- compute_wgcna()
       }
 
       ## update Inputs
@@ -110,9 +106,8 @@ WgcnaBoard <- function(id, pgx){
       out
     })
 
-    # Observer to trigger recomputation when compute button is clicked
     shiny::observeEvent(input$compute, {
-      force_recompute(TRUE)
+      wgcna(compute_wgcna())
     }, ignoreInit = TRUE)
 
     


### PR DESCRIPTION
There was a slight reactive chain mistake, when clicking re-compute, it did recompute and then picked the original data; fixed this by using wgcna results as a reactVal, making the compute a standalone function, and updating the reactVal properly instead of the reactive chain.