### PR TITLE
fix: genecorr edge case less than 4 features

### DIFF
--- a/components/board.compare/R/compare_plot_genecorr.R
+++ b/components/board.compare/R/compare_plot_genecorr.R
@@ -233,7 +233,7 @@ compare_plot_genecorr_server <- function(id,
       # Assemble all subplot in to grid
       plt <- plotly::subplot(
         sub_plots,
-        nrows = 4,
+        nrows = min(4, length(sub_plots)),
         margin = 0.03,
         titleX = TRUE,
         titleY = TRUE


### PR DESCRIPTION
Very edge case where we have less than 4 features, more precisely 3 (the minimum amount of features for compute to work).

## Before
<img width="2706" height="1730" alt="image" src="https://github.com/user-attachments/assets/8668f09b-8eaa-4af4-9153-dabea502be3e" />

## After
<img width="2706" height="1730" alt="image" src="https://github.com/user-attachments/assets/7b48b952-6e9f-4058-a2f1-103584d76a74" />
