### PR TITLE
enable grouping by database of geneset table

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -96,12 +96,8 @@ enrichment_plot_top_enrich_gsets_server <- function(id,
       }
 
       ## selected
-      sel <- as.integer(gseatable$rows_selected())
-      sel.gs <- NULL
-      if (!is.null(sel) && length(sel) > 0) sel.gs <- rownames(rpt)[sel]
-
-      ii <- gseatable$rows_selected()
-      jj <- gseatable$rows_current()
+      ii <- gseatable$rownames_selected()
+      jj <- gseatable$rownames_current()
       shiny::req(jj)
 
       if (nrow(rpt) == 0) {

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -368,13 +368,21 @@ EnrichmentBoard <- function(id, pgx,
     ## Enrichment table
     ## ================================================================================
 
-    gset_selected <- shiny::reactive({
+    gset_selected.SAVE <- shiny::reactive({
       i <- as.integer(gseatable$rows_selected())
       if (is.null(i) || length(i) == 0) {
         return(NULL)
       }
       rpt <- getFilteredGeneSetTable()
       gs <- rownames(rpt)[i]
+      return(gs)
+    })
+
+    gset_selected <- shiny::reactive({
+      gs <- gseatable$rownames_selected()
+      if (is.null(gs) || length(gs) == 0) {
+        return(NULL)
+      }
       return(gs)
     })
 


### PR DESCRIPTION
This enables to group the genesets by database collection by using the DT table filter. The toggle is in the plot options. This can be extended to other gene set tables in the app.

<img width="2899" height="1377" alt="image" src="https://github.com/user-attachments/assets/df97e02a-daeb-4bab-9d50-47d252f7865c" />