### PR TITLE
fix: samples heatmap when averaged by group

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -106,6 +106,7 @@ clustering_plot_splitmap_server <- function(id,
                                             hm_ntop,
                                             hm_topmode,
                                             hm_clustk,
+                                            hm_average_group,
                                             watermark = FALSE,
                                             labeltype) {
   moduleServer(id, function(input, output, session) {
@@ -151,14 +152,15 @@ clustering_plot_splitmap_server <- function(id,
       sample_cor <- FALSE
       if (input$plot_type == "sample correlation") {
         sample_cor <- TRUE
-        X <- pgx$X
+        X <- zx
         if (input$hm_scale == "row.center") X <- X - rowMeans(X, na.rm = TRUE)
         if (input$hm_scale == "row") X <- t(scale(t(X)))
         zx <- cor(X, method = "pearson", use = "pairwise.complete.obs")
         D <- as.dist(1 - zx)
         D[which(is.nan(D) | is.na(D))] <- 1
         hc <- fastcluster::hclust(D, method = "ward.D2")
-        zx.idx <- paste0("S", cutree(hc, hm_clustk()))
+        zx.idx <- try(paste0("S", cutree(hc, hm_clustk())), silent = TRUE)
+        if (inherits(zx.idx, "try-error")) zx.idx <- paste0("S", cutree(hc, 1))
       }
 
       return(list(zx = zx, annot = annot, zx.idx = zx.idx, filt = filt, sample_cor = sample_cor))
@@ -358,6 +360,10 @@ clustering_plot_splitmap_server <- function(id,
 
       if (sample_cor) {
         idx <- splitx
+        if (hm_average_group()) {
+          idx <- NULL
+          splitx <- NULL
+        }
         scale.mode <- "none"
         zlim <- c(min(X, na.rm = TRUE), max(X, na.rm = TRUE))
         symm <- TRUE

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -747,6 +747,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       ## hm_scale = shiny::reactive(input$hm_scale),
       hm_topmode = shiny::reactive(input$hm_topmode),
       hm_clustk = shiny::reactive(input$hm_clustk),
+      hm_average_group = shiny::reactive(input$hm_average_group),
       watermark = WATERMARK,
       labeltype = labeltype
     )


### PR DESCRIPTION
There was a bug affecting sample correlation heatmap when grouping by phenotype and averaging by group:
(From Hubspot tickets also reproducible on example-data).

## Before
<img width="3010" height="1726" alt="image" src="https://github.com/user-attachments/assets/a98fd916-2e72-4f66-bf1e-1d3f724f2925" />

## After
<img width="3010" height="1726" alt="image" src="https://github.com/user-attachments/assets/8dc5c6c3-714e-4778-8f66-75bdd4e7afaa" />
