### PR TITLE
Rename T to M. Avoid confusion.

### DIFF
--- a/components/board.timeseries/R/board_server.R
+++ b/components/board.timeseries/R/board_server.R
@@ -106,7 +106,7 @@ TimeSeriesBoard <- function(id,
 
       knn <- as.integer(input$knn)
       modules <- clust[, paste0("kmeans.", knn)]
-      modules <- paste0("T", modules)
+      modules <- paste0("M", modules)
       names(modules) <- rownames(clust)
 
       ## compute geneset enrichment


### PR DESCRIPTION
Rename T to M. Indicate modules, not time. Users wrongly believed that were "time" modules.