### PR TITLE
feat: marketing-aligned modals for plan-limit popups

### DIFF
--- a/components/board.loading/R/loading_module_received.R
+++ b/components/board.loading/R/loading_module_received.R
@@ -181,25 +181,32 @@ upload_module_received_server <- function(id,
             return(NULL)
           }
 
-          ## Peek dataset dimensions to check plan limits before accepting.
-          ## Shared dir has no aggregated metadata CSV, so we load the file.
-          pgx_dims <- tryCatch(
-            shiny::withProgress(message = "Checking dataset...", value = 0.5, {
-              pgx_data <- playbase::pgx.load(file_from)
-              list(
-                nsamples = ncol(pgx_data$X),
-                ngenes = nrow(pgx_data$X),
-                datatype = if (!is.null(pgx_data$datatype)) pgx_data$datatype else ""
-              )
-            }),
-            error = function(e) NULL
-          )
+          ## Enforce plan size limits, but skip the check when the sender is a
+          ## CRO so CRO-shared datasets always go through.
+          sender_email <- gsub(".*__from__|__$", "", pgx_name)
+          cro_emails <- get_cro_emails()
+          sender_is_cro <- !is.null(cro_emails) && sender_email %in% cro_emails
 
-          if (!is.null(pgx_dims) && dataset_exceeds_limits(
-            pgx_dims$nsamples, pgx_dims$ngenes, pgx_dims$datatype, auth$options
-          )) {
-            shinyalert_exceeds_plan_limits() ## ui-alerts.R
-            return(NULL)
+          if (!sender_is_cro) {
+            ## Shared dir has no aggregated metadata CSV, so we load the file.
+            pgx_dims <- tryCatch(
+              shiny::withProgress(message = "Checking dataset...", value = 0.5, {
+                pgx_data <- playbase::pgx.load(file_from)
+                list(
+                  nsamples = ncol(pgx_data$X),
+                  ngenes = nrow(pgx_data$X),
+                  datatype = if (!is.null(pgx_data$datatype)) pgx_data$datatype else ""
+                )
+              }),
+              error = function(e) NULL
+            )
+
+            if (!is.null(pgx_dims) && dataset_exceeds_limits(
+              pgx_dims$nsamples, pgx_dims$ngenes, pgx_dims$datatype, auth$options
+            )) {
+              shinyalert_exceeds_plan_limits() ## ui-alerts.R
+              return(NULL)
+            }
           }
 
           ## Rename file to user folder. Some servers do not allow

--- a/components/board.loading/R/loading_module_received.R
+++ b/components/board.loading/R/loading_module_received.R
@@ -181,6 +181,27 @@ upload_module_received_server <- function(id,
             return(NULL)
           }
 
+          ## Peek dataset dimensions to check plan limits before accepting.
+          ## Shared dir has no aggregated metadata CSV, so we load the file.
+          pgx_dims <- tryCatch(
+            shiny::withProgress(message = "Checking dataset...", value = 0.5, {
+              pgx_data <- playbase::pgx.load(file_from)
+              list(
+                nsamples = ncol(pgx_data$X),
+                ngenes = nrow(pgx_data$X),
+                datatype = if (!is.null(pgx_data$datatype)) pgx_data$datatype else ""
+              )
+            }),
+            error = function(e) NULL
+          )
+
+          if (!is.null(pgx_dims) && dataset_exceeds_limits(
+            pgx_dims$nsamples, pgx_dims$ngenes, pgx_dims$datatype, auth$options
+          )) {
+            shinyalert_exceeds_plan_limits() ## ui-alerts.R
+            return(NULL)
+          }
+
           ## Rename file to user folder. Some servers do not allow
           ## "cross-device link" and then we resort to slower copy
           if (!file.rename(file_from, file_to)) {

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -1046,18 +1046,7 @@ loading_table_datasets_server <- function(id,
             inputId = "confirmdelete"
           )
         } else {
-          msg <- paste(
-            "Deleting is disabled.",
-            "Please <a href='https://events.bigomics.ch/upgrade' target='_blank'>",
-            "<b><u>upgrade</u></b></a> your account to enable it."
-          )
-          shinyalert::shinyalert(
-            title = "Oops!",
-            text = HTML(msg),
-            showCancelButton = TRUE,
-            showConfirmButton = FALSE,
-            html = TRUE
-          )
+          shinyalert_delete_without_limits() ## ui-alerts.R
         }
       },
       ignoreNULL = TRUE,

