### PR TITLE
fix: recompute code deleted

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -832,6 +832,9 @@ UploadBoard <- function(id,
     observeEvent(recompute_pgx(),
       {
         req(!is.null(recompute_pgx()))
+        if (!is.null(recompute_pgx()$datatype) && recompute_pgx()$datatype != "") {
+          upload_datatype(recompute_pgx()$datatype)
+        }
         numpgx <- length(dir(auth$user_dir, pattern = "*.pgx$"))
         if (!auth$options$ENABLE_DELETE) {
           ## count also deleted files...


### PR DESCRIPTION
Bring back code to set data type on recompute. Code was deleted by some PR on the last months.

Original PR: https://github.com/bigomics/omicsplayground/pull/1516