### PR TITLE
fix: move computeok email to main thread

### DIFF
--- a/bin/pgxcreate_op.R
+++ b/bin/pgxcreate_op.R
@@ -90,13 +90,15 @@ if (dir.exists(params$pgx.save.folder)) {
 }
 save(pgx, file = pgx_name)
 
-ds_name <- paste0("<b>", params$name, "</b>")
-gmail_creds <- file.path(params$ETC, "gmail_creds")
+# We now send success message to user from the shiny app, because the process only runs if the app is alive, so there is no need to send the message here.
 
-params$sendSuccessMessageToUser(
-  user_email = params$email,
-  pgx_name = ds_name,
-  path_to_creds = gmail_creds
-)
+# ds_name <- paste0("<b>", params$name, "</b>")
+# gmail_creds <- file.path(params$ETC, "gmail_creds")
+
+# params$sendSuccessMessageToUser(
+#   user_email = params$email,
+#   pgx_name = ds_name,
+#   path_to_creds = gmail_creds
+# )
 
 message("[compute PGX process] : process finished, pgx is saved as", pgx_name, "\n")

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1124,6 +1124,14 @@ upload_module_computepgx_server <- function(
               if (!auth$email == "") {
                 gmail_creds <- file.path(ETC, "gmail_creds")
                 ds_name <- paste0("<b>", PROCESS_LIST[[i]]$dataset_name, "</b>")
+                # We now send success message to user from the shiny app,
+                # because the process only runs if the app is alive, so
+                # there is no need to send the message from the process.
+                sendSuccessMessageToUser(
+                  user_email = auth$email,
+                  pgx_name = ds_name,
+                  path_to_creds = gmail_creds
+                )
               }
               raw_dir(NULL)
             } else {


### PR DESCRIPTION
Move the email sender outside of processx, it seems under very particular circumstances it crashes for no reason. By placing the email sender on "main" thread it always sends it successfully. 

Given our deploy architecture, if the user closes the tab, the processx also dies, so it makes no sense anymore in either case to send the email from there.