### PR TITLE
improve prefix matching

### DIFF
--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -471,12 +471,12 @@ upload_table_preview_counts_server <- function(id,
       combined_df <- NULL
       for (i in 1:length(data_cache)) {
         df <- data_cache[[i]]
-        prefix <- switch(datatypes[i],
-          "RNA-seq" = "gx",
-          "Proteomics" = "px",
-          "Metabolomics" = "mx",
-          "mx" # default fallback
-        )
+        dt <- tolower(datatypes[i])
+        prefix <- "gx"
+        if(grepl("proteomics",dt)) prefix <- "px"
+        if(grepl("metabolomics|lipidomics",dt)) prefix <- "mx"
+        if(grepl("microarray|micro.array|rna|rnatranscriptomics",dt)) prefix <- "gx"
+        if(grepl("mirna|mi.rna",dt))  prefix <- "mi"          
         rownames(df) <- paste0(prefix, ":", rownames(df))
         df <- df[, common_cols, drop = FALSE]
         combined_df <- rbind(combined_df, df)


### PR DESCRIPTION
fix prefix matching for multiomics upload. Older versions can have pgx$datatype lower case or have different names (like "LC/MS proteomics"). 