### PR TITLE
Read Olink in standard csv

### DIFF
--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -666,23 +666,34 @@ upload_table_preview_counts_server <- function(id,
           df.samples <- NULL
           if (upload_datatype() == "proteomics" && is.olink()) {
             df0 <- tryCatch(
+            {
+              playbase::read_Olink_NPX(datafile)
+            },
+            error = function(w) {
+              NULL
+            }
+            )
+            if (!is.null(df0)) {
+              df <- df0[["counts"]]
+              df.samples <- df0[["samples"]]
+            } else {
+              df0 <- tryCatch(
               {
-                playbase::read_Olink_NPX(datafile)
+                playbase::read_counts(datafile)
               },
               error = function(w) {
                 NULL
               }
-            )
+              )
+              if (!is.null(df0)) df <- df0
+            }
             if (is.null(df0)) {
               shinyalert::shinyalert(
                 title = "Error",
-                text = "Your data may not be in Official Olink format. Please check."
+                text = "Your data may not be correctly formatted as either standard abundance.csv or Official Olink format. Please check."
               )
-            } else {
-              df <- df0[["counts"]]
-              df.samples <- df0[["samples"]]
-              rm(df0)
             }
+            rm(df0)
           } else if (upload_datatype() == "proteomics" && !is.olink()) {
             df <- tryCatch(
               {
@@ -749,7 +760,8 @@ upload_table_preview_counts_server <- function(id,
         if (is.null(uploaded$annot.csv)) {
           c1 <- (upload_datatype() != "scRNA-seq")
           c2 <- (!file.ext %in% c("h5", "h5ad", "parquet"))
-          ann.data <- if (c1 & c2) playbase::read_annot(datafile) else NULL
+          olink_loaded <- exists("df.samples", inherits = FALSE) && !is.null(df.samples)
+          ann.data <- if (c1 && c2 && !olink_loaded) playbase::read_annot(datafile) else NULL
           uploaded$annot.csv <- ann.data
         }
       }


### PR DESCRIPTION
Simply allow upload of Olink NPX as standard csv. it covers the rare case where user already pre-converted NPX format to standard csv using their own scripts.