### PR TITLE
feat: add pgx argument to board.launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,10 @@ push.version:
 	docker push bigomics/omicsplayground:$(VERSION)
 
 auth=none
+pgx=
 
 board.launch:
-	R -e "options(board = '$(board)', authentication = '$(auth)'); shiny::runApp('dev/board.launch')"
+	R -e "options(board = '$(board)', pgx_file = '$(if $(pgx),$(realpath $(pgx)),)', authentication = '$(auth)'); shiny::runApp('dev/board.launch')"
 
 board.example:
 	R -e "options(board = '$(board)', use_example_data = TRUE, authentication = '$(auth)'); shiny::runApp('dev/board.launch')"

--- a/dev/board.launch/ui.R
+++ b/dev/board.launch/ui.R
@@ -10,8 +10,11 @@ app_ui <- function() {
     # handle pgx file input
     pgx_file <- ""
 
-    if(!is.null(use_example_data) && use_example_data == TRUE){
-        pgx_file <- file.path(OPG,"data/example-data.pgx")
+    pgx_file_opt <- options()$pgx_file
+    if (!is.null(pgx_file_opt) && nchar(pgx_file_opt) > 0) {
+        pgx_file <- pgx_file_opt
+    } else if (!is.null(use_example_data) && use_example_data == TRUE) {
+        pgx_file <- file.path(OPG, "data/example-data.pgx")
     }
 
     # handle board inputs and dependencies


### PR DESCRIPTION
Add pgx file argument to make board.launch.

Usage example: make board.launch board=dataview pgx=data/my-dataset.pgx                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                        
No impact on board.example or snapshot tests. 