### PR TITLE
fix: update wgcna inputs at recompute

### DIFF
--- a/components/board.wgcna/R/wgcna_server.R
+++ b/components/board.wgcna/R/wgcna_server.R
@@ -93,20 +93,21 @@ WgcnaBoard <- function(id, pgx) {
       } else {
         out <- compute_wgcna()
       }
+      out
+    })
 
+    shiny::observeEvent(wgcna(), {
       ## update Inputs
-      me <- sort(names(out$me.genes))
+      me <- sort(names(wgcna()$me.genes))
       shiny::updateSelectInput(session, "selected_module",
         choices = me,
         sel = me[1]
       )
-      tt <- sort(colnames(out$datTraits))
+      tt <- sort(colnames(wgcna()$datTraits))
       shiny::updateSelectInput(session, "selected_trait",
         choices = tt,
         selected = tt[1]
       )
-
-      out
     })
 
     shiny::observeEvent(input$compute,


### PR DESCRIPTION
Multiple hubspot tickets

The wgcna inputs where not updated at recompute with old architecture. That led to user being able to select modules that do not exist, crashing multiple plots