### PR TITLE
feat: display gene symbols in selector using labeltype

### DIFF
--- a/components/board.correlation/R/correlation_server.R
+++ b/components/board.correlation/R/correlation_server.R
@@ -61,6 +61,9 @@ CorrelationBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       ## genes <- sort(pgx$genes[genes, ]$gene_name)
       sel <- genes[1] ## most var gene
       ## sel <- names(head(sort(-rowMeans(playbase::pgx.getMetaMatrix(pgx)$fc**2)), 1))
+
+      names(genes) <- playbase::probe2symbol(genes, pgx$genes, labeltype(), fill_na = TRUE)
+
       shiny::updateSelectizeInput(
         session, "gene",
         choices = genes, selected = sel, server = TRUE


### PR DESCRIPTION
Client report: as we do on dataview tab, update feature selector with label type.