### PR TITLE
Read NULISA data

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -32,6 +32,8 @@ upload_module_computepgx_server <- function(
   upload_name,
   upload_description,
   upload_datatype,
+  is.olink = shiny::reactive(FALSE),
+  is.nulisa = shiny::reactive(FALSE),
   upload_organism,
   upload_gx_methods,
   upload_gset_methods,
@@ -138,6 +140,11 @@ upload_module_computepgx_server <- function(
             "drug connectivity" = "drugs", "wordcloud",
             "experiment similarity" = "connectivity", "WGCNA" = "wgcna"
           )
+        } else if (is.olink() || is.nulisa()) {
+          mm <- c(
+            "drug connectivity" = "drugs",
+            "wordcloud", "experiment similarity" = "connectivity", "WGCNA" = "wgcna"
+          )
         } else {
           mm <- c(
             "celltype deconvolution" = "deconv", "drug connectivity" = "drugs",
@@ -168,6 +175,8 @@ upload_module_computepgx_server <- function(
         ## Default selection based on datatype
         if (grepl("multi-omics", upload_datatype(), ignore.case = TRUE)) {
           mm <- c("wgcna", "mofa")
+        } else if (is.olink() || is.nulisa()) {
+          mm <- c("drugs", "wordcloud", "connectivity", "wgcna")
         } else {
           mm <- c("deconv", "drugs", "wordcloud", "connectivity", "wgcna")
         }

--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -23,6 +23,7 @@ upload_module_normalization_server <- function(
   r_annot,
   upload_datatype,
   is.olink,
+  is.nulisa,
   is.count = FALSE,
   height = 720,
   recompute_pgx = NULL
@@ -59,10 +60,9 @@ upload_module_normalization_server <- function(
         counts[which(is.infinite(counts))] <- NA
 
         ## Olink NPX are passed on up to here unaltered.
-        if (is.olink()) {
-          dbg("[normalization_server:imputedX] Olink NPX Proteomics")
+        if (is.olink() | is.nulisa()) {
+          dbg("[normalization_server:imputedX] Olink NPX or NULISA NPQ Proteomics")
           counts <- 2**counts
-          shiny::updateCheckboxInput(session, "normalize", value = FALSE)
         }
 
         if (any(counts < 0, na.rm = TRUE)) counts <- pmax(counts, 0)
@@ -854,7 +854,7 @@ upload_module_normalization_server <- function(
         }
 
         ## Normalization defaults
-        default_normalize <- TRUE
+        default_normalize <- !(is.olink() || is.nulisa())
         default_norm_method <- 1
         if (!is.null(pgx_settings$norm_method)) {
           if (pgx_settings$norm_method == "skip_normalization") {

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -100,7 +100,7 @@ UploadBoard <- function(id,
         shiny::selectInput(
           ns("proteomics_type"),
           label = "Proteomics type:",
-          choices = c("MS", "Olink NPX"),
+          choices = c("MS", "Olink NPX", "Nulisa NPQ"),
           selected = "MS",
           width = "150px"
         )
@@ -113,6 +113,15 @@ UploadBoard <- function(id,
       req(upload_datatype())
       if (upload_datatype() == "proteomics" && !is.null(input$proteomics_type)) {
         return(input$proteomics_type == "Olink NPX")
+      } else {
+        return(FALSE)
+      }
+    })
+
+    is.nulisa <- shiny::reactive({
+      req(upload_datatype())
+      if (upload_datatype() == "proteomics" && !is.null(input$proteomics_type)) {
+        return(input$proteomics_type == "Nulisa NPQ")
       } else {
         return(FALSE)
       }
@@ -275,7 +284,8 @@ UploadBoard <- function(id,
         write_check_output(res$checks, "COUNTS", raw_dir())
 
         olink <- is.olink()
-        if (olink) {
+        nulisa <- is.nulisa()
+        if (olink || nulisa) {
           checked_for_log(TRUE)
         } else {
           if ("e29" %in% names(res$checks)) {
@@ -295,7 +305,7 @@ UploadBoard <- function(id,
             checked_for_log(TRUE)
           }
         }
-        return(list(res = res, olink = olink))
+        return(list(res = res, olink = olink, nulisa = nulisa))
       }
     )
 
@@ -308,6 +318,7 @@ UploadBoard <- function(id,
         checked <- NULL
         res <- uploaded_counts()$res
         olink <- uploaded_counts()$olink
+        nulisa <- uploaded_counts()$nulisa
         if (is.null(res)) {
           return(list(status = "Missing counts.csv", matrix = NULL))
         }
@@ -323,7 +334,7 @@ UploadBoard <- function(id,
         isConfirmed <- input$logCorrectCounts
         if (is.null(isConfirmed)) isConfirmed <- FALSE
 
-        if (olink) {
+        if (olink || nulisa) {
           res$checks[["e29"]] <- NULL
           check.e29 <- TRUE
         } else {
@@ -340,11 +351,11 @@ UploadBoard <- function(id,
           }
         }
 
-        # For data != Olink NPX, no further negative values allowed (in the linear space).
+        # For data != Olink NPX and != NULISA NPQ, no further negative values allowed (in the linear space).
         # Set any negatives to zero and inform the user. Store value.
         # Olink NPX are passed to upload_module_normalization_server as original. There I get counts.
         negs <- sum(res$df < 0, na.rm = TRUE)
-        if (negs > 0 && !olink) {
+        if (negs > 0 && !olink && !nulisa) {
           res$df <- pmax(res$df, 0)
           ss <- paste(negs, " negative values detected and set to zero. If you wish otherwise, please correct your data manually.")
           shinyalert::shinyalert(title = "Negative values", text = ss, type = "warning")
@@ -1259,6 +1270,7 @@ UploadBoard <- function(id,
       r_annot = shiny::reactive(checked_annot()$matrix),
       upload_datatype = upload_datatype,
       is.olink = is.olink,
+      is.nulisa = is.nulisa,
       is.count = TRUE,
       height = height,
       recompute_pgx = recompute_pgx
@@ -1322,6 +1334,8 @@ UploadBoard <- function(id,
       upload_name = upload_name,
       upload_description = upload_description,
       upload_datatype = upload_datatype,
+      is.olink = is.olink,
+      is.nulisa = is.nulisa,
       upload_organism = upload_organism,
       upload_gx_methods = upload_gx_methods,
       upload_gset_methods = upload_gset_methods,


### PR DESCRIPTION
No need for playbase code. At least for now. Handling in OPG follows similar workflow as Olink NPX. Ask me for test data. If olink or nulisa, normalization off by default. Cell type deconv also disabled.