### PR TITLE
Devel custom features input

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -239,8 +239,8 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
           }
           # heatmap does not like single gene
           shiny::validate(shiny::need(
-            length(gg1) > 1 && !is.regex,
-            tspan("Please input more than 1 gene.", js = FALSE)
+            length(gg1) > 1 && !is.regex && sum(gg1 %in% genes) > 1,
+            tspan("Please input more than 1 valid gene.", js = FALSE)
           ))
 
           ## build index idx that determines groups/cluster of genes.

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -214,7 +214,8 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         gsets <- unique(gset_collections[[ft]])
         zx <- pgx$gsetX
         if (input$hm_customfeatures != "") {
-          gsets1 <- genesets[grep(input$hm_customfeatures, genesets, ignore.case = TRUE)]
+          customfeatures <- clean_custom_features(input$hm_customfeatures)
+          gsets1 <- genesets[grep(customfeatures, genesets, ignore.case = TRUE)]
           if (length(gsets1) > 2) gsets <- gsets1
         }
         zx <- zx[intersect(gsets, rownames(zx)), ]
@@ -230,7 +231,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         } else if (ft %in% names(pgx$families)) {
           pp <- playbase::map_probes(pgx$genes, pgx$families[[ft]])
         } else if (ft == "<custom>" && ft != "") {
-          customfeatures <- input$hm_customfeatures
+          customfeatures <- clean_custom_features(input$hm_customfeatures)
           gg1 <- strsplit(customfeatures, split = "[, ;\n\t]")[[1]]
           is.regex <- grepl("[*?\\[]", gg1[1])
           if (length(gg1) == 1 && is.regex) {

--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -290,9 +290,12 @@ FeatureMapBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       }
       if ("<custom>" %in% sel) {
         custum.genes <- strsplit(input$customlist, split = "[, ;]")[[1]]
+        if (length(custum.genes) == 0) {
+          custum.genes <- c()
+        }
         if (length(custum.genes) > 0) {
           custum.probes <- playbase::map_probes(pgx$genes, custum.genes)
-          filtprobes <- c(custom.probes, filtprobes)
+          filtprobes <- c(custum.probes, filtprobes)
         }
       }
       filtprobes

--- a/components/ui/ui-utils.R
+++ b/components/ui/ui-utils.R
@@ -506,3 +506,19 @@ create_loader <- function(id) {
     )
   )
 }
+
+clean_custom_features <- function(features) {
+  # Remove quotes and clean up the features string
+  features <- gsub("['\"]", "", features)
+
+  # Split by common separators and clean each feature
+  feature_list <- strsplit(features, "[,;\n\t]+")[[1]]
+
+  # Trim whitespace and remove empty strings
+  feature_list <- trimws(feature_list)
+  feature_list <- feature_list[feature_list != ""]
+
+  # Rejoin with commas
+  features <- paste(feature_list, collapse = ", ")
+  return(features)
+}


### PR DESCRIPTION
On cluster samples, when user inputs custom features to subset, we need to do a little bit of stream cleaning. 

From Hubspot ticket 228557347053, the user subsetted with the following string

`VSIG1 PSCA','MUCL3','SCEL','DHRS9','MUC5AC','IL1R2','IFI44L','PHGR1','COL17A1`

The quotes make our subseting system fail:

<img width="2672" height="1658" alt="image" src="https://github.com/user-attachments/assets/58d038f6-55ba-4d48-bae9-ba70e0c67481" />

By cleaning it (this PR), it works fine:

<img width="2672" height="1658" alt="image" src="https://github.com/user-attachments/assets/fd13ff91-0cb3-404c-bb33-3bb313f3e153" />

Also I added a small modification for the "Please input more than 1 gene", before it only checked the length of the input genes, now I added to check that those added are also on the data, otherwise it does not count properly and gives an error.


---

Also fixed ticket 228284026088 on this PR on cluster features, which had a typo so custom features actually did not work, also added a small safety feature to avoid errors
