### PR TITLE
fix: avoid unneeded translation to avoid missing symbol errors

### DIFF
--- a/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
+++ b/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
@@ -116,8 +116,7 @@ singlecell_plot_crosstabPlot_server <- function(id,
       getProportionsTable <- function(pheno, is.gene = FALSE) {
         y <- NULL
         if (is.gene) {
-          X <- playbase::rename_by(pgx$X, pgx$genes, "symbol")
-          pheno <- pgx$genes[pheno, ]$symbol
+          X <- pgx$X
           gx <- X[which(rownames(X) == pheno), kk, drop = FALSE]
           # Handle case where multiple genes have same symbol, happens easily on weird species
           if (nrow(gx) > 1) {


### PR DESCRIPTION
Related to client data error found by Axel. We can avoid this un-needed translation (`pheno` comes from a list populated by `rownames(pgx$X)`). This solves an issue where we allow features with no symbols to the platform. 