### PR TITLE
fix: group averaging crash with single annotation column

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -616,7 +616,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         w.null <- sapply(f, is.null)
         if (any(w.null)) f[which(w.null)] <- NA
         unlist(f)
-      })
+      }, simplify = FALSE)
       grp.annot <- data.frame(do.call(rbind, grp.annot))
       grp.annot <- grp.annot[colnames(grp.zx), , drop = FALSE]
       grp <- colnames(grp.zx)


### PR DESCRIPTION
Fix clustering group averaging for single-column annotations

Datasets with only one annotation column crashed when using group averaging.
tapply() was simplifying single-column results to vectors instead of lists,
causing rbind to fail. Added simplify=FALSE to ensure consistent list output.

## Before
<img width="3022" height="1728" alt="image" src="https://github.com/user-attachments/assets/26b17d20-c679-4701-8bd9-f2f186030568" />

## After
<img width="3022" height="1728" alt="image" src="https://github.com/user-attachments/assets/54edc585-8de4-4f9f-b3bc-df6a62b97bbc" />

