### PR TITLE
Add option to show other samples in contrast-specific heatmap

### DIFF
--- a/components/board.clustering/R/clustering_ui.R
+++ b/components/board.clustering/R/clustering_ui.R
@@ -36,6 +36,14 @@ ClusteringInputs <- function(id) {
         "Average expression values by group."
       ),
     ),
+    shiny::conditionalPanel(
+      "input.hm_splitby == 'contrast'",
+      ns = ns,
+      withTooltip(
+        shiny::checkboxInput(ns("hm_show_others"), "show other samples", FALSE),
+        "Include all other samples in the heatmap."
+      ),
+    ),
     ## ----- level ----
     shiny::hr(),
     withTooltip(


### PR DESCRIPTION
Clustering samples: add option to add all available samples in contrast-specific heatmap. Important: the features displayed are dependent on the contrast. Added samples will not have effects on features (genes/proteins; genesets/proteinsets) as these keep reflecting the selected contrast. 