### PR TITLE
fix: pass correct list element

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -186,7 +186,7 @@ enrichment_plot_volcanoall_server <- function(id,
       shiny::req(pd)
 
       fc <- pd[["FC"]]
-      qv <- pd[["Q"]]
+      qv <- pd[["S"]]
 
       gene_names <- rep(rownames(fc), each = ncol(fc))
       fc <- data.frame(fc) %>%


### PR DESCRIPTION
From hubspot tickets (multiple), using example data.

We were passing an outdated list element to the plot, which caused an error

## Before
<img width="3022" height="1732" alt="image" src="https://github.com/user-attachments/assets/9c9bf092-0163-416c-885a-db02eb30e81e" />

## After
<img width="3022" height="1732" alt="image" src="https://github.com/user-attachments/assets/4546d505-f7e8-49f6-b40c-796b2e3b31db" />
