### PR TITLE
fix: not add splitgene is splited by phenotype

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -460,7 +460,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       }
 
       addsplitgene <- function(gg) {
-        if (do.split && splitvar %in% rownames(pgx$X)) {
+        if (do.split && splitvar %in% rownames(pgx$X) && splitby != "phenotype") {
           gg <- unique(c(splitvar, gg))
         }
         return(gg)


### PR DESCRIPTION
From hubspot bugs.

We have this `addsplitgene` that gets called even when splitting by phenotype. On a client dataset, the selected phenotype had the same name as a gene, therefore `do.split && splitvar %in% rownames(pgx$X)` was `TRUE`. On the gene level heatmap that would work, however, when displaying the genesets heatmap it obviously failed.

Fixed it by making sure when we split by phenotype, the `addspligene` does not run.
