### PR TITLE
style: remove background box on venn diagrams

### DIFF
--- a/components/board.intersection/R/intersection_plot_table_venn_diagram.R
+++ b/components/board.intersection/R/intersection_plot_table_venn_diagram.R
@@ -158,7 +158,8 @@ intersection_plot_venn_diagram_server <- function(id,
           p <- ggVennDiagram::ggVennDiagram(
             x,
             label = "both",
-            edge_size = 0.4
+            edge_size = 0.4,
+            label_alpha = 0
           ) +
             ggplot2::scale_fill_gradient(low = "grey90", high = "red") +
             ggplot2::theme(
@@ -172,7 +173,8 @@ intersection_plot_venn_diagram_server <- function(id,
           p <- ggVennDiagram::ggVennDiagram(
             x,
             label = "count",
-            edge_size = 0.4
+            edge_size = 0.4,
+            label_alpha = 0
           ) +
             ggplot2::scale_fill_gradient(low = "grey90", high = "red") +
             ggplot2::theme(


### PR DESCRIPTION
As per Axel request, make the Venn diagram easier to read. Removed the background box, on deploy was black, local white, strange behavior.

<img width="968" height="720" alt="image" src="https://github.com/user-attachments/assets/755241c9-9035-4a04-910a-6992ced14c41" />
