### PR TITLE
fix: filter features to avoid subset error

### DIFF
--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -448,6 +448,9 @@ SignatureBoard <- function(id, pgx,
       fc <- meta$fc
       qv <- meta$qv
 
+      # Filter features
+      features <- features[features %in% rownames(fc)]
+
       # Get contrasts, FC, and gene info
       fc <- fc[features, contr]
       qv <- qv[features, contr]


### PR DESCRIPTION
From Hubspot ticket 228195914954

As very recent PR, we were subsetting based on user input without checking those features exist on our matrix.