### PR TITLE
fix: check raw_dir before

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1266,9 +1266,11 @@ upload_module_computepgx_server <- function(
       session$onSessionEnded(
       function() {
         # Clean up raw_dir if it exists
-        if (dir.exists(shiny::isolate(raw_dir()))) {
-          message("Cleaning up raw_dir: ", shiny::isolate(raw_dir()))
-          unlink(shiny::isolate(raw_dir()), recursive = TRUE)
+        if(!is.null(shiny::isolate(raw_dir()))) {
+          if (dir.exists(shiny::isolate(raw_dir()))) {
+            message("Cleaning up raw_dir: ", shiny::isolate(raw_dir()))
+            unlink(shiny::isolate(raw_dir()), recursive = TRUE)
+          }
         }
       })
 


### PR DESCRIPTION
Avoid error on logs when `raw_dir` is NULL (`dir.exists(NULL)` gives error)