### PR TITLE
Fix #1644: when using 'symbol' as label prefix needed in wgcna heatmap

### DIFF
--- a/components/board.wgcna/R/wgcna_plot_gene_heatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_gene_heatmap.R
@@ -68,9 +68,12 @@ wgcna_plot_gene_heatmap_server <- function(id,
 
       df <- pgx$X[pp, , drop = FALSE]
       shiny::validate(shiny::need(nrow(df) > 1, "Geneset should contain at least two genes to plot a heatmap."))
-      rownames(df) <- playbase::probe2symbol(rownames(df), pgx$genes, "gene_name", fill_na = TRUE)
+      if (playbase::is.multiomics(rownames(pgx$X))) {
+        rownames(df) <- playbase::probe2symbol(rownames(df), pgx$genes, "gene_name", fill_na = TRUE, add_datatype = TRUE)
+      } else {
+        rownames(df) <- playbase::probe2symbol(rownames(df), pgx$genes, "gene_name", fill_na = TRUE)
+      }
 
-      # pgx <- pgx.load("~/Playground/omicsplayground/data/multi-liver2.pgx")
       sel <- input$pheno
       shiny::req(sel)
       annot <- pgx$samples[, sel, drop = FALSE]


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1644

When doing the "tranlation" use the new option `add_datatype` for multiomics data only. This requires https://github.com/bigomics/playbase/pull/407