### PR TITLE
feat: properly control data upload at login stage

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -225,30 +225,30 @@ app_server <- function(input, output, session) {
   )
 
   ## Modules needed from the start
-  if (opt$ENABLE_UPLOAD) {
-    upload_datatype <- UploadBoard(
-      id = "upload",
-      pgx_dir = PGX.DIR,
-      pgx = PGX,
-      auth = auth,
-      reload_pgxdir = reload_pgxdir,
-      load_uploaded_data = load_uploaded_data,
-      recompute_pgx = recompute_pgx,
-      inactivityCounter = inactivityCounter,
-      new_upload = new_upload
-    )
+  ## NOTE: UploadBoard is always loaded to allow per-user ENABLE_UPLOAD options
+  ## The upload tab visibility is controlled after login based on user/global options
+  upload_datatype <- UploadBoard(
+    id = "upload",
+    pgx_dir = PGX.DIR,
+    pgx = PGX,
+    auth = auth,
+    reload_pgxdir = reload_pgxdir,
+    load_uploaded_data = load_uploaded_data,
+    recompute_pgx = recompute_pgx,
+    inactivityCounter = inactivityCounter,
+    new_upload = new_upload
+  )
 
 
-    shiny::observeEvent(upload_datatype(), {
-      if (grepl("proteomics", upload_datatype(), ignore.case = TRUE)) {
-        shiny.i18n::update_lang("proteomics", session)
-      } else if (tolower(upload_datatype()) == "metabolomics") {
-        shiny.i18n::update_lang("metabolomics", session)
-      } else {
-        shiny.i18n::update_lang("RNA-seq", session)
-      }
-    })
-  }
+  shiny::observeEvent(upload_datatype(), {
+    if (grepl("proteomics", upload_datatype(), ignore.case = TRUE)) {
+      shiny.i18n::update_lang("proteomics", session)
+    } else if (tolower(upload_datatype()) == "metabolomics") {
+      shiny.i18n::update_lang("metabolomics", session)
+    } else {
+      shiny.i18n::update_lang("RNA-seq", session)
+    }
+  })
 
   ## Modules needed after dataset is loaded (deferred) --------------
   observeEvent(env$load$is_data_loaded(), {
@@ -1097,9 +1097,20 @@ app_server <- function(input, output, session) {
       message("-------------------------------")
 
       pgx.record_access(auth$email, action = "login", session = session)
+
+      ## Show/hide upload tab based on user-specific or global ENABLE_UPLOAD option
+      ## User option takes precedence over global option if set
+      enable_upload <- auth$options$ENABLE_UPLOAD
+      if (is.null(enable_upload)) {
+        enable_upload <- opt$ENABLE_UPLOAD
+      }
+      bigdash.toggleMenuItem(session, "upload-tab", isTRUE(enable_upload))
+      dbg("[SERVER] ENABLE_UPLOAD for user = ", enable_upload)
     } else {
       ## clear PGX data as soon as the user logs out
       clearPGX()
+      ## Hide upload tab when logged out (will be re-evaluated on next login)
+      bigdash.hideMenuItem(session, "upload-tab")
     }
   })
 

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -1041,6 +1041,11 @@ UploadBoard <- function(id,
     shiny::observeEvent(
       list(new_upload()),
       {
+        # skip upload trigger at first startup (must be first check!)
+        if (new_upload() == 0) {
+          return(NULL)
+        }
+
         shiny::req(auth$options)
         enable_upload <- auth$options$ENABLE_UPLOAD
         if (!enable_upload) {
@@ -1071,11 +1076,6 @@ UploadBoard <- function(id,
 
         reset_upload_text_input(reset_upload_text_input() + 1)
         wizardR::reset("upload_wizard")
-
-        # skip upload trigger at first startup
-        if (new_upload() == 0) {
-          return(NULL)
-        }
 
         if (input$selected_organism == "No organism") {
           shinyalert::shinyalert(


### PR DESCRIPTION
For enterprise deploy:

Per-user `ENABLE_UPLOAD` option now works independently of the deploy setting. Previously, if disabled at deploy level, users couldn't upload even with the option enabled in their profile