### PR TITLE
feat: change histogram colors

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -451,7 +451,7 @@ upload_module_normalization_server <- function(
           if (input$missing_plottype == "heatmap") {
             if (any(X2 > 0)) {
               par(mar = c(3, 3, 2, 2), mgp = c(2.5, 0.85, 0))
-              playbase::gx.imagemap(X2, cex = -1)
+              playbase::gx.imagemap(X2, cex = -1, col = rev(heat.colors(64)))
               title("missing values patterns", cex.main = 1.2)
             } else {
               plot.new()


### PR DESCRIPTION
Issue found thanks to an Axel provided dataset with just 1 missing value, heatmap was ALL red so it revealed the problem.

red should mean missing, white not missing. this makes it like that
