### PR TITLE
fix: guard against missing cols

### DIFF
--- a/components/board.wgcna/R/wgcna_table_genes.R
+++ b/components/board.wgcna/R/wgcna_table_genes.R
@@ -107,11 +107,11 @@ wgcna_table_genes_server <- function(id,
           deferRender = TRUE,
           columnDefs = list(
             list(
-              targets = c("feature","symbol"),
+              targets = intersect(c("feature", "symbol"), colnames(df)),
               render = DT::JS(js.ellipsis20)
             ),
             list(
-              targets = c("title"),
+              targets = intersect(c("title"), colnames(df)),
               render = DT::JS(js.ellipsis40)
             )
           )


### PR DESCRIPTION
with example-data

symbol col can miss if showall is not selected

### Before
<img width="1915" height="1025" alt="image" src="https://github.com/user-attachments/assets/61b5f6ba-ae4f-4a51-9713-06889d0f1f96" />


### After
<img width="1908" height="1022" alt="image" src="https://github.com/user-attachments/assets/8dc5d6af-d957-4c35-b744-8479db1ae5f8" />
