### PR TITLE
feat: show meta.p instead of meta.q in enrichment table when "Show p-values" is enabled

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -132,7 +132,7 @@ enrichment_plot_top_enrich_gsets_server <- function(id,
       }
 
       fx.col <- grep("score|fx|fc|sign|NES|logFC", colnames(rpt))[1]
-      qv.col <- grep("meta.q|q$", colnames(rpt))[1]
+      qv.col <- grep("meta.q|meta.p|q$", colnames(rpt))[1]
       fx <- rpt[, fx.col]
       qv <- rpt[, qv.col]
       names(qv) <- names(fx) <- rownames(rpt)

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -252,6 +252,7 @@ EnrichmentBoard <- function(id, pgx,
           rpt <- data.frame(
             logFC = meta.fc[gs],
             meta.q = meta[gs, "qv"],
+            meta.p = meta[gs, "pv"],
             matched.genes = gset.size[gs],
             stars = stars[gs],
             AveExpr0 = AveExpr0[gs],
@@ -263,6 +264,7 @@ EnrichmentBoard <- function(id, pgx,
           rpt <- data.frame(
             logFC = meta.fc[gs],
             meta.q = meta[gs, "qv"],
+            meta.p = meta[gs, "pv"],
             matched.genes = pgx$gset.meta$info[gs, "gset.size"],
             total.genes = pgx$gset.meta$info[gs, "gset.size.raw"],
             fraction.genes.covered = pgx$gset.meta$info[gs, "gset.fraction"],
@@ -331,7 +333,9 @@ EnrichmentBoard <- function(id, pgx,
       }
 
       if (!input$show_pv) {
-        res <- res[, -grep("^p.", colnames(res)), drop = FALSE]
+        res <- res[, -grep("^p.|^meta\\.p$", colnames(res)), drop = FALSE]
+      } else {
+        res <- res[, -grep("^meta\\.q$", colnames(res)), drop = FALSE]
       }
 
       res <- data.frame(res)

--- a/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
+++ b/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
@@ -98,7 +98,8 @@ enrichment_table_enrichment_analysis_server <- function(id,
       if (input$rowgroup) {
         db <- sub(":.*", "", rownames(rpt))
         rpt <- cbind(DB = db, rpt)
-        rpt <- rpt[order(rpt$DB, rpt$meta.q, -abs(rpt$logFC)), ]
+        meta.sig <- if ("meta.q" %in% colnames(rpt)) rpt$meta.q else rpt$meta.p
+        rpt <- rpt[order(rpt$DB, meta.sig, -abs(rpt$logFC)), ]
       }
 
       is.numcol <- sapply(rpt, function(col) is.numeric(col) && !is.integer(col))


### PR DESCRIPTION
This closes #1726 

<img width="957" height="513" alt="image" src="https://github.com/user-attachments/assets/2fcd04f7-eb2b-458e-9ffd-44a3dcccd728" />
