### PR TITLE
Fix PCA dimension error in clustering heatmap

### DIFF
--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -476,7 +476,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       ## create matrix
       grp.zx <- NULL
       if (topmode == "pca") {
-        NPCA <- 5
+        NPCA <- min(5, ncol(zx) - 1)
         svdres <- irlba::irlba(zx - rowMeans(zx, na.rm = TRUE), nv = NPCA)
         ntop <- 12
         ntop <- as.integer(input$hm_ntop) / NPCA


### PR DESCRIPTION
From husbpot tickets

Prevents `irlba::irlba()` from failing when the filtered matrix has fewer samples than the requested number of principal components (5).

Previously, NPCA was hardcoded to 5, which caused errors for small datasets or heavily filtered sample selections. Now uses `min(5, ncol(zx) - 1)` to ensure the SVD computation always has valid dimensions.