### PR TITLE
feat: make sure subsetting is right

### DIFF
--- a/components/board.signature/R/signature_plot_markers.R
+++ b/components/board.signature/R/signature_plot_markers.R
@@ -207,6 +207,8 @@ signature_plot_markers_server <- function(id,
       shiny::req(res)
 
       features <- markers$features
+      # make sure features are in pgx$X
+      features <- intersect(features, rownames(pgx$X))
       gx <- pgx$X[features, , drop = FALSE]
       if (nrow(gx) == 0) {
         cat("WARNING:: Markers:: markers do not match!!\n")


### PR DESCRIPTION
From automatic snapshots, human-ENST sig:

<img width="1905" height="1080" alt="human-ENST_signature_Markers" src="https://github.com/user-attachments/assets/0fdfd3a1-14c7-453f-89a8-084bcc7260e0" />

After making sure subsetting is right:

<img width="2306" height="1628" alt="image" src="https://github.com/user-attachments/assets/f87a0a3a-8b30-46c4-bc59-22dfe1c45b06" />
