### PR TITLE
fix: ensure consistency for subset

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -266,6 +266,9 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
           return(NULL)
         }
 
+        # Ensure that the genes are in X
+        pp <- intersect(pp, rownames(pgx$X))
+
         if (length(pp) == 0) {
           warning("[getFilteredMatrix] warning: no genes overlap with filter")
           return(NULL)


### PR DESCRIPTION
Fix for hubspot ticket 227499473143

There was no guarantee that pp would subset pgx$X correctly, so when filtering features it could fail.

Ask me for data to reproduce (client data)

## Before

<img width="2666" height="1666" alt="image" src="https://github.com/user-attachments/assets/732aa2ef-5072-4008-9336-66e7eef44980" />

## After

<img width="2666" height="1666" alt="image" src="https://github.com/user-attachments/assets/18b6b1c5-606a-4457-9e9c-de93121e48b9" />
