### PR TITLE
fix: require valid gset variable

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_compare.R
+++ b/components/board.enrichment/R/enrichment_plot_compare.R
@@ -54,6 +54,7 @@ enrichment_plot_compare_server <- function(id,
         return()
       }
       gset <- gset[1]
+      shiny::req(gset)
 
       score <- sapply(pgx$gset.meta$meta, function(x) x[gset, "meta.fx"])
 


### PR DESCRIPTION
This fixes a red transient error that appears and disappears automatically on the platform. It does not affect user experience but it helps us not pollute the error tickets.