--- a/components/board.loading/R/loading_table_datasets_public.R
+++ b/components/board.loading/R/loading_table_datasets_public.R
@@ -182,7 +182,8 @@ loading_table_datasets_public_server <- function(id,
 
     observeEvent(input$importbutton, {
       selected_row <- pgxtable_public$rows_selected()
-      pgx_name <- pgxtable_public$data()[selected_row, "dataset"]
+      row_data <- pgxtable_public$data()[selected_row, ]
+      pgx_name <- row_data[, "dataset"]
       pgx_file <- file.path(pgx_public_dir, paste0(pgx_name, ".pgx"))
       pgx_path <- auth$user_dir
       new_pgx_file <- file.path(pgx_path, paste0(pgx_name, ".pgx"))
@@ -205,6 +206,19 @@ loading_table_datasets_public_server <- function(id,
           )
         )
         return()
+      }
+
+      cols <- colnames(row_data)
+      get_num <- function(col) {
+        if (col %in% cols) suppressWarnings(as.numeric(row_data[, col])) else NA_real_
+      }
+      nsamples <- get_num("nsamples")
+      ngenes <- get_num("ngenes")
+      if (is.na(ngenes)) ngenes <- get_num("nfeatures")
+      datatype <- if ("datatype" %in% cols) as.character(row_data[, "datatype"]) else ""
+      if (dataset_exceeds_limits(nsamples, ngenes, datatype, auth$options)) {
+        shinyalert_exceeds_plan_limits() ## ui-alerts.R
+        return(NULL)
       }
 
       ## Copy the file from Public folder to user folder

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -384,7 +384,7 @@ upload_module_makecontrast_server <- function(
         }
 
         if (!is.null(rv_contr()) && ncol(rv_contr()) >= auth$options$MAX_COMPARISONS) {
-          shinyalert::shinyalert("ERROR", paste0("You have reached the maximum number of ", auth$options$MAX_COMPARISONS, " comparisons. Please delete some comparisons before adding a new one."))
+          shinyalert_max_contrasts_reached(auth$options$MAX_COMPARISONS, auth$level)
           shiny::updateTextInput(session, "newname", value = "")
           return(NULL)
         }

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -526,12 +526,8 @@ UploadBoard <- function(id,
           if (ncol(checked) > MAXCONTRASTS) {
             status <- paste("ERROR: max", MAXCONTRASTS, "contrasts allowed")
             checked <- NULL
-            # pop up telling user max contrasts reached
-            shinyalert::shinyalert(
-              title = "Maximum contrasts reached",
-              text = paste("You have reached the maximum number of contrasts allowed. Please upload a new contrasts file with a maximum of", MAXCONTRASTS, "contrasts."),
-              type = "error"
-            )
+            # pop up telling user max contrasts reached (ui-alerts.R)
+            shinyalert_max_contrasts_reached(MAXCONTRASTS, auth$level)
           }
         }
 

--- a/components/ui/ui-alerts.R
+++ b/components/ui/ui-alerts.R
@@ -4,11 +4,19 @@
 ##
 
 BIGOMICS_CONTACT_US_URL <- "https://bigomics.ch/contact-us/"
+BIGOMICS_PRICING_URL <- "https://bigomics.ch/pricing/"
 
 contact_us_callback_js <- function() {
   sprintf(
     "function(value) { if (value === true) { window.open('%s', '_blank'); } }",
     BIGOMICS_CONTACT_US_URL
+  )
+}
+
+upgrade_callback_js <- function() {
+  sprintf(
+    "function(value) { if (value === true) { window.open('%s', '_blank'); } }",
+    BIGOMICS_PRICING_URL
   )
 }
 
@@ -60,7 +68,9 @@ shinyalert_storage_full <- function(numpgx = NULL, maxpgx = NULL, user_level = N
       text = shiny::HTML(msg),
       html = TRUE,
       type = "warning",
+      showCancelButton = TRUE,
       confirmButtonText = "Contact us",
+      cancelButtonText = "Cancel",
       confirmButtonCol = "#337ab7",
       callbackJS = contact_us_callback_js()
     )
@@ -107,4 +117,93 @@ shinyalert_max_samples_reached <- function(max_samples,
     text = msg,
     type = "error"
   )
+}
+
+## Check if a dataset's size exceeds the user's plan limits. Mirrors the
+## grey-out logic in loading_table_datasets.R (MAX_GENES, MAX_SAMPLES for
+## non-scRNAseq, multi-omics when ENABLE_MULTIOMICS is off).
+dataset_exceeds_limits <- function(nsamples, ngenes, datatype, opts) {
+  if (is.null(opts)) {
+    return(FALSE)
+  }
+  dt <- as.character(datatype)
+  if (!is.null(opts$MAX_GENES) && !is.na(ngenes) && ngenes > opts$MAX_GENES) {
+    return(TRUE)
+  }
+  if (!is.null(opts$MAX_SAMPLES) && !is.na(nsamples) &&
+    !identical(dt, "scRNAseq") && nsamples > opts$MAX_SAMPLES) {
+    return(TRUE)
+  }
+  if (!isTRUE(opts$ENABLE_MULTIOMICS) && identical(dt, "multi-omics")) {
+    return(TRUE)
+  }
+  FALSE
+}
+
+## Hard-block alert when importing/accepting a dataset that exceeds plan
+## limits. Upgrade button opens the pricing page in a new tab.
+shinyalert_exceeds_plan_limits <- function() {
+  shinyalert::shinyalert(
+    title = "Dataset exceeds plan limits",
+    text = "This dataset can't be imported because it exceeds your plan limits. Upgrade to analyze larger datasets.",
+    type = "warning",
+    showCancelButton = TRUE,
+    confirmButtonText = "Upgrade now",
+    cancelButtonText = "Cancel",
+    confirmButtonCol = "#337ab7",
+    callbackJS = upgrade_callback_js()
+  )
+}
+
+## Shown when delete is disabled (free tier). Paid users delete normally
+## upstream and never see this alert.
+shinyalert_delete_without_limits <- function() {
+  shinyalert::shinyalert(
+    title = "Delete without limits",
+    text = "Running out of space? The free plan limits deletions, but upgrading gives you unlimited control.",
+    type = "warning",
+    showCancelButton = TRUE,
+    confirmButtonText = "Upgrade now",
+    cancelButtonText = "Later",
+    confirmButtonCol = "#337ab7",
+    callbackJS = upgrade_callback_js()
+  )
+}
+
+## user_level: auth$level from AuthenticationModule ("free", "starter", "premium", ...)
+shinyalert_max_contrasts_reached <- function(max_contrasts, user_level = NULL) {
+  x_str <- if (!is.null(max_contrasts) && length(max_contrasts) && !is.na(max_contrasts)) {
+    as.character(max_contrasts)
+  } else {
+    "X"
+  }
+  is_free <- auth_user_level_is_free(user_level)
+  if (is_free) {
+    msg <- paste0(
+      "You have reached the maximum number of contrasts allowed in your free plan. ",
+      "Please upload a new contrasts file with a maximum of ", x_str,
+      " contrasts or upgrade to analyze larger datasets"
+    )
+    shinyalert::shinyalert(
+      title = "Maximum contrasts reached",
+      text = msg,
+      type = "error",
+      showCancelButton = TRUE,
+      confirmButtonText = "Upgrade now",
+      cancelButtonText = "Cancel",
+      confirmButtonCol = "#337ab7",
+      callbackJS = upgrade_callback_js()
+    )
+  } else {
+    msg <- paste0(
+      "You have reached the maximum number of contrasts allowed for your account. ",
+      "Please upload a new contrasts file with a maximum of ", x_str,
+      " contrasts or contact support."
+    )
+    shinyalert_ok_contact_us(
+      title = "Maximum contrasts reached",
+      text = msg,
+      type = "error"
+    )
+  }
 }


### PR DESCRIPTION
  ## Summary
  - Centralizes plan-limit modals in ui-alerts.R with marketing-approved copy
  - Adds Upgrade now CTAs pointing to https://bigomics.ch/pricing
  - Fixes a no-cancel-button trap on the free-tier "storage full" alert
  - Hard-blocks importing/accepting datasets that exceed the user's plan
    size limits (samples/genes/multi-omics), since they wouldn't be analyzable

  Follows the pattern established in #1750.