### PR TITLE
fix: dynamically update batch correction methods based on sample size

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -211,20 +211,12 @@ upload_module_normalization_server <- function(
         if (any(grepl("<none>", batch.pars))) batch.pars <- NULL
 
         methods <- c("ComBat", "limma", "RUV", "SVA", "NPM")
-        if (ncol(X0) > 100){
-          methods <- methods[methods != "NPM"]
-          shiny::updateSelectInput(
-            session,
-            "bec_method",
-            choices = methods
-          )
-        } else {
-          shiny::updateSelectInput(
-            session,
-            "bec_method",
-            choices = methods
-          )
-        }
+        if (ncol(X0) > 100)  methods <- methods[methods != "NPM"]
+        shiny::updateSelectInput(
+          session,
+          "bec_method",
+          choices = methods
+        )
         xlist.init <- list("uncorrected" = X0, "normalized" = X1)
 
         shiny::withProgress(


### PR DESCRIPTION
Ensures the batch correction method dropdown is properly updated when NPM  is conditionally excluded for large datasets (>100 samples).