### PR TITLE
fix: need 2 samples minimum on clustering samples tab otherwise we get multiple plots with errors

### DIFF
--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -244,7 +244,7 @@ clustering_plot_clustpca_server <- function(id,
       label <- input$pca_label
 
       shiny::validate(shiny::need(
-        length(samples) > 0,
+        length(samples) > 1,
         "Filtering too restrictive. Please change 'Filter samples' settings."
       ))
       shiny::req(samples, colvar, shapevar, clustmethod, legend)

--- a/components/board.clustering/R/clustering_plot_phenoplot.R
+++ b/components/board.clustering/R/clustering_plot_phenoplot.R
@@ -60,7 +60,7 @@ clustering_plot_phenoplot_server <- function(id,
       kk <- kk[which(kk %in% colnames(Y))]
       pos <- pos[jj, , drop = FALSE]
       shiny::validate(shiny::need(
-        nrow(pos) > 0,
+        nrow(pos) > 1,
         "Filtering too restrictive. Please change 'Filter samples' settings."
       ))
       Y <- Y[jj, kk, drop = FALSE]

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -325,7 +325,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         if (!is.null(idx)) idx <- idx[rownames(zx)]
       }
       shiny::validate(shiny::need(
-        ncol(zx) > 0, "Filtering too restrictive. Please change 'Filter samples' settings."
+        ncol(zx) > 1, "Filtering too restrictive. Please change 'Filter samples' settings."
       ))
 
       flt <- list(
@@ -715,6 +715,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       rownames(rho) <- sub(".*:", "", rownames(ref))
 
       if (nrow(ref) > 0) {
+        browser()
         for (i in 1:length(idxx)) {
           gg <- rownames(zx)[which(idx == idxx[i])]
           aa <- t(X[gg, samples, drop = FALSE])


### PR DESCRIPTION
From hubspot bugs.

Before we checked that the filtering got us more than 0 samples (which of course also failed), but we actually need 2 at minimum since we are "clustering" samples.