### PR TITLE
feat: add consent text to customer support

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1110,7 +1110,8 @@ upload_module_computepgx_server <- function(
                   message = "Would you like to get support from our customer service?",
                   error   = shiny::HTML(errors),
                   btn_id  = "send_data_to_support__",
-                  onclick = paste0('Shiny.onInputChange(\"', ns("send_data_to_support"), '\", this.id, {priority: "event"})')
+                  onclick = paste0('Shiny.onInputChange(\"', ns("send_data_to_support"), '\", this.id, {priority: "event"})'),
+                  show_consent = TRUE
                 )
                 # send error message to user
                 gmail_creds <- file.path(ETC, "gmail_creds")

--- a/components/board.upload/R/upload_utils.R
+++ b/components/board.upload/R/upload_utils.R
@@ -79,7 +79,7 @@ preview_module_legend <- shiny::div(
   span("= error and data will not be uploaded.")
 )
 
-error_popup <- function(title, header, message, error, btn_id, onclick) {
+error_popup <- function(title, header, message, error, btn_id, onclick, show_consent = FALSE) {
   showModal(
     shiny::tagList(
       tags$div(
@@ -130,6 +130,12 @@ error_popup <- function(title, header, message, error, btn_id, onclick) {
           # add grey style to tag p, and corner edges
           tags$p(error, style = "font-size:12px; background-color: rgba(0,0,0,0.1); border-radius: 5px; padding: 10px; overflow: auto;"),
           shiny::p(message, style = "font-size:15px;"),
+          if (show_consent) {
+            tags$p(
+              style = "font-size:13px; font-style: italic; color: #5E81AC; background-color: rgba(94, 129, 172, 0.1); border-left: 3px solid #5E81AC; padding: 10px; margin: 10px 0;",
+              HTML("<strong>Note:</strong> By clicking \"Send data to customer support\", you authorize BigOmics to access your data solely for the purpose of fixing computation errors, if any.")
+            )
+          },
           div(
             tags$button(
               id = btn_id,


### PR DESCRIPTION
When there is a computation support, we have a popup to send the data to customer support to fix any error. Added the text:

"By clicking 'Send data to customer support', you authorize BigOmics to access your data solely for the purpose of fixing computation errors, if any."