### PR TITLE
fix: stop sparse GMT row-matching from crashing on multi-hit features

### DIFF
--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -585,7 +585,8 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       if (length(j) == 0) {
         return(NULL)
       } else {
-        gset <- names(which(pgx$GMT[j, ] != 0))
+        gmt_rows <- as.matrix(pgx$GMT[j, , drop = FALSE])
+        gset <- colnames(gmt_rows)[colSums(gmt_rows != 0, na.rm = TRUE) > 0]
         gset <- intersect(gset, rownames(pgx$gsetX))
       }
 


### PR DESCRIPTION
From hubspot tickets, ask me for dataset and instructions via slack to replicate

lookup in diff expr was not robust when a selected feature mapped to multiple `pgx$GMT` rows. (so far only seen this on metabolomics dataset)

- Replaced `which(pgx$GMT[j, ] != 0)` with a matrix-safe path:
- force 2D selection with `drop = FALSE`
- coerce to base matrix
- derive genesets via `colSums(... != 0) > 0`

This was a latent bug, not a dataset specific thing
