### PR TITLE
fix: pass NA free X to detectOutlierSamples

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -161,6 +161,7 @@ upload_module_normalization_server <- function(
         if (input$remove_outliers) {
           threshold <- input$outlier_threshold
           dbg("[normalization_server:cleanX] Removing outliers: Threshold = ", threshold)
+          if (any(is.na(X))) X <- playbase::imputeMissing(X, method = "SVD2")
           res <- playbase::detectOutlierSamples(X, plot = FALSE)
           is.outlier <- (res$z.outlier > threshold)
           if (any(is.outlier) && !all(is.outlier)) {


### PR DESCRIPTION
From client crash. Uploaded dataset with missings, when removing outliers we need to pass a clean X so that `detectOutlierSamples` does not crash.