### PR TITLE
feat: add priority flag to HubSpot crash tickets

### DIFF
--- a/components/app/R/utils/utils.R
+++ b/components/app/R/utils/utils.R
@@ -184,7 +184,7 @@ sever_disconnected <- function() {
   sever_crash(error = NULL)
 }
 
-sendErrorLogToCustomerSuport <- function(user_email, pgx_name, raw_dir, error, path_to_creds = "hubspot_creds") {
+sendErrorLogToCustomerSuport <- function(user_email, pgx_name, raw_dir, error, path_to_creds = "hubspot_creds", full_app_crash = FALSE) {
   if (!file.exists(path_to_creds)) {
     message("[sendErrorMessageToCustomerSuport] WARNING : ticket not opened. cannot get credential =", path_to_creds)
     return(NULL)
@@ -209,6 +209,8 @@ sendErrorLogToCustomerSuport <- function(user_email, pgx_name, raw_dir, error, p
           {error}"
   )
 
+  subject <- if (full_app_crash) "PRIORITY: Full App Crash Ticket" else "Simple Error Ticket"
+
   # Define the payload
   payload <- list(
     fields = list(
@@ -220,7 +222,7 @@ sendErrorLogToCustomerSuport <- function(user_email, pgx_name, raw_dir, error, p
       list(
         objectTypeId = "0-5",
         name = "subject",
-        value = "Blue Screen Crash Ticket"
+        value = subject
       ),
       list(
         objectTypeId = "0-5",


### PR DESCRIPTION
  - Add `full_app_crash` parameter to `sendErrorLogToCustomerSuport` to distinguish full app crashes from simple errors in HubSpot tickets
  - When `full_app_crash = TRUE`, the ticket subject is prefixed with "PRIORITY:"
  - Default is `FALSE`, no breaking change to existing call sites

Use `shiny::onUnhandledError(function(err) {` and `inherits(error, "shiny.error.fatal")` to detect if its a simple red error or shiny application completely crashed.

For reference: https://github.com/rstudio/shiny/pull/3993