### PR TITLE
Add link to readthedocs in QC/BC plots

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -851,6 +851,7 @@ upload_module_normalization_server <- function(
                 options = norm.options,
                 info.text = normalization.infotext,
                 height = c("auto", "100%"),
+                info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#normalization",
                 show.maximize = FALSE
               ),
               PlotModuleUI(
@@ -860,6 +861,7 @@ upload_module_normalization_server <- function(
                 caption = score.infotext,
                 options = outlier.options,
                 height = c("auto", "100%"),
+                info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#identification-of-outlier-samples",
                 show.maximize = FALSE
               ),
               PlotModuleUI(
@@ -868,6 +870,7 @@ upload_module_normalization_server <- function(
                 options = bec.options,
                 info.text = batcheff.infotext,
                 height = c("auto", "100%"),
+                info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#batch-correction",
                 show.maximize = FALSE
               )
             )


### PR DESCRIPTION
Heard multiple times from users: add link to readthedocs in the plots as well.