### PR TITLE
fix: copilot reload/new-chat   reliability + AI report auto-gen

### DIFF
--- a/components/app_copilot/R/CopilotBoardServer.R
+++ b/components/app_copilot/R/CopilotBoardServer.R
@@ -185,6 +185,8 @@ CopilotBoardServer <- function(
       # adds dataset_path to the notification_sink payload). p$name_arg
       # is the raw LLM input — could be a basename — and must not be
       # stored as a locator path or restore will fail to re-load.
+      # apply_dataset() funnels pgx_val through copilot_normalize_pgx()
+      # internally — no need to snapshot here.
       run_ctrl$apply_dataset(
         pgx_val  = p$pgx,
         name     = p$dataset_name,
@@ -194,17 +196,16 @@ CopilotBoardServer <- function(
       pgx_loaded_event(NULL)
     }, ignoreNULL = TRUE)
 
-    # Source 2: global PGX from other boards. Materialise reactiveValues into
-    # a plain list with class "pgx" — tools run outside the reactive domain
-    # and downstream package code expects a plain list.
+    # Source 2: global PGX from other boards. apply_dataset() funnels
+    # pgx_val through copilot_normalize_pgx(), which handles the
+    # reactiveValues -> classed list snapshot. We pass `pgx` directly
+    # so there's only one snapshot site.
     shiny::observeEvent(pgx$name, {
       shiny::req(pgx$name, !is.null(pgx$X))
       if (!is.null(restore_inflight())) return()
-      snapshot <- shiny::reactiveValuesToList(pgx)
-      class(snapshot) <- unique(c("pgx", class(snapshot)))
       run_ctrl$apply_dataset(
-        pgx_val  = snapshot,
-        name     = as.character(pgx$name[[1]]),
+        pgx_val  = pgx,
+        name     = as.character(shiny::isolate(pgx$name)[[1]]),
         path     = NULL,
         data_dir = pgx_dir
       )

--- a/components/app_copilot/R/CopilotBoardUI.R
+++ b/components/app_copilot/R/CopilotBoardUI.R
@@ -23,29 +23,26 @@ CopilotBoardUI <- function(id) {
       col_widths = 12,
       row_heights = c(2,1),
       bslib::card(
-        height = "calc(100% - 40px)",        
-        bslib::layout_columns(
-          col_widths = 12,
-          row_heights = c(1,NA),
-          bslib::navset_underline(
-            #bslib::nav_panel("Datasets", CopilotDatasetsUI(ns("datasets"))),
-            bslib::nav_panel("Dataset",            
-              shiny::uiOutput(ns("dataset_info"))
-            ),
-            bslib::nav_panel("Settings",
-              CopilotChatSettings(ns("chat"))
-            ),
-            bslib::nav_panel("History",
-              CopilotHistoryUI(ns("history"))
-            )
+        height = "calc(100% - 40px)",
+        shiny::actionButton(
+          ns("new_chat"),
+          label = "New chat",
+          icon  = shiny::icon("plus"),
+          class = "btn-sm btn-outline-secondary w-100",
+          style = "margin-bottom: 8px;"
+        ),
+        bslib::navset_underline(
+          #bslib::nav_panel("Datasets", CopilotDatasetsUI(ns("datasets"))),
+          bslib::nav_panel("Dataset",
+            shiny::uiOutput(ns("dataset_info"))
           ),
-          shiny::actionButton(
-            ns("new_chat"),
-            label = "New chat",
-            icon  = shiny::icon("plus"),
-            class = "btn-sm btn-outline-secondary w-100"
+          bslib::nav_panel("Settings",
+            CopilotChatSettings(ns("chat"))
+          ),
+          bslib::nav_panel("History",
+            CopilotHistoryUI(ns("history"))
           )
-        ),        
+        )
       ),
       bslib::card(
         bslib::navset_underline(

--- a/components/app_copilot/R/CopilotChatServer.R
+++ b/components/app_copilot/R/CopilotChatServer.R
@@ -202,6 +202,13 @@ CopilotChatServer <- function(
         },
         replay = {
           records <- event$records %||% list()
+          # Atomic clear+replay: the restore controller sets clear_first
+          # so the "Restoring…" placeholder is dropped in the same observer
+          # firing as the records append. A separate `clear` event would
+          # coalesce with this one at the reactiveVal layer and be lost.
+          if (isTRUE(event$clear_first)) {
+            shinychat::chat_clear("chat")
+          }
           # Prefer content_text_visible (no injected preamble) so the user
           # sees only what they typed on replay; fall back to content_text
           # for records saved before omicsagentovi 0.5.0 added the split.

--- a/components/app_copilot/R/copilot_pgx_normalize.R
+++ b/components/app_copilot/R/copilot_pgx_normalize.R
@@ -1,0 +1,76 @@
+# copilot_pgx_normalize.R — Centralised PGX normaliser
+#
+# Single funnel that every code path uses to convert whatever pgx-like
+# value it has (NULL, reactiveValues, plain list, classed pgx list) into
+# a value that satisfies omicspgx::.pgx_check() — i.e. a plain list with
+# class c("pgx", "list") — or NULL when no data is available.
+#
+# Why this exists
+# ---------------
+# The chat board receives PGX from three sources:
+#   1. Global `pgx` reactiveValues observer (CopilotBoardServer.R)
+#   2. `pgx_loaded_event` from the manage_pgx tool (omicsagentovi)
+#   3. The currently-loaded agent's `@context@pgx` slot
+#   4. The restore controller, reading the global pgx at restore time
+#
+# Historically each site re-implemented the snapshot+class stamp by hand,
+# and at least one (the restore controller) forgot — leaking the bare
+# reactiveValues into agent@context@pgx and tripping .pgx_check() with
+# "got 'reactivevalues'" on the next omicspgx call (e.g. after clicking
+# "+ New chat" the freshly rebuilt agent inherited the dirty pgx).
+#
+# Funnelling every site through copilot_normalize_pgx() guarantees:
+#   - reactiveValues are isolated + snapshot-listed exactly once
+#   - the class stamp is always applied
+#   - one place to add tracing or extra coercions
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+#' Normalise a pgx-shaped value into a classed pgx list
+#'
+#' Accepts `NULL`, a `shiny::reactiveValues`, a plain `list`, or an
+#' already classed `pgx` list. Returns a list with class
+#' `c("pgx", "list")` or `NULL` when the input has no usable payload.
+#'
+#' @param pgx Any pgx-shaped value (or `NULL`).
+#' @param source Character tag identifying the caller. Reserved for future
+#'   tracing; ignored by the current implementation.
+#' @return A classed pgx list, or `NULL`.
+#' @export
+copilot_normalize_pgx <- function(pgx, source = "unknown") {
+  if (is.null(pgx)) return(NULL)
+
+  # reactiveValues -> plain list. Must isolate; reactiveValuesToList()
+  # touches the dependency graph and will explode outside a reactive
+  # consumer (e.g. session$onFlushed callbacks, observer bodies that
+  # already isolated upstream).
+  #
+  # Log every actual coercion: this is supposed to be a fallback for
+  # source-1/2 boundaries that already snapshot, so if the call site is
+  # anything else (e.g. `run_controller/.current_pgx/agent`) we have a
+  # regression somewhere upstream that we want to see in the logs.
+  if (inherits(pgx, "reactivevalues")) {
+    if (exists("log_info", mode = "function")) {
+      log_info("copilot.pgx.normalize_coerce",
+               source = source %||% "unknown")
+    }
+    pgx <- tryCatch(
+      shiny::isolate(shiny::reactiveValuesToList(pgx)),
+      error = function(e) NULL
+    )
+    if (is.null(pgx)) return(NULL)
+  }
+
+  # Sanity: must look like a populated pgx (has $X and $name). Otherwise
+  # treat as "no dataset yet" and return NULL so downstream first-load
+  # guards (apply_dataset, .current_pgx) keep behaving the same way.
+  if (is.null(pgx[["X"]]) || is.null(pgx[["name"]])) return(NULL)
+
+  # Stamp the class. unique() preserves an existing "pgx" tag from inputs
+  # already produced by playbase::pgx.initialize().
+  if (!inherits(pgx, "pgx")) {
+    class(pgx) <- unique(c("pgx", class(pgx)))
+  }
+
+  pgx
+}

--- a/components/app_copilot/R/copilot_restore_controller.R
+++ b/components/app_copilot/R/copilot_restore_controller.R
@@ -39,9 +39,12 @@
   records <- omicsagentovi::session_transcript(agent@session, view = "user")
   # Drop empty-content records (keep filter semantics from Phase 3).
   records <- Filter(function(r) nzchar(r@content_text), records)
-  if (length(records) > 0L) {
-    chat_event(list(type = "replay", records = records))
-  }
+  # Always emit the event (even with zero records) and instruct the chat
+  # module to clear first — this drops the "Restoring…" placeholder line
+  # before the historical messages land. clear_first is consumed by
+  # CopilotChatServer's replay handler in the same observer firing, so
+  # there is no chance of the reactiveVal write coalescing away the clear.
+  chat_event(list(type = "replay", clear_first = TRUE, records = records))
   length(records)
 }
 
@@ -139,14 +142,21 @@ copilot_restore_controller <- function(
   .complete_restore <- function(restored, session_id, restore_mode = "async") {
     if (is.null(restored)) return(invisible(NULL))
 
-    current_pgx <- tryCatch(shiny::isolate(local_pgx()), error = function(e) NULL)
-    # `current_pgx` is typically a reactiveValues-like object; field reads
-    # must also be isolated when this runs outside a reactive consumer
-    # (e.g. the sync fast path firing from session$onFlushed).
+    raw_pgx <- tryCatch(shiny::isolate(local_pgx()), error = function(e) NULL)
+    # Read $name BEFORE normalisation: on a reactiveValues the field
+    # lookup still works, and after normalisation we still want the same
+    # name; doing it here keeps NA-handling symmetric with the old behaviour.
     pgx_name <- tryCatch(
-      shiny::isolate(current_pgx$name),
+      shiny::isolate(raw_pgx$name),
       error = function(e) NA_character_
     )
+
+    # Funnel the global reactiveValues through the centralised normaliser
+    # so agent@context@pgx is ALWAYS a classed list (or NULL). Bypassing
+    # this (as the pre-fix code did) leaks a `reactivevalues` object into
+    # the agent context and trips omicspgx::.pgx_check on the next call.
+    current_pgx <- copilot_normalize_pgx(raw_pgx,
+                                         source = "restore_controller/.complete_restore")
 
     if (!is.null(current_pgx)) {
       restore_status("attaching_dataset")
@@ -229,9 +239,14 @@ copilot_restore_controller <- function(
     # Clear evidence panel if wired (Phase 5)
     if (!is.null(evidence)) evidence$clear()
 
-    # Clear chat and show placeholder via the event bus.
-    chat_event(list(type = "clear"))
-    chat_event(list(type = "post", role = "assistant",
+    # Clear chat AND post placeholder atomically. Two back-to-back writes
+    # to a reactiveVal in the same flush cycle coalesce — only the second
+    # value reaches the observer, which dropped the "clear" and left the
+    # previous chat in place. The `reset` event type bundles clear+post
+    # in a single observer firing (see CopilotChatServer chat_event
+    # handler). Restoring without this is exactly the "appends to current
+    # conversation" bug.
+    chat_event(list(type = "reset", role = "assistant",
                     text = copilot_msg("restore_started")))
 
     has_local_pgx <- !is.null(tryCatch(local_pgx(), error = function(e) NULL))

--- a/components/app_copilot/R/copilot_run_controller.R
+++ b/components/app_copilot/R/copilot_run_controller.R
@@ -132,16 +132,18 @@ copilot_run_controller <- function(
     current <- shiny::isolate(agent())
     if (!is.null(current)) {
       ctx_pgx <- tryCatch(current@context@pgx, error = function(e) NULL)
-      if (!is.null(ctx_pgx)) return(ctx_pgx)
+      if (!is.null(ctx_pgx)) {
+        # Defensive normalisation: if an upstream code path (restore,
+        # legacy plumbing) leaked a reactiveValues into the agent's
+        # context, this is the last line of defence before .pgx_check
+        # blows up on the next omicspgx call.
+        return(copilot_normalize_pgx(ctx_pgx,
+                                     source = "run_controller/.current_pgx/agent"))
+      }
     }
-    has_data <- tryCatch(
-      !is.null(shiny::isolate(pgx$name)) && !is.null(shiny::isolate(pgx$X)),
-      error = function(e) FALSE
-    )
-    if (!isTRUE(has_data)) return(NULL)
-    snapshot <- shiny::reactiveValuesToList(pgx)
-    class(snapshot) <- unique(c("pgx", class(snapshot)))
-    snapshot
+    # Fallback: snapshot the global pgx reactiveValues through the
+    # centralised normaliser.
+    copilot_normalize_pgx(pgx, source = "run_controller/.current_pgx/global")
   }
 
   # ------------------------------------------------------------------------
@@ -412,6 +414,10 @@ copilot_run_controller <- function(
   # apply_dataset — shared dataset-change controller
   # ------------------------------------------------------------------------
   apply_dataset <- function(pgx_val, name, path, data_dir) {
+    # Funnel every caller through the normaliser so a stray reactiveValues
+    # can never reach RunContext / agent_set_pgx.
+    pgx_val <- copilot_normalize_pgx(pgx_val,
+                                     source = "run_controller/apply_dataset")
     if (is.null(pgx_val)) return(invisible(NULL))
 
     current <- shiny::isolate(agent())

--- a/components/app_studio/R/aireport_server.R
+++ b/components/app_studio/R/aireport_server.R
@@ -258,69 +258,78 @@ AiReportServer <- function(id, pgx, save_pgx = NULL) {
 
     
     ##---------------------------------------------------------------
-    ## --------- main observer: generate reports --------------------
+    ## --------- refresh observer: pgx load -------------------------
     ##---------------------------------------------------------------
-    
-    shiny::observeEvent({
-      list(input$generate, pgx$X, pgx$name)
-    }, {
+    ## On dataset change, only refresh the Studio UI from whatever
+    ## reports the pgx already carries. Auto-generation on load is
+    ## owned by LoadingBoard's yes/no prompt
+    ## (board.loading/R/loading_server.R::maybe_offer_ai_reports).
+
+    shiny::observeEvent(list(pgx$X, pgx$name), {
       shiny::req(pgx$X, pgx$name)
-      ##shiny::req(!is.null(input$generate))
-      dbg("[[AiReportServer]] is.null(input$generate)", is.null(input$generate))
-      
-      ## compute reports (if missing)
-      llm_model = "groq:openai/gpt-oss-120b"
-      img_model = "google:gemini-3.1-flash-image-preview"
-      llm_model <- getUserOption(session, "llm_model")
-      img_model <- getUserOption(session, "img_model")      
-      img_model <- NULL
-      if (llm_model=="") llm_model <- NULL
+      dbg("[AiReportServer] pgx load refresh (no auto-generation)")
 
-      has.reports <- playbase::pgx.has_reports(pgx)
-      dbg("[AiReportServer] has.reports = ", has.reports)
-      
-      if (!is.null(llm_model) && llm_model != "") {
-        dbg("[AiReportServer] updating reports using llm = ", llm_model)
-        
-        progress <- shiny::Progress$new()
-        on.exit(progress$close())
-        progress$set(message = "Please wait. Updating AI reports...", value = 0.3)
-
-        pgx_list <- shiny::reactiveValuesToList(pgx)
-        pgx_list <- playbase::pgx.update_reports(
-          pgx_list, force = input$force, llm_model = llm_model, img_model = NULL,
-          select = c("wgcna", "mofa", "cmap", "summary"))
-
-        ## patch report slots back into reactiveValues so other modules
-        ## see the new content without reload
-        shiny::isolate({
-          for (slot in c("report", "wgcna", "wgcna_mox", "mofa", "drugs")) {
-            if (!is.null(pgx_list[[slot]])) pgx[[slot]] <- pgx_list[[slot]]
-          }
-        })
-
-        ## persist to disk if user owns this dataset
-        if (!is.null(save_pgx)) save_pgx(pgx)
-      }
-
-      update_nav(pgx)      
+      update_nav(pgx)
       clear_files()
 
-      rpt_wgcna <- pgx$wgcna$report$report
-      rpt_wgcna2 <- pgx$wgcna_mox$report$report      
-      rpt_mofa <- pgx$mofa$report$report
-      rpt_cmap <- pgx$drugs[[1]]$report$report      
-      rpt_summary <- pgx$report$report
-      
-      updateTextAreaInput(session, "edit_wgcna", value = rpt_wgcna)
-      updateTextAreaInput(session, "edit_wgcna2", value = rpt_wgcna2)
-      updateTextAreaInput(session, "edit_mofa", value = rpt_mofa)
-      updateTextAreaInput(session, "edit_cmap", value = rpt_cmap)
-      updateTextAreaInput(session, "edit_summary", value = rpt_summary)
+      updateTextAreaInput(session, "edit_wgcna",   value = pgx$wgcna$report$report)
+      updateTextAreaInput(session, "edit_wgcna2",  value = pgx$wgcna_mox$report$report)
+      updateTextAreaInput(session, "edit_mofa",    value = pgx$mofa$report$report)
+      updateTextAreaInput(session, "edit_cmap",    value = pgx$drugs[[1]]$report$report)
+      updateTextAreaInput(session, "edit_summary", value = pgx$report$report)
 
       updateCheckboxInput(session, "force", value = FALSE)
-      updateActionButton(session, "generate", label = "Reset reports")      
+      label <- if (isTRUE(playbase::pgx.has_reports(pgx))) "Reset reports" else "Generate reports"
+      updateActionButton(session, "generate", label = label)
     })
+
+    ##---------------------------------------------------------------
+    ## --------- main observer: generate reports --------------------
+    ##---------------------------------------------------------------
+    ## Only the Generate button triggers report computation. PGX
+    ## load is handled by the refresh observer above and must not
+    ## re-enter this path, otherwise we re-introduce the silent
+    ## auto-generation that LoadingBoard's prompt is meant to gate.
+
+    shiny::observeEvent(input$generate, {
+      shiny::req(pgx$X, pgx$name)
+
+      llm_model <- getUserOption(session, "llm_model")
+      if (is.null(llm_model) || llm_model == "") {
+        return(NULL)
+      }
+
+      dbg("[AiReportServer] updating reports using llm = ", llm_model)
+
+      progress <- shiny::Progress$new()
+      on.exit(progress$close())
+      progress$set(message = "Please wait. Updating AI reports...", value = 0.3)
+
+      pgx_list <- shiny::reactiveValuesToList(pgx)
+      pgx_list <- playbase::pgx.update_reports(
+        pgx_list, force = input$force, llm_model = llm_model, img_model = NULL,
+        select = c("wgcna", "mofa", "cmap", "summary"))
+
+      shiny::isolate({
+        for (slot in c("report", "wgcna", "wgcna_mox", "mofa", "drugs")) {
+          if (!is.null(pgx_list[[slot]])) pgx[[slot]] <- pgx_list[[slot]]
+        }
+      })
+
+      if (!is.null(save_pgx)) save_pgx(pgx)
+
+      update_nav(pgx)
+      clear_files()
+
+      updateTextAreaInput(session, "edit_wgcna",   value = pgx$wgcna$report$report)
+      updateTextAreaInput(session, "edit_wgcna2",  value = pgx$wgcna_mox$report$report)
+      updateTextAreaInput(session, "edit_mofa",    value = pgx$mofa$report$report)
+      updateTextAreaInput(session, "edit_cmap",    value = pgx$drugs[[1]]$report$report)
+      updateTextAreaInput(session, "edit_summary", value = pgx$report$report)
+
+      updateCheckboxInput(session, "force", value = FALSE)
+      updateActionButton(session, "generate", label = "Reset reports")
+    }, ignoreInit = TRUE)
     
     ##-------------------------------------------------
     ##------------ other observers --------------------

--- a/tests/testthat/test-copilot-restore-controller.R
+++ b/tests/testthat/test-copilot-restore-controller.R
@@ -16,7 +16,14 @@ if (packageVersion("omicsagentovi") < "0.4.0") {
 }
 
 # ---- Source dependencies ----
-.board_dir <- if (dir.exists("components/board.copilot/R")) {
+# Historical name was `board.copilot`; the live module is `app_copilot`.
+# Prefer the current name and fall back to the legacy one so test fixtures
+# from older branches keep working.
+.board_dir <- if (dir.exists("components/app_copilot/R")) {
+  "components/app_copilot/R"
+} else if (dir.exists("../../components/app_copilot/R")) {
+  "../../components/app_copilot/R"
+} else if (dir.exists("components/board.copilot/R")) {
   "components/board.copilot/R"
 } else {
   "../../components/board.copilot/R"
@@ -26,6 +33,12 @@ source(file.path(.board_dir, "copilot_options.R"),  local = TRUE)
 source(file.path(.board_dir, "copilot_messages.R"), local = TRUE)
 source(file.path(.board_dir, "copilot_logger.R"),   local = TRUE)
 source(file.path(.board_dir, "copilot_bindings.R"),           local = TRUE)
+# Centralised pgx normaliser; the restore controller funnels every
+# leak-prone pgx source through it before handing off to agent_set_pgx.
+source(file.path(.board_dir, "copilot_pgx_normalize.R"),       local = TRUE)
+# Context-block staging providers (current_dataset, future AI report, etc.)
+# are invoked by .complete_restore after agent reconstruction.
+source(file.path(.board_dir, "copilot_context_blocks.R"),      local = TRUE)
 source(file.path(.board_dir, "copilot_restore_controller.R"), local = TRUE)
 
 library(omicsagentovi)
@@ -74,7 +87,12 @@ make_chat_event_capture <- function() {
 # Unit: .replay_transcript — pushes one replay event with filtered records
 # ===========================================================================
 
-test_that(".replay_transcript with 0 records pushes 0 events", {
+test_that(".replay_transcript with 0 records still emits one replay event with clear_first=TRUE", {
+  # Restore-controller invariant: every call to .replay_transcript MUST
+  # emit exactly one replay event, even with zero records, because the
+  # event is what clears the "Restoring…" placeholder from chat. A
+  # separate `clear` event would coalesce with this one at the
+  # reactiveVal layer and be lost — see the "append on restore" bug.
   agent <- make_stub_agent()
   cap <- make_chat_event_capture()
 
@@ -85,7 +103,11 @@ test_that(".replay_transcript with 0 records pushes 0 events", {
 
   n <- .replay_transcript(agent, cap$writer)
   expect_equal(n, 0L)
-  expect_length(cap$events(), 0L)
+  expect_length(cap$events(), 1L)
+  ev <- cap$events()[[1]]
+  expect_equal(ev$type, "replay")
+  expect_true(isTRUE(ev$clear_first))
+  expect_length(ev$records, 0L)
 })
 
 test_that(".replay_transcript with N visible records pushes a single replay event with those records", {
@@ -110,6 +132,7 @@ test_that(".replay_transcript with N visible records pushes a single replay even
 
   ev <- cap$events()[[1]]
   expect_equal(ev$type, "replay")
+  expect_true(isTRUE(ev$clear_first))
   expect_length(ev$records, 3L)
   expect_equal(vapply(ev$records, function(r) r@role, character(1)),
                c("user", "assistant", "user"))
@@ -363,10 +386,13 @@ test_that("start() happy path: chat clear + post events pushed, evidence cleared
       expect_equal(shiny::isolate(restore_inflight()), "test-session-id")
       expect_true(evidence_cleared)
 
-      # At least two events: clear then post
-      expect_true(length(events) >= 2L)
-      expect_equal(events[[1]]$type, "clear")
-      expect_equal(events[[2]]$type, "post")
+      # restore_controller emits a single atomic `reset` event (clear +
+      # placeholder post in one observer firing). Two back-to-back writes
+      # to chat_event would coalesce at the reactiveVal layer and the
+      # `clear` would be lost — that was the "append on restore" bug.
+      expect_true(length(events) >= 1L)
+      expect_equal(events[[1]]$type, "reset")
+      expect_true(nzchar(events[[1]]$text %||% ""))
 
       expect_equal(shiny::isolate(ctrl$status()), "restoring")
     }
@@ -425,17 +451,32 @@ test_that("after task starts with NULL local_pgx: inflight set, status restoring
   )
 })
 
-test_that("after task starts with non-NULL local_pgx: inflight set, status restoring", {
+test_that("non-NULL local_pgx triggers the sync fast path: restore completes inside session$onFlushed", {
+  # Sync fast path contract: when local_pgx is non-NULL, ovi_restore runs
+  # inside session$onFlushed and .complete_restore fires immediately after.
+  # By the time flushReact() returns, the controller has already cleared
+  # restore_inflight and dropped status back to "idle". (The pre-fix
+  # assertion checked the "restoring" mid-state — that only holds in the
+  # async path; for the sync path the right invariant is post-completion.)
   store            <- make_fake_store()
+  restored_agent   <- make_stub_agent()
   agent_rv         <- shiny::reactiveVal(make_stub_agent())
   run_status_rv    <- shiny::reactiveVal("idle")
   restore_inflight <- shiny::reactiveVal(NULL)
   chat_event_rv    <- shiny::reactiveVal(NULL)
-  fake_pgx <- list(name = "test-dataset")
+  # copilot_normalize_pgx now requires both $name and $X to consider a
+  # value a usable PGX — incomplete shapes get treated as "no dataset
+  # yet" and return NULL. Give the fake both fields so agent_set_pgx
+  # actually fires on the sync path.
+  fake_pgx <- list(name = "test-dataset", X = matrix(1, 2, 2))
+  agent_set_pgx_called <- FALSE
 
   local_mocked_bindings(
-    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) make_stub_agent(),
-    agent_set_pgx = function(agent, pgx, ...) agent,
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) restored_agent,
+    agent_set_pgx = function(agent, pgx, ...) {
+      agent_set_pgx_called <<- TRUE
+      agent
+    },
     session_transcript = function(agent_session, view = "user") list(),
     .package = "omicsagentovi"
   )
@@ -462,8 +503,12 @@ test_that("after task starts with non-NULL local_pgx: inflight set, status resto
     expr = {
       ctrl$start("test-session-id")
       session$flushReact()
-      expect_equal(shiny::isolate(restore_inflight()), "test-session-id")
-      expect_equal(shiny::isolate(ctrl$status()), "restoring")
+      # Sync path complete: inflight cleared, status idle, pgx injected,
+      # restored agent committed.
+      expect_null(shiny::isolate(restore_inflight()))
+      expect_equal(shiny::isolate(ctrl$status()), "idle")
+      expect_true(agent_set_pgx_called)
+      expect_identical(shiny::isolate(agent_rv()), restored_agent)
     }
   )
 })
@@ -508,18 +553,28 @@ test_that("failure during start() leaves agent() unchanged (previous_agent prese
   )
 })
 
-test_that("agent_set_pgx throws during injection: restore completes with no-pgx agent, inflight cleared", {
+test_that("agent_set_pgx throws during injection: restore still completes, agent committed without pgx", {
+  # Resilience contract: if agent_set_pgx errors (e.g. omicspgx accessor
+  # blows up on a malformed dataset), .complete_restore must log and
+  # proceed — the rest of the restore (context block staging, transcript
+  # replay) must still land, and the controller must reach idle. We
+  # supply a well-shaped fake_pgx so the normaliser lets it through; the
+  # MOCKED agent_set_pgx is what throws.
   store            <- make_fake_store()
-  original_agent   <- make_stub_agent()
-  agent_rv         <- shiny::reactiveVal(original_agent)
+  restored_agent   <- make_stub_agent()
+  agent_rv         <- shiny::reactiveVal(make_stub_agent())
   run_status_rv    <- shiny::reactiveVal("idle")
   restore_inflight <- shiny::reactiveVal(NULL)
   chat_event_rv    <- shiny::reactiveVal(NULL)
-  fake_pgx <- list(name = "bad-dataset")
+  fake_pgx <- list(name = "bad-dataset", X = matrix(1, 2, 2))
+  set_pgx_attempted <- FALSE
 
   local_mocked_bindings(
-    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) make_stub_agent(),
-    agent_set_pgx = function(agent, pgx, ...) stop("agent_set_pgx: simulated failure"),
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) restored_agent,
+    agent_set_pgx = function(agent, pgx, ...) {
+      set_pgx_attempted <<- TRUE
+      stop("agent_set_pgx: simulated failure")
+    },
     session_transcript = function(agent_session, view = "user") list(),
     .package = "omicsagentovi"
   )
@@ -547,8 +602,13 @@ test_that("agent_set_pgx throws during injection: restore completes with no-pgx 
       ctrl$start("test-session-id")
       session$flushReact()
 
-      expect_equal(shiny::isolate(restore_inflight()), "test-session-id")
-      expect_equal(shiny::isolate(ctrl$status()), "restoring")
+      # Injection was attempted (the normaliser accepted the fake_pgx).
+      expect_true(set_pgx_attempted)
+      # And restoration still completed cleanly — failure of the pgx
+      # inject must not strand inflight or block agent commit.
+      expect_null(shiny::isolate(restore_inflight()))
+      expect_equal(shiny::isolate(ctrl$status()), "idle")
+      expect_identical(shiny::isolate(agent_rv()), restored_agent)
     }
   )
 })


### PR DESCRIPTION
## Summary

- I found three bugs in the Copilot flow: (1) after clicking "+ New chat" the next query crashed with a cryptic .pgx_check "got 'reactivevalues'" error, (2) restoring a saved chat after a reload appended to the current conversation instead of replacing it, and (3) AI reports were silently regenerating on every dataset load, bypassing the LoadingBoard yes/no prompt. He also flagged that the "+ New chat" button was getting visually hidden by the History table.
- Centralised reactiveValues -> classed pgx conversion in copilot_normalize_pgx() at every site handing a pgx to the agent, and coalesced the restore controller's clear+replay into a single event so the transcript actually clears before replay.
- Split the AiReportServer observer so input$generate is the sole auto-gen trigger; pgx changes now only refresh the Studio UI(restores the intent of 8761b55c3).
- Moved the Copilot "+ New chat" button above the Dataset/Settings/History tabset so it

## Test plan

- Load a dataset, run a Copilot query, click "+ New chat", run another query — no pgx-class
   errors.
- Restore a saved session after a reload: transcript replaces (not appends).
- Load a dataset: AI reports do not auto-generate; only the LoadingBoard prompt or Generate button triggers them.
- "+ New chat" visible on all three left-panel tabs regardless of History row count.


## Notes
Requires update in `omicsagentovi`