### PR TITLE
fix(correlation): restore gene-name axis labels in scatter plots

### DIFF
--- a/components/board.correlation/R/correlation_plot_scattercorr.R
+++ b/components/board.correlation/R/correlation_plot_scattercorr.R
@@ -226,7 +226,7 @@ correlation_plot_scattercorr_server <- function(id,
               inherit = FALSE
             )
         }
-        plt %>%
+        plt <- plt %>%
           # Legend
           plotly::layout(
             legend = list(orientation = "h", bgcolor = "transparent"),


### PR DESCRIPTION
this closes #1786 . it reverts back to how the plot looked in the past:

<img width="757" height="886" alt="image" src="https://github.com/user-attachments/assets/c45721df-922b-4af3-869a-84123bb9f1cc" />
