### PR TITLE
cleanup: remove chirpbutton

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -157,7 +157,6 @@ opt.default <- list(
   USE_CREDENTIALS = FALSE,
   DOMAIN = NULL,
   BLOCKED_DOMAIN = "bigomics.com|massdynamics.com|pluto.bio|rosalind.bio",
-  ## ENABLE_CHIRP         = TRUE,
   ENABLE_DELETE = TRUE,
   ENABLE_PGX_DOWNLOAD = TRUE,
   ENABLE_PUBLIC_SHARE = TRUE,

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -206,15 +206,6 @@ app_ui <- function(x) {
         .where = "declarations"
       )
 
-      ## offcanvas chatbox
-      div.chirpbutton <- NULL
-      if (opt$ENABLE_CHIRP) {
-        div.chirpbutton <- shiny::actionButton("chirp_button", "Discuss!",
-          width = "auto", class = "quick-button",
-          onclick = "window.open('https://www.reddit.com/r/omicsplayground', '_blank')"
-        )
-      }
-
       div.invitebutton <- InviteFriendUI("invite")
       div.upgradebutton <- if (opt$ENABLE_UPGRADE) {
         UpgradeModuleUI("upgrade")
@@ -268,7 +259,6 @@ app_ui <- function(x) {
           ),
           div.upgradebutton,
           div.invitebutton,
-          div.chirpbutton,
           div(
             id = "mainmenu_help",
             bigdash::navbarDropdown(


### PR DESCRIPTION
Remove the `Discuss!` button. It goes to our reddit, which contains 2 posts from 4 years ago, we don't need a button that stays on the UI the whole time for that. https://www.reddit.com/r/OmicsPlayground/

<img width="654" height="318" alt="image" src="https://github.com/user-attachments/assets/ba98937b-37a8-4e79-9d98-b14ca3ce2df5" />
