### PR TITLE
Remove parallel plot from OPG

### DIFF
--- a/components/board.clustering/R/clustering_plot_table_parcoord.R
+++ b/components/board.clustering/R/clustering_plot_table_parcoord.R
@@ -4,50 +4,6 @@
 ##
 
 
-## Annotate clusters ############
-
-clustering_plot_parcoord_ui <- function(
-  id,
-  label = "",
-  title,
-  info.text,
-  info.methods,
-  info.references,
-  info.extra_link,
-  caption,
-  height,
-  width
-) {
-  ns <- shiny::NS(id)
-
-  parcoord_opts <- shiny::tagList(
-    withTooltip(
-      shiny::checkboxInput(ns("hm_pcaverage"), tspan("Average by gene module"), FALSE),
-      "Average gene by gene module"
-    ),
-    withTooltip(
-      shiny::checkboxInput(ns("hm_pcscale"), "Scale values", TRUE),
-      "Scale expression values to mean=0 and SD=1."
-    )
-  )
-
-  PlotModuleUI(
-    ns("pltmod"),
-    title = title,
-    label = label,
-    plotlib = "plotly",
-    info.text = info.text,
-    info.methods = info.methods,
-    info.references = info.references,
-    info.extra_link = info.extra_link,
-    caption = caption,
-    options = parcoord_opts,
-    download.fmt = c("png", "pdf", "csv", "svg"),
-    width = width,
-    height = height
-  )
-}
-
 clustering_table_parcoord_ui <- function(
   id,
   label = "",
@@ -77,36 +33,6 @@ clustering_plot_table_parcoord_server <- function(id,
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    parcoord.ranges <- shiny::reactiveValues()
-
-    shiny::observeEvent(plotly::event_data("plotly_restyle", source = "pcoords"), {
-      ## From: https://rdrr.io/cran/plotly/src/inst/examples/shiny/event_data_parcoords/app.R
-      d <- plotly::event_data("plotly_restyle", source = "pcoords")
-      ## what is the relevant dimension (i.e. variable)?
-      dimension <- as.numeric(stringr::str_extract(names(d[[1]]), "[0-9]+"))
-      ## If the restyle isn't related to a dimension, exit early.
-      if (!length(dimension)) {
-        return()
-      }
-      if (is.na(dimension)) {
-        return()
-      }
-
-      pc <- parcoord.matrix()
-      shiny::req(pc)
-      ## careful of the indexing in JS (0) versus R (1)!
-      dimension_name <- colnames(pc$mat)[[dimension + 1]]
-      ## a given dimension can have multiple selected ranges
-      ## these will come in as 3D arrays, but a list of vectors
-      ## is nicer to work with
-      info <- d[[1]][[1]]
-      if (length(dim(info)) == 3) {
-        parcoord.ranges[[dimension_name]] <- lapply(seq_len(dim(info)[2]), function(i) info[, i, ])
-      } else {
-        parcoord.ranges[[dimension_name]] <- list(as.numeric(info))
-      }
-    })
-
     parcoord.matrix <- shiny::reactive({
       filt <- getTopMatrix()
       shiny::req(filt)
@@ -115,114 +41,13 @@ clustering_plot_table_parcoord_server <- function(id,
         ncol(zx) > 1,
         "Filter is too restrictive. Please change 'Filter samples:'."
       ))
-      if (input$hm_pcscale) {
-        zx <- t(scale(t(zx)))
-      }
-      if (input$hm_pcaverage) {
-        idx <- filt$idx
-        zx.mean <- tapply(1:nrow(zx), idx, function(ii) colMeans(zx[c(ii, ii), ]))
-        zx <- do.call(rbind, zx.mean)
-        rownames(zx) <- names(zx.mean)
-        filt$idx <- names(zx.mean)
-      }
-      rr <- shiny::isolate(shiny::reactiveValuesToList(parcoord.ranges))
-      nrange <- length(rr)
-      for (i in names(rr)) parcoord.ranges[[i]] <- NULL
+      zx <- t(scale(t(zx)))
       zx <- round(zx, digits = 4)
       list(mat = zx, clust = filt$idx)
     })
 
-    parcoord.selected <- shiny::reactive({
-      mat <- parcoord.matrix()$mat
-      clust <- parcoord.matrix()$clust
-      shiny::req(mat)
-      keep <- TRUE
-      for (i in names(parcoord.ranges)) {
-        range_ <- parcoord.ranges[[i]]
-        range_ <- range_[sapply(range_, length) > 0]
-        if (length(range_) > 0) {
-          keep_var <- FALSE
-          for (j in seq_along(range_)) {
-            rng <- range_[[j]]
-            keep_var <- keep_var | dplyr::between(mat[, i], min(rng), max(rng))
-          }
-          keep <- (keep & keep_var)
-        }
-      }
-      list(mat = mat[keep, , drop = FALSE], clust = clust[keep])
-    })
-
-    plot_data <- function() {
-      parcoord.matrix()
-    }
-
-    parcoord.RENDER <- function() {
-      pc <- plot_data()
-      zx <- pc$mat
-      ## build dimensions
-      dimensions <- list()
-      for (i in 1:ncol(zx)) {
-        dimensions[[i]] <- list(
-          range = c(min(zx[, i]), max(zx[, i])),
-          visible = TRUE,
-          label = colnames(zx)[i],
-          values = zx[, i]
-        )
-      }
-
-      clust.id <- as.integer(factor(pc$clust))
-      table(clust.id)
-
-      df <- data.frame(clust.id = clust.id, zx)
-      klrpal <- rep(omics_pal_d("light")(8), 99)
-      klrpal <- klrpal[1:max(clust.id)]
-      klrpal2 <- lapply(1:length(klrpal), function(i) c((i - 1) / (length(klrpal) - 1), klrpal[i]))
-
-      plt <- plotly::plot_ly(df, source = "pcoords") %>%
-        plotly::add_trace(
-          type = "parcoords",
-          line = list(
-            color = ~clust.id,
-            colorscale = klrpal2,
-            cmin = min(clust.id),
-            cmax = max(clust.id),
-            showscale = FALSE,
-            width = 10
-          ),
-          dimensions = dimensions
-        )
-      plt <- plt %>%
-        plotly::layout(margin = list(l = 60, r = 60, t = 0, b = 30)) %>%
-        plotly::config(toImageButtonOptions = list(
-          format = "svg",
-          width = 900, height = 350, scale = 1.2
-        )) %>%
-        plotly::config(displaylogo = FALSE) %>%
-        plotly::event_register("plotly_restyle")
-
-      plt
-    }
-
-    parcoord.RENDER_MODAL <- function() {
-      parcoord.RENDER() %>%
-        plotly_modal_default()
-    }
-
-    PlotModuleServer(
-      "pltmod",
-      plotlib = "plotly",
-      func = parcoord.RENDER,
-      func2 = parcoord.RENDER_MODAL,
-      csvFunc = plot_data,
-      res = c(90, 170),
-      pdf.width = 8,
-      pdf.height = 8,
-      add.watermark = watermark
-    )
-
-    ## Table ------------------------------------------------------------------
     parcoord_table.RENDER <- function() {
-      parcoord <- parcoord.selected()
+      parcoord <- parcoord.matrix()
 
       mat <- parcoord$mat
       clust <- parcoord$clust

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -756,18 +756,18 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       parent = ns
     )
 
-    clustering_plot_table_parcoord_server(
-      id = "parcoord",
-      getTopMatrix = getTopMatrixGrouped,
-      pgx = pgx,
-      watermark = WATERMARK
-    )
+    # clustering_plot_table_parcoord_server(
+    #   id = "parcoord",
+    #   getTopMatrix = getTopMatrixGrouped,
+    #   pgx = pgx,
+    #   watermark = WATERMARK
+    # )
 
-    clustering_plot_genemodule_server(
-      id = "genemodule",
-      getTopMatrix = getTopMatrixGrouped,
-      watermark = WATERMARK
-    )
+    # clustering_plot_genemodule_server(
+    #   id = "genemodule",
+    #   getTopMatrix = getTopMatrixGrouped,
+    #   watermark = WATERMARK
+    # )
 
     clustering_plot_phenoplot_server(
       id = "clust_phenoplot",

--- a/components/board.clustering/R/clustering_ui.R
+++ b/components/board.clustering/R/clustering_ui.R
@@ -291,35 +291,16 @@ ClusteringUI <- function(id) {
           height = fullH,
           bs_alert(parallel_info),
           bslib::layout_columns(
-            col_widths = c(8, 4),
-            bslib::layout_columns(
-              col_widths = 12,
-              clustering_plot_parcoord_ui(
-                id = ns("parcoord"),
-                title = "Parallel coordinates",
-                info.text = "Control the scale of the values from the options. Also, there is the possibility of averaging by gene module. Arrange the experimental conditions by click&dragging their names on the x-axis. Highlight genes by click and dragging on any y-axis.",
-                info.methods = "Expression levels of selected genes across all conditions in the analysis. On the x-axis the experimental conditions are plotted. The y-axis shows the expression level of the genes grouped by condition. The colors correspond to the gene groups as defined by the hierarchical clustering (performed using the fastcluster R package [1]).",
-                info.references = list(
-                  list(
-                    "Müllner D (2013). “fastcluster: Fast Hierarchical, Agglomerative Clustering Routines for R and Python.” Journal of Statistical Software, 53(9), 1–18.",
-                    "https://doi.org/10.18637/jss.v053.i09"
-                  )
-                ),
-                info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#clustering",
-                caption = "The interactive Parallel Coordinates plot displays the expression levels of selected genes across all conditions.",
-                label = "a",
-                width = c("100%", "100%"),
-                height = c("100%", TABLE_HEIGHT_MODAL)
-              ),
-              clustering_table_parcoord_ui(
-                id = ns("parcoord"),
-                title = "Selected genes",
-                info.text = "Expression levels of selected genes across all conditions in the analysis. The selection of genes is performed on the Parallel coordinates plot by click & dragging on any y-axis. If not selection is performed on the plot, all the genes are displayed.",
-                caption = "Table showing the expression in each sample of the  genes displayed in the Parallel Coordinates.",
-                label = "a",
-                width = c("100%", "100%"),
-                height = c("100%", TABLE_HEIGHT_MODAL)
-              )
+            col_widths = c(6, 6),
+            height = fullH,
+            clustering_table_parcoord_ui(
+              id = ns("parcoord"),
+              title = "Features and modules",
+              info.text = "Expression levels of selected genes across all conditions in the analysis. The selection of genes is performed on the Parallel coordinates plot by click & dragging on any y-axis. If not selection is performed on the plot, all the genes are displayed.",
+              caption = "Table showing the expression in each sample of the  genes displayed in the Parallel Coordinates.",
+              label = "a",
+              width = c("100%", "100%"),
+              height = c("100%", TABLE_HEIGHT_MODAL)
             ),
             clustering_plot_genemodule_ui(
               id = ns("genemodule"),
@@ -343,3 +324,4 @@ ClusteringUI <- function(id) {
     )
   )
 }
+  

--- a/components/board.clustering/R/clustering_ui.R
+++ b/components/board.clustering/R/clustering_ui.R
@@ -284,43 +284,43 @@ ClusteringUI <- function(id) {
           )
         )
       ),
-      shiny::tabPanel(
-        "Parallel",
-        bslib::layout_columns(
-          col_widths = 12,
-          height = fullH,
-          bs_alert(parallel_info),
-          bslib::layout_columns(
-            col_widths = c(6, 6),
-            height = fullH,
-            clustering_table_parcoord_ui(
-              id = ns("parcoord"),
-              title = "Features and modules",
-              info.text = "Expression levels of selected genes across all conditions in the analysis. The selection of genes is performed on the Parallel coordinates plot by click & dragging on any y-axis. If not selection is performed on the plot, all the genes are displayed.",
-              caption = "Table showing the expression in each sample of the  genes displayed in the Parallel Coordinates.",
-              label = "a",
-              width = c("100%", "100%"),
-              height = c("100%", TABLE_HEIGHT_MODAL)
-            ),
-            clustering_plot_genemodule_ui(
-              id = ns("genemodule"),
-              title = "Module expression",
-              info.text = "Series of histograms displaying the overall expression of each module by individual sample.",
-              info.methods = "The modules are computed using the fastcluster R package [1].",
-              info.references = list(
-                list(
-                  "Müllner D (2013). “fastcluster: Fast Hierarchical, Agglomerative Clustering Routines for R and Python.” Journal of Statistical Software, 53(9), 1–18.",
-                  "https://doi.org/10.18637/jss.v053.i09"
-                )
-              ),
-              info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#clustering",
-              caption = "",
-              width = c("100%", "100%"),
-              height = c("calc(100vh - 200px)", TABLE_HEIGHT_MODAL)
-            )
-          )
-        )
-      )
+      # shiny::tabPanel(
+      #   "Parallel",
+      #   bslib::layout_columns(
+      #     col_widths = 12,
+      #     height = fullH,
+      #     bs_alert(parallel_info),
+      #     bslib::layout_columns(
+      #       col_widths = c(6, 6),
+      #       height = fullH,
+      #       clustering_table_parcoord_ui(
+      #         id = ns("parcoord"),
+      #         title = "Features and modules",
+      #         info.text = "Expression levels of selected genes across all conditions in the analysis. The selection of genes is performed on the Parallel coordinates plot by click & dragging on any y-axis. If not selection is performed on the plot, all the genes are displayed.",
+      #         caption = "Table showing the expression in each sample of the  genes displayed in the Parallel Coordinates.",
+      #         label = "a",
+      #         width = c("100%", "100%"),
+      #         height = c("100%", TABLE_HEIGHT_MODAL)
+      #       ),
+      #       clustering_plot_genemodule_ui(
+      #         id = ns("genemodule"),
+      #         title = "Module expression",
+      #         info.text = "Series of histograms displaying the overall expression of each module by individual sample.",
+      #         info.methods = "The modules are computed using the fastcluster R package [1].",
+      #         info.references = list(
+      #           list(
+      #             "Müllner D (2013). “fastcluster: Fast Hierarchical, Agglomerative Clustering Routines for R and Python.” Journal of Statistical Software, 53(9), 1–18.",
+      #             "https://doi.org/10.18637/jss.v053.i09"
+      #           )
+      #         ),
+      #         info.extra_link = "https://omicsplayground.readthedocs.io/en/latest/methods/#clustering",
+      #         caption = "",
+      #         width = c("100%", "100%"),
+      #         height = c("calc(100vh - 200px)", TABLE_HEIGHT_MODAL)
+      #       )
+      #     )
+      #   )
+      # )
     )
   )
 }


### PR DESCRIPTION
Toward cleaner platform. This PR entirely removes the Parallel coordinates plot from OPG.  Very confusing and largely unused. Also suggested by AM based on user-heard experiences. We rely on time-series for similar things.