### PR TITLE
feat: message instead of error when azimuth run is unsuccessful

### DIFF
--- a/components/board.upload/R/upload_module_normalizationSC.R
+++ b/components/board.upload/R/upload_module_normalizationSC.R
@@ -218,6 +218,16 @@ upload_module_normalizationSC_server <- function(id,
             dbg("[normalizationSC_server:ds_norm_Counts:] Cell types inferred.")
           })
 
+          if (is.null(azm)) {
+            message_text <- paste(
+              "Please select the Azimuth reference atlas that fits your data.",
+              "NOTE: The uploaded data might NOT be single cell data. Please check your input matrix."
+            )
+            shiny::validate(
+              shiny::need(FALSE, message_text)
+            )
+          }
+
           if (class(azm) %in% c("matrix", "data.frame")) {
             kk <- grep("^predicted.*l*2$", colnames(azm))
             if (any(kk)) {


### PR DESCRIPTION
When azimuth run returns NULL, handle the case to avoid errors and display correctly formatted message.

<img width="3022" height="1738" alt="image" src="https://github.com/user-attachments/assets/9490defd-1214-44a4-9504-f86cd9052ce5" />
