### PR TITLE
Fix multiomics normalization at upload

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -72,7 +72,7 @@ upload_module_normalization_server <- function(
         is.multiomics <- playbase::is.multiomics(rownames(counts))
         if (is.multiomics) {
           X <- counts
-          dtypes <- unique(unlist(lapply(rownames(counts), function(x) strsplit(x, ":")[[1]][1])))
+          dtypes <- unique(sub(":.*", "", rownames(X)))
           for(i in 1:length(dtypes)) {
             ii <- grep(paste0("^", dtypes[i], ":"), rownames(counts))
             prior <- 1


### PR DESCRIPTION
Fix multi-omics normalization. 
logCPM always for gx;
Max Median always for non-gx data.
Depends on https://github.com/bigomics/playbase/pull/354
 