### PR TITLE
feat: move decision to display remove button to the server part

### DIFF
--- a/components/board.loading/R/loading_table_datasets_public.R
+++ b/components/board.loading/R/loading_table_datasets_public.R
@@ -39,12 +39,16 @@ loading_table_datasets_public_ui <- function(
         icon = icon("file-import"),
         class = "btn btn-primary"
       ),
+      ## Always render delete button but hidden initially.
+      ## Server-side will control visibility based on user options.
       if (delete_button) {
-        shiny::actionButton(
-          ns("deletebutton"),
-          label = "Delete dataset",
-          icon = icon("trash"),
-          class = "btn btn-danger"
+        shinyjs::hidden(
+          shiny::actionButton(
+            ns("deletebutton"),
+            label = "Delete dataset",
+            icon = icon("trash"),
+            class = "btn btn-danger"
+          )
         )
       }
     )
@@ -58,6 +62,18 @@ loading_table_datasets_public_server <- function(id,
                                                  reload_pgxdir,
                                                  loadAndActivatePGX = NULL) {
   moduleServer(id, function(input, output, session) {
+    ## Control delete button visibility based on per-user options
+    observeEvent(auth$logged, {
+      if (!is.null(auth$logged) && auth$logged) {
+        enable_delete <- isTRUE(auth$options$ENABLE_PUBLIC_DELETE)
+        if (enable_delete) {
+          shinyjs::show("deletebutton")
+        } else {
+          shinyjs::hide("deletebutton")
+        }
+      }
+    })
+
     getPGXINFO_PUBLIC <- shiny::reactive({
       shiny::req(auth$logged)
       if (is.null(auth$logged) || !auth$logged) {

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -105,7 +105,7 @@ LoadingUI <- function(id) {
           height = c("100%", 700),
           width = c("100%", "100%"),
           load_button = opt$ENABLE_PUBLIC_LOAD,
-          delete_button = opt$ENABLE_PUBLIC_DELETE
+          delete_button = TRUE
         ),
         loading_tsne_ui(
           ns("tsne_public"),


### PR DESCRIPTION
Before we were setting button display on UI load, which is before user login, so even a particular user had the option enabled, it did not change. 

now we hide by default and then on server we display if user has the correct setting