### PR TITLE
force update of conn if contains NaNs, related to bg fix

### DIFF
--- a/components/board.connectivity/R/connectivity_server.R
+++ b/components/board.connectivity/R/connectivity_server.R
@@ -232,7 +232,7 @@ ConnectivityBoard <- function(
         }
 
         has.user_sigdb <- "datasets-sigdb.h5" %in% names(pgx$connectivity)
-        if (need_update || !has.user_sigdb) {
+        if (need_update || !has.user_sigdb || any(unlist(pgx$connectivity) == "NaN")) {
           user.scores <- NULL
           if (file.exists(sigdb.file)) {
             info("[compute_connectivity] re-computing connectivity scores...")


### PR DESCRIPTION
If we have NaNs on pgx$connectivity, force recompute, on old pgx we might have NaNs from failed fisher, we fixed it now so we want to recompute.

Related to https://github.com/bigomics/playbase/pull/374