### PR TITLE
fix: static splitmap annotations to match dynamic plot logic

### DIFF
--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -208,12 +208,16 @@ clustering_plot_splitmap_server <- function(id,
       if (!input$show_colnames) cex1 <- 0
       show_colnames <- (cex1 > 0)
 
+      annotF <- data.frame(as.list(annot), stringsAsFactors = TRUE, check.names = FALSE)
+      rownames(annotF) <- rownames(annot)
+
       # Select annot to display (user input)
       sel <- selected_phenotypes()
+      sel <- intersect(sel, colnames(annotF))
       if (length(sel) == 0) {
         annot <- NULL
       } else {
-        annot <- annot[, sel, drop = FALSE]
+        annot <- annotF[, sel, drop = FALSE]
       }
 
       if (hm_level() == "gene") {


### PR DESCRIPTION
From hubspot tickets.

Fix is using same logic we have on dynamic plot for the static.

### Before
<img width="1698" height="587" alt="image" src="https://github.com/user-attachments/assets/58940f29-0bbf-4ea3-9817-a6ef9904b1e7" />

### After
<img width="1696" height="597" alt="image" src="https://github.com/user-attachments/assets/c51a3535-6c3f-4241-8db6-b9b3cb990194" />
