### PR TITLE
fix: wgcna heatmap for small genesets

### DIFF
--- a/components/board.wgcna/R/wgcna_plot_gene_heatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_gene_heatmap.R
@@ -41,7 +41,8 @@ wgcna_plot_gene_heatmap_server <- function(id,
       gg <- strsplit(data$genes[sel], split = "\\|")[[1]]
       pp <- playbase::map_probes(pgx$genes, gg)
       pp <- intersect(pp, rownames(pgx$X))
-      df <- pgx$X[pp, ]
+      df <- pgx$X[pp, , drop = FALSE]
+      shiny::validate(shiny::need(nrow(df) > 1, "Geneset should contain at least two genes to plot a heatmap."))
       rownames(df) <- playbase::probe2symbol(rownames(df), pgx$genes, "gene_name", fill_na = TRUE)
       playbase::gx.splitmap(
         df,


### PR DESCRIPTION
From automatic snapshots, celegans WGCNA:

<img width="1920" height="1080" alt="celegans-wormbase_wgcna_Enrichment" src="https://github.com/user-attachments/assets/c80d03bd-15a7-4322-a45a-e0f712d19279" />

Error happens when selected geneset has 1 or less genes, which does not allow for a heatmap plot:

## After

<img width="2306" height="1628" alt="image" src="https://github.com/user-attachments/assets/055a8a90-84ef-48e3-8ac8-a054ce5a6685" />

<img width="2306" height="1628" alt="image" src="https://github.com/user-attachments/assets/8cc879df-4474-4e57-ab37-2cd088c931ce" />

<img width="2306" height="1628" alt="image" src="https://github.com/user-attachments/assets/016d6019-2ea9-4154-9fbb-6744e8fb94c9" />
