### PR TITLE
feat: skip annotation table for scRNA-seq during computePGX

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1002,7 +1002,11 @@ upload_module_computepgx_server <- function(
         samples <- samplesRT()
         samples <- data.frame(samples, stringsAsFactors = FALSE, check.names = FALSE)
         contrasts <- as.matrix(contrastsRT())
-        annot_table <- annotRT()
+        if (upload_datatype() != "scRNA-seq") {
+          annot_table <- annotRT()
+        } else {
+          annot_table <- NULL
+        }
 
         ## -----------------------------------------------------------
         ## Set statistical methods and run parameters


### PR DESCRIPTION
Fix scRNA-seq upload pipeline

Skip annotation table lookup for scRNA-seq data in computePGX — it's not needed and was causing failures