### PR TITLE
feat: validate grouping and filter combo is valid

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -390,6 +390,10 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         grp <- pgx$contrasts[colnames(zx), splitvar]
       }
 
+      shiny::validate(
+        shiny::need(is.null(grp) || any(!is.na(grp)), "Selected grouping and filter combination is not valid (no samples left).")
+      )
+
       ## split on gene expression value: hi vs. low
       if (do.split && splitvar %in% rownames(pgx$X)) {
         gx <- pgx$X[1, ]


### PR DESCRIPTION
From hubspot ticket 228572974287

Combination of cluster samples board (and subset) yields empty table. we should control it before displaying an error

<img width="2668" height="1626" alt="image" src="https://github.com/user-attachments/assets/864e64fd-ca61-4d9b-8468-f9a5e368824e" />

## After control

<img width="2668" height="1626" alt="image" src="https://github.com/user-attachments/assets/23278082-6bc0-4700-8899-84c208b875e7" />
