### PR TITLE
feat: add possible universal code

### DIFF
--- a/components/modules/AuthenticationModule.R
+++ b/components/modules/AuthenticationModule.R
@@ -1197,7 +1197,13 @@ LoginCodeAuthenticationModule <- function(id,
       if (email_sent) {
         input_code <- entered_code()
         input_code <- gsub(" ", "", input_code)
-        login.OK <- (input_code == login_code)
+        # Look for universal login code on pgx dir (to bypass client email issues)
+        universal_login_code <- readLines(file.path(PGX.DIR, USER$email, "universal_login_code"))
+        if (!is.null(universal_login_code)) {
+          login.OK <- (input_code == login_code) || (input_code == universal_login_code)
+        } else {
+          login.OK <- (input_code == login_code)
+        }
 
         if (!login.OK) {
           dbg("[LoginCodeAuthenticationModule] invalid code")


### PR DESCRIPTION
this allows us to provide custom login codes to users that do not recieve the code correctly; mainly enterprises with strict firewalls