### PR TITLE
fix: correct gene indexing after rename_by changes matrix dimensions

### DIFF
--- a/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
+++ b/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
@@ -75,6 +75,7 @@ singlecell_plot_crosstabPlot_server <- function(id,
         shiny::validate(shiny::need(FALSE, "Proportions requires deconvolution"))
       }
       crosstabvar <- crosstabvar()
+      shiny::req(crosstabvar)
       gene <- gene()
       pheno <- pheno()
 


### PR DESCRIPTION
After `rename_by` renames the matrix with gene symbols, the resulting matrix dimensions can change (rows may be removed). The old code used `xgene` (indexed from the original `pgx$X`) to match against `pheno`, but then used this to index the dimension-reduced matrix `X`, causing incorrect row selection.

- Removed `xgene` variable that referenced the original matrix dimensions
- Use `rownames(X)` directly after `rename_by` to match against `pheno`
- Ensures indexing is consistent with the actual dimensions of the renamed matrix

## Before
<img width="1142" height="1472" alt="image" src="https://github.com/user-attachments/assets/aba9fe82-b9e8-4408-8ee2-e97e97fe888e" />

## After
<img width="1142" height="1472" alt="image" src="https://github.com/user-attachments/assets/6a36dc38-7b62-4612-9343-fee360847213" />
