### PR TITLE
Fix custom bar ordering in expression plot

### DIFF
--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -174,8 +174,8 @@ dataview_plot_expression_server <- function(id,
             df$group <- reorder(df$group, -df$x)
           } else if (input$bars_order == "custom" && !is.null(input$rank_list_basic) &&
             all(input$rank_list_basic %in% unique(data$group))) {
-            data$group <- factor(data$group, levels = valid_ranks)
-            df$group <- factor(df$group, levels = valid_ranks)
+            data$group <- factor(data$group, levels = input$rank_list_basic)
+            df$group <- factor(df$group, levels = input$rank_list_basic)
           }
         }
 


### PR DESCRIPTION
Fix undefined `valid_ranks` variable in `dataview_plot_expression.R` that caused custom bar ordering to break when using grouped data

example data -> dataview -> protein abundance group by time, open editor and set custom order

## Before
<img width="1658" height="1064" alt="image" src="https://github.com/user-attachments/assets/59753bba-8852-4c80-be7e-49e5cd49bef7" />

## After
<img width="1880" height="1570" alt="image" src="https://github.com/user-attachments/assets/6acc18ad-1959-4eae-a7eb-5f6496c9e178" />
