### PR TITLE
Defer copilot initialization to modal open

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -711,7 +711,7 @@ app_server <- function(input, output, session) {
     }
     return(ui)
   })
-  CopilotServer("copilot", pgx=PGX, input.click = reactive(input$copilot_click),
+  CopilotServer("copilot", pgx=PGX, input.click = reactive({ req(input$copilot_click > 0); input$copilot_click }),
     layout="fixed", maxturns=opt$LLM_MAXTURNS)
 
   ## count the number of times a navtab is clicked during the session

--- a/components/modules/CopilotModule.R
+++ b/components/modules/CopilotModule.R
@@ -150,9 +150,9 @@ CopilotServer <- function(id, pgx, input.click, layout="fixed", maxturns=100) {
 
     })
 
-    ## On new pgx data, reset/create new chatbot
+    ## On modal open or reset, create new chatbot
     observeEvent({
-      list( input$reset, pgx$X )
+      list( input$reset, input.click() )
     }, {
       req( dim(pgx$X) )
       


### PR DESCRIPTION
- Copilot no longer runs `ai.create_report` on every dataset load — only when the user actually opens the modal
- Avoid trigger when the Copilot button is rendered when enabling beta features (from NULL to value 0)