### PR TITLE
Expand Olink Proteomics metadata

### DIFF
--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -260,7 +260,7 @@ upload_table_preview_counts_server <- function(id,
                       ns("counts_csv"),
                       shiny::h4(tspan("Upload counts.csv", js = FALSE), class = "mb-0"),
                       multiple = FALSE,
-                      accept = c(".csv"),
+                      accept = if (upload_datatype() == "proteomics" && is.olink()) c(".csv", ".parquet") else c(".csv"),
                       width = "100%"
                     )
                   }

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -166,7 +166,7 @@ upload_table_preview_samples_server <- function(
       bslib::card(fileInputArea(ns("metadata_csv"),
           shiny::h4("Expand Olink metadata: upload an additional file (.csv)", class = "mb-0"),
           multiple = FALSE, accept = c(".csv"), width = "100%"),
-        style = "background-color: lightyellow; border: 0.07rem dashed goldenrod;")
+        style = "background-color: #fffef5; border: 0.07rem dashed goldenrod;")
     })
 
     samples_options <- shiny::reactive({

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -475,7 +475,7 @@ upload_table_preview_samples_server <- function(
         shinyalert::shinyalert(
           title = "Samples mismatch.",
           text = "The newly uploaded sample file contains a different set of samples than the current metadata. We will intersect these.",
-          type = "error"
+          type = "warning"
         )
         samples <- samples[cm, ]
         new_samples <- new_samples[cm, ]

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -212,7 +212,7 @@ upload_table_preview_samples_server <- function(
       action_buttons <- div(
         style = "display: flex; justify-content: left; margin-bottom: 8px;",
         div(
-          if (loaded_samples()) {
+          if (loaded_samples() && !is.olink()) {
             shiny::actionButton(
               ns("remove_samples"),
               "Cancel",

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -462,7 +462,7 @@ upload_table_preview_samples_server <- function(
       }
       samples <- uploaded$samples.csv
       shiny::req(samples)
-      cm <- intersect(rownames(samples), rownames(new_samples))
+      cm <- intersect(as.character(rownames(samples)), as.character(rownames(new_samples)))
       if (length(cm) == 0) {
         shinyalert::shinyalert(
           title = "No matching samples.",
@@ -470,6 +470,15 @@ upload_table_preview_samples_server <- function(
           type = "error"
         )
         return()
+      }
+      if ((length(cm) != nrow(samples)) | (length(cm) != nrow(new_samples))) {
+        shinyalert::shinyalert(
+          title = "Samples mismatch.",
+          text = "The newly uploaded sample file contains a different set of samples than the current metadata. We will intersect these.",
+          type = "error"
+        )
+        samples <- samples[cm, ]
+        new_samples <- new_samples[cm, ]
       }
       new_cols <- setdiff(colnames(new_samples), colnames(samples))
       if (length(new_cols) > 0) {

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -1279,6 +1279,7 @@ UploadBoard <- function(id,
       info.text = "This is the uploaded samples data.",
       caption = "This is the uploaded samples data.",
       upload_datatype = upload_datatype,
+      is.olink = is.olink,
       public_dataset_id = public_dataset_id ## accession ID
     )
 


### PR DESCRIPTION
For Olink Proteomics, sample matrix is automatically produced from Olink NPX csv or parquet file. As per client request, new metadata are often required as either collected separately or not present in existing parquet NPX profiles. This PR addresses this request. It adds new button to expand Olink Proteomics metadata: add new variables. The requirement for uploading the new sample file is same to current: samples' order needs to match sample's order of current sample and new columns must be present. 