### PR TITLE
Fix #1649: Label type should follow global selection in LASAGNA multipartite graph and table

### DIFF
--- a/components/board.mofa/R/plot_lasagna_partite.R
+++ b/components/board.mofa/R/plot_lasagna_partite.R
@@ -23,11 +23,7 @@ mofa_plot_lasagna_partite_ui <- function(
     shiny::hr(),
     shiny::sliderInput(ns("xdist"), "Layer spacing:", 0.2, 5, 2, 0.1),
     shiny::hr(),
-    shiny::radioButtons(ns("labeltype"), "Label type:",
-      c("feature", "symbol", "title"),
-      selected = "feature", inline = TRUE
-    ),
-    shiny::checkboxInput(ns("strip_prefix"), "strip prefix", TRUE)
+    shiny::checkboxInput(ns("strip_prefix"), "Strip prefix", TRUE)
   )
 
   PlotModuleUI(
@@ -68,17 +64,10 @@ mofa_plot_lasagna_partite_server <- function(id,
     plot_render <- function() {
       res <- data()
       shiny::req(res)
-      
-      labtype <- input$labeltype
-      if (labtype == "title") {
-        labels <- paste0(
-          pgx$genes[, "gene_title"],
-          " (", pgx$genes[, "symbol"], ")"
-        )
-      } else {
-        labels <- pgx$genes[, labtype] ## user reactive
-      }
-      names(labels) <- rownames(pgx$genes)
+
+      features <- rownames(pgx$genes)
+      labels <- playbase::probe2symbol(features, pgx$genes, "gene_name", fill_na = TRUE)
+      names(labels) <- features
 
       graph <- res$graph
       layers <- setdiff(res$layers, c("SOURCE", "SINK"))

--- a/components/board.mofa/R/table_lasagna_multipartite_data.R
+++ b/components/board.mofa/R/table_lasagna_multipartite_data.R
@@ -8,18 +8,12 @@ lasagna_multipartite_nodes_table_ui <- function(id,
 
   ns <- shiny::NS(id)
 
-  options <- shiny::tagList(
-    shiny::radioButtons(ns("labeltype"), "Label type:",
-      c("feature", "symbol", "title"), selected = "feature", inline = TRUE)
-  )
-
   TableModuleUI(
     ns("table"),
     info.text = info.text,
     width = width,    
     height = height,
     title = title,
-    options = options,
     caption = caption,
     label = label
   )
@@ -90,15 +84,8 @@ lasagna_multipartite_nodes_table_server <- function(id,
         ff0 <- ff0[-hh]
       }
 
-      if (input$labeltype == "feature") ff <- c(ff0, phenos)
-      jj <- match(ff0, pgx$genes$feature)
-      if (input$labeltype == "symbol") {
-        ff <- c(pgx$genes$symbol[jj], phenos)
-      } else if (input$labeltype == "title") {
-        ff <- c(pgx$genes$gene_title[jj], phenos)
-      }      
-      nas <- which(is.na(ff))
-      if (any(nas)) ff[nas] <- rownames(dt)[nas]
+      labels <- playbase::probe2symbol(ff0, pgx$genes, "gene_name", fill_na = TRUE)
+      ff <- c(labels, phenos)
       dt$label <- ff
       
       DTable <- DT::datatable(


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1649

Use global selector "gene_name"