### PR TITLE
Do not recompute table at every selection

### DIFF
--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -91,7 +91,7 @@ upload_table_preview_samples_server <- function(
           ns("update_vars_selected"),
           "Update",
           icon = icon("refresh"),
-          class = "btn-sm btn-success"
+          class = "btn-sm btn-outline-primary"
         )
       )
     })


### PR DESCRIPTION
Sample table (preview) gets recomputed at every changes in metadata variables. Very slow for big matrices. Added updated button for the user to click when selection of the variables of interest is completed.