### PR TITLE
feat: remove metadata filters, they are too messy

### DIFF
--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -137,15 +137,6 @@ loading_table_datasets_server <- function(id,
           filters <- filters & (df$datatype %in% input$flt_datatype)
         }
 
-        ## Apply dynamic metadata filters (columns with metadata_ prefix)
-        metadata_cols <- grep("^metadata_", colnames(df), value = TRUE)
-        for (mcol in metadata_cols) {
-          filter_id <- paste0("flt_", mcol)
-          if (notnull(input[[filter_id]])) {
-            filters <- filters & (df[[mcol]] %in% input[[filter_id]])
-          }
-        }
-
         df <- df[which(filters), , drop = FALSE]
         df$date <- as.Date(df$date, format = "%Y-%m-%d")
         df <- df[order(df$date, decreasing = TRUE), ]


### PR DESCRIPTION
When adding the metadata feature, I included it as a filter for the datasets loading page.

I realized it can be very crowded and bad, so I prefer removing it and making it better in the future if required.

## Before
<img width="660" height="1040" alt="image" src="https://github.com/user-attachments/assets/e2b641b1-153a-4949-a730-2c6c9c2f0ba0" />

## Clean (after)
<img width="676" height="390" alt="image" src="https://github.com/user-attachments/assets/086ff00e-4a96-4e8d-b8c7-256d2cb5fa38" />
