### PR TITLE
improvement: inform user if custom feature list has no matches

### DIFF
--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -180,6 +180,8 @@ SignatureBoard <- function(id, pgx,
           genes <- union(genes, rx.genes)
         }
         genes <- intersect(toupper(genes), symbols)
+        shiny::validate(shiny::need(length(genes) > 0,
+          "Custom feature selection not found in the data. Please check your custom feature list."))
         ## map to probes
         features1 <- playbase::map_probes(pgx$genes, genes,
           column = "human_ortholog", ignore.case = TRUE


### PR DESCRIPTION
On test genesets, if we use `<custom>` and there are no matches with the dataset, all the plots are blank. Added a shiny validate/need to display a message to inform the user better.

## Before
<img width="2702" height="1494" alt="image" src="https://github.com/user-attachments/assets/37d3a8e6-2677-487a-a037-56fce747cfa4" />

## After
<img width="2702" height="1494" alt="image" src="https://github.com/user-attachments/assets/d99d17ef-a32c-4e39-8eab-46a4be76bc0e" />
