### PR TITLE
feat: Add dynamic visibility control for archive tab panel

### DIFF
--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -203,7 +203,9 @@ LoadingBoard <- function(id,
       pgx_archive_dir <- file.path(auth$user_dir, "data_archive")
       enable_archive_tabpanel <- dir.exists(pgx_archive_dir)
 
+      ## Show/hide archive tab based on whether directory exists
       if (enable_archive_tabpanel) {
+        shiny::showTab(inputId = "tabs", target = "archive_tab", session = session)
         pgxtable_archive <- loading_table_datasets_public_server(
           id = "pgxtable_archive",
           pgx_public_dir = pgx_archive_dir,
@@ -219,6 +221,8 @@ LoadingBoard <- function(id,
           r_selected = reactive(pgxtable_archive$rows_all()),
           watermark = WATERMARK
         )
+      } else {
+        shiny::hideTab(inputId = "tabs", target = "archive_tab", session = session)
       }
     })
 

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -121,6 +121,7 @@ LoadingUI <- function(id) {
 
   archive_tabpanel <- shiny::tabPanel(
     "Data archive",
+    value = "archive_tab",
     bslib::layout_columns(
       col_widths = 12,
       height = "calc(100vh - 181px)",


### PR DESCRIPTION
From MA request:

Implements dynamic visibility control for the "Data archive" tab panel in the Loading board. The archive tab now automatically shows or hides based on whether the user's `data_archive` directory exists.