### PR TITLE
feat: make biomarker work with 1 feature

### DIFF
--- a/components/board.biomarker/R/biomarker_plot_heatmap.R
+++ b/components/board.biomarker/R/biomarker_plot_heatmap.R
@@ -85,7 +85,7 @@ biomarker_plot_heatmap_server <- function(id,
         } else {
           kk <- colnames(res$X)
         }
-        X <- pgx$X[gg, kk]
+        X <- pgx$X[gg, kk, drop = FALSE]
         ## X <- head(X[order(-apply(X, 1, sd)), ], 40) ## top50
         splitx <- NULL
         ct <- pdx_predicted()


### PR DESCRIPTION
From hubspot bugs.

Using biomarker module filtering by 1 feature crashed completely. Fixed it.

Playbase PR related: https://github.com/bigomics/playbase/pull/398

## Before
<img width="3022" height="1734" alt="image" src="https://github.com/user-attachments/assets/64eaf4ba-b913-4c34-a44f-11363908d1c9" />

## After
<img width="3022" height="1734" alt="image" src="https://github.com/user-attachments/assets/20691b1b-d92a-4eee-9d41-96f67af5cf5b" />

