### PR TITLE
fix: match hyperbolic volcano with expr genes table

### DIFF
--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -290,5 +290,10 @@ expression_plot_volcano_server <- function(id,
         download.contrast.name = comp1
       )
     })
+
+    list(
+      cutoff_type = shiny::reactive(input$cutoff_type),
+      hyperbola_k = shiny::reactive(input$hyperbola_k)
+    )
   }) ## end of moduleServer
 }

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -293,7 +293,19 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       if (!is.null(input$gx_showall) && !input$gx_showall) {
         n <- length(tests)
         ## sel <- which(res$stars == playbase::star.symbols(n))
-        if (input$show_pv) {
+        ct <- if (exists("volcano_cutoff")) volcano_cutoff$cutoff_type() else NULL
+        if (!is.null(ct) && ct == "hyperbolic") {
+          ## Match playbase::ggVolcano hyperbola: y uses pval_cap-floored
+          ## meta.p / meta.q on the same scale as the plot.
+          cap <- pval_cap()
+          if (input$show_pv) {
+            y <- -log10(pmax(res$meta.p, cap) + cap)
+          } else {
+            y <- -log10(pmax(res$meta.q, cap) + cap)
+          }
+          k <- volcano_cutoff$hyperbola_k()
+          sel <- which(hyperbolic_significance(res$logFC, y, psig = fdr, lfc = lfc, k = k))
+        } else if (input$show_pv) {
           sel <- which(res$meta.p <= fdr & abs(res$logFC) >= lfc)
         } else {
           sel <- which(res$meta.q <= fdr & abs(res$logFC) >= lfc)
@@ -412,7 +424,7 @@ ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     # Plotting ###
 
     # tab differential expression > Plot ####
-    expression_plot_volcano_server(
+    volcano_cutoff <- expression_plot_volcano_server(
       id = "plots_volcano",
       comp1 = shiny::reactive(input$gx_contrast),
       fdr = shiny::reactive(input$gx_fdr),

--- a/components/ui/ui-EditorHelpers.R
+++ b/components/ui/ui-EditorHelpers.R
@@ -461,6 +461,27 @@ extract_label_settings <- function(input, defaults = list()) {
 }
 
 
+#' Hyperbolic significance mask matching playbase::ggVolcano.
+#'
+#' Returns a logical vector flagging points that lie above the hyperbola
+#' (y - -log10(psig)) * (|fc| - lfc) > k, with |fc| > lfc.
+#'
+#' @param fc Effect size (log2FC) vector.
+#' @param y  Already -log10-transformed significance vector.
+#' @param psig Significance threshold on the original scale (FDR/p).
+#' @param lfc Log fold-change threshold (vertical asymptote).
+#' @param k Hyperbola curvature.
+#' @return Logical vector the same length as \code{fc}.
+hyperbolic_significance <- function(fc, y, psig, lfc, k = 1) {
+  if (is.null(k) || is.na(k)) k <- 1
+  psig_t <- -log10(psig)
+  sig <- (y - psig_t) * (abs(fc) - lfc) > k
+  sig[abs(fc) <= lfc] <- FALSE
+  sig[is.na(sig)] <- FALSE
+  sig
+}
+
+
 ## ---------------------------------------------------------------
 ## 6. Custom palette UI helpers
 ## ---------------------------------------------------------------


### PR DESCRIPTION
from client feedback

when using the "hyperbolic" volcano plot, the table does not match

note the difference in table dimensions:

### before
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/a0fbf33e-0a4b-42f5-82d4-a09d796f680f" />


### after
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/ae9eb7c2-2dd7-48f4-9769-3a4f62b84d4c" />
