### PR TITLE
chore: bump copyright year to 2026

### DIFF
--- a/.github/workflows/snapshot-test-resources/Dockerfile
+++ b/.github/workflows/snapshot-test-resources/Dockerfile
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 ## Start from base image, update git code and add data

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 BigOmics Analytics OmicsPlaygroud
 
-Copyright (c) 2020-2024 BigOmics Analytics
+Copyright (c) 2020-2026 BigOmics Analytics
 
 This product includes software developed at BigOmics Analytics
 (http://www.bigomics.ch/).

--- a/bin/PARAMS.yml
+++ b/bin/PARAMS.yml
@@ -1,7 +1,7 @@
 ##
 ## Make PGX file from CSV files
 ##
-## (c) 2023 BigOmics Analytics 
+## (c) 2023-2026 BigOmics Analytics 
 ##
 
 # options to compute pgx script

--- a/bin/pgxcreate
+++ b/bin/pgxcreate
@@ -3,7 +3,7 @@
 ##
 ## Make PGX file from CSV files
 ##
-## (c) 2023 BigOmics Analytics 
+## (c) 2023-2026 BigOmics Analytics 
 ##
 
 

--- a/bin/pgxcreate_op.R
+++ b/bin/pgxcreate_op.R
@@ -3,7 +3,7 @@
 ##
 ## Make PGX file from CSV files
 ##
-## (c) 2023 BigOmics Analytics
+## (c) 2023-2026 BigOmics Analytics
 ##
 
 message("[create PGX process] : starting process")

--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 app_ui <- function(x) {

--- a/components/app/R/utils/auth.R
+++ b/components/app/R/utils/auth.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 GOOGLE_BASE_URL <- "https://firestore.googleapis.com/v1/projects"

--- a/components/app/R/utils/utils.R
+++ b/components/app/R/utils/utils.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #########################################################################

--- a/components/app/R/www/playground.css
+++ b/components/app/R/www/playground.css
@@ -1,7 +1,7 @@
 /*
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 */
 

--- a/components/app/R/www/test_trigger.js
+++ b/components/app/R/www/test_trigger.js
@@ -1,7 +1,7 @@
 /*
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 */
 

--- a/components/board.admin/R/admin_module_info.R
+++ b/components/board.admin/R/admin_module_info.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.admin/R/admin_module_status.R
+++ b/components/board.admin/R/admin_module_status.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.admin/R/admin_server.R
+++ b/components/board.admin/R/admin_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.admin/R/admin_table_credentials.R
+++ b/components/board.admin/R/admin_table_credentials.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.admin/R/admin_table_datamanager.R
+++ b/components/board.admin/R/admin_table_datamanager.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.admin/R/admin_table_users.R
+++ b/components/board.admin/R/admin_table_users.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.admin/R/admin_ui.R
+++ b/components/board.admin/R/admin_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.biomarker/R/biomarker_plot_boxplots.R
+++ b/components/board.biomarker/R/biomarker_plot_boxplots.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Boxplots plot UI input function

--- a/components/board.biomarker/R/biomarker_plot_decisiontree.R
+++ b/components/board.biomarker/R/biomarker_plot_decisiontree.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Decisiontree plot UI input function

--- a/components/board.biomarker/R/biomarker_plot_featurerank.R
+++ b/components/board.biomarker/R/biomarker_plot_featurerank.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.biomarker/R/biomarker_plot_heatmap.R
+++ b/components/board.biomarker/R/biomarker_plot_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Heatmap plot UI input function

--- a/components/board.biomarker/R/biomarker_plot_importance.R
+++ b/components/board.biomarker/R/biomarker_plot_importance.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.biomarker/R/biomarker_server.R
+++ b/components/board.biomarker/R/biomarker_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 BiomarkerBoard <- function(id, pgx) {

--- a/components/board.biomarker/R/biomarker_ui.R
+++ b/components/board.biomarker/R/biomarker_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 BiomarkerInputs <- function(id) {

--- a/components/board.clustering/R/clustering_plot_clustannot.R
+++ b/components/board.clustering/R/clustering_plot_clustannot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 clustering_plot_clusterannot_ui <- function(

--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 clustering_plot_clustpca_ui <- function(

--- a/components/board.clustering/R/clustering_plot_genemodule.R
+++ b/components/board.clustering/R/clustering_plot_genemodule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.clustering/R/clustering_plot_phenoplot.R
+++ b/components/board.clustering/R/clustering_plot_phenoplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.clustering/R/clustering_plot_splitmap.R
+++ b/components/board.clustering/R/clustering_plot_splitmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Clustering plot UI input function

--- a/components/board.clustering/R/clustering_plot_table_parcoord.R
+++ b/components/board.clustering/R/clustering_plot_table_parcoord.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.clustering/R/clustering_table_clustannot.R
+++ b/components/board.clustering/R/clustering_table_clustannot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' UI code for table code: expression board

--- a/components/board.clustering/R/clustering_ui.R
+++ b/components/board.clustering/R/clustering_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ClusteringInputs <- function(id) {

--- a/components/board.compare/R/__init.R
+++ b/components/board.compare/R/__init.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MODULE.compare <- list(

--- a/components/board.compare/R/compare_plot_compare1.R
+++ b/components/board.compare/R/compare_plot_compare1.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.compare/R/compare_plot_compare2.R
+++ b/components/board.compare/R/compare_plot_compare2.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.compare/R/compare_plot_cum_fc1.R
+++ b/components/board.compare/R/compare_plot_cum_fc1.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.compare/R/compare_plot_cum_fc2.R
+++ b/components/board.compare/R/compare_plot_cum_fc2.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.compare/R/compare_plot_expression.R
+++ b/components/board.compare/R/compare_plot_expression.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 compare_plot_expression_ui <- function(

--- a/components/board.compare/R/compare_plot_fcfc.R
+++ b/components/board.compare/R/compare_plot_fcfc.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.compare/R/compare_plot_genecorr.R
+++ b/components/board.compare/R/compare_plot_genecorr.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 compare_plot_genecorr_ui <- function(

--- a/components/board.compare/R/compare_server.R
+++ b/components/board.compare/R/compare_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "mini-example")),

--- a/components/board.compare/R/compare_table_corr_score.R
+++ b/components/board.compare/R/compare_table_corr_score.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 compare_table_corr_score_ui <- function(id, width, height) {

--- a/components/board.compare/R/compare_ui.R
+++ b/components/board.compare/R/compare_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 CompareInputs <- function(id) {

--- a/components/board.connectivity/R/connectivity_plot_FCFCplots.R
+++ b/components/board.connectivity/R/connectivity_plot_FCFCplots.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_connectivityHeatmap.R
+++ b/components/board.connectivity/R/connectivity_plot_connectivityHeatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_connectivityMap.R
+++ b/components/board.connectivity/R/connectivity_plot_connectivityMap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_cumEnrichmentPlot.R
+++ b/components/board.connectivity/R/connectivity_plot_cumEnrichmentPlot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_cumFCplot.R
+++ b/components/board.connectivity/R/connectivity_plot_cumFCplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_enrichmentGraph.R
+++ b/components/board.connectivity/R/connectivity_plot_enrichmentGraph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_leadingEdgeGraph.R
+++ b/components/board.connectivity/R/connectivity_plot_leadingEdgeGraph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_plot_scatterPlot.R
+++ b/components/board.connectivity/R/connectivity_plot_scatterPlot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.connectivity/R/connectivity_server.R
+++ b/components/board.connectivity/R/connectivity_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ConnectivityBoard <- function(

--- a/components/board.connectivity/R/connectivity_table_foldchange.R
+++ b/components/board.connectivity/R/connectivity_table_foldchange.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 connectivity_table_foldchange_ui <- function(

--- a/components/board.connectivity/R/connectivity_table_similarity_scores.R
+++ b/components/board.connectivity/R/connectivity_table_similarity_scores.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 connectivity_table_similarity_scores_ui <- function(

--- a/components/board.connectivity/R/connectivity_ui.R
+++ b/components/board.connectivity/R/connectivity_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ConnectivityInputs <- function(id) {

--- a/components/board.correlation/R/correlation_plot_barplot.R
+++ b/components/board.correlation/R/correlation_plot_barplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.correlation/R/correlation_plot_cor_graph.R
+++ b/components/board.correlation/R/correlation_plot_cor_graph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.correlation/R/correlation_plot_correlation_UMAP.R
+++ b/components/board.correlation/R/correlation_plot_correlation_UMAP.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.correlation/R/correlation_plot_scattercorr.R
+++ b/components/board.correlation/R/correlation_plot_scattercorr.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.correlation/R/correlation_server.R
+++ b/components/board.correlation/R/correlation_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 CorrelationBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {

--- a/components/board.correlation/R/correlation_table_corr.R
+++ b/components/board.correlation/R/correlation_table_corr.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.correlation/R/correlation_ui.R
+++ b/components/board.correlation/R/correlation_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 CorrelationInputs <- function(id) {

--- a/components/board.dataview/R/dataview_module_geneinfo.R
+++ b/components/board.dataview/R/dataview_module_geneinfo.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.dataview/R/dataview_plot_abundance.R
+++ b/components/board.dataview/R/dataview_plot_abundance.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_abundance_ui <- function(

--- a/components/board.dataview/R/dataview_plot_averagerank.R
+++ b/components/board.dataview/R/dataview_plot_averagerank.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_averagerank_ui <- function(id,

--- a/components/board.dataview/R/dataview_plot_boxplot.R
+++ b/components/board.dataview/R/dataview_plot_boxplot.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 dataview_plot_boxplot_ui <- function(
   id,

--- a/components/board.dataview/R/dataview_plot_coefficientOfvariation.R
+++ b/components/board.dataview/R/dataview_plot_coefficientOfvariation.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_variationcoefficient_ui <- function(

--- a/components/board.dataview/R/dataview_plot_correlation.R
+++ b/components/board.dataview/R/dataview_plot_correlation.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_correlation_ui <- function(

--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_expression_ui <- function(

--- a/components/board.dataview/R/dataview_plot_histogram.R
+++ b/components/board.dataview/R/dataview_plot_histogram.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_histogram_ui <- function(

--- a/components/board.dataview/R/dataview_plot_phenoassociation.R
+++ b/components/board.dataview/R/dataview_plot_phenoassociation.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_phenoassociation_ui <- function(

--- a/components/board.dataview/R/dataview_plot_phenoheatmap.R
+++ b/components/board.dataview/R/dataview_plot_phenoheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_phenoheatmap_ui <- function(

--- a/components/board.dataview/R/dataview_plot_tissue.R
+++ b/components/board.dataview/R/dataview_plot_tissue.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.dataview/R/dataview_plot_totalcounts.R
+++ b/components/board.dataview/R/dataview_plot_totalcounts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_totalcounts_ui <- function(

--- a/components/board.dataview/R/dataview_plot_tsneplot.R
+++ b/components/board.dataview/R/dataview_plot_tsneplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 dataview_plot_tsne_ui <- function(

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.dataview/R/dataview_table_contrasts.R
+++ b/components/board.dataview/R/dataview_table_contrasts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.dataview/R/dataview_table_rawdata.R
+++ b/components/board.dataview/R/dataview_table_rawdata.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.dataview/R/dataview_table_samples.R
+++ b/components/board.dataview/R/dataview_table_samples.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.dataview/R/dataview_ui.R
+++ b/components/board.dataview/R/dataview_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.drugconnectivity/R/__init.R
+++ b/components/board.drugconnectivity/R/__init.R
@@ -1,6 +1,6 @@
 #
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MODULE.systems <- list(

--- a/components/board.drugconnectivity/R/drugconnectivity_plot_actmap.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_plot_actmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Activation map plot UI input function

--- a/components/board.drugconnectivity/R/drugconnectivity_plot_cmap_dsea.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_plot_cmap_dsea.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Drug Connectivity plot UI input function

--- a/components/board.drugconnectivity/R/drugconnectivity_plot_cmap_enplot.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_plot_cmap_enplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Drug Connectivity plot UI input function

--- a/components/board.drugconnectivity/R/drugconnectivity_plot_enplots.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_plot_enplots.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Drug Connectivity plot UI input function

--- a/components/board.drugconnectivity/R/drugconnectivity_plot_moa.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_plot_moa.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Mechanism-of-action plot UI input function

--- a/components/board.drugconnectivity/R/drugconnectivity_report.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_report.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Mechanism-of-action plot UI input function

--- a/components/board.drugconnectivity/R/drugconnectivity_server.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DrugConnectivityBoard <- function(id, pgx) {

--- a/components/board.drugconnectivity/R/drugconnectivity_table_cmap.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_table_cmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.drugconnectivity/R/drugconnectivity_table_dsea.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_table_dsea.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.drugconnectivity/R/drugconnectivity_ui.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DrugConnectivityInputs <- function(id) {

--- a/components/board.enrichment/R/enrichment_plot_barplot.R
+++ b/components/board.enrichment/R/enrichment_plot_barplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_plot_barplot_ui <- function(

--- a/components/board.enrichment/R/enrichment_plot_compare.R
+++ b/components/board.enrichment/R/enrichment_plot_compare.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_plot_compare_ui <- function(

--- a/components/board.enrichment/R/enrichment_plot_freq_top_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_freq_top_gsets.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_plot_freq_top_gsets_ui <- function(

--- a/components/board.enrichment/R/enrichment_plot_geneplot.R
+++ b/components/board.enrichment/R/enrichment_plot_geneplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.enrichment/R/enrichment_plot_scatter.R
+++ b/components/board.enrichment/R/enrichment_plot_scatter.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
+++ b/components/board.enrichment/R/enrichment_plot_top_enrich_gsets.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_plot_volcano_ui <- function(

--- a/components/board.enrichment/R/enrichment_plot_volcanoall.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanoall.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_plot_volcanoall_ui <- function(

--- a/components/board.enrichment/R/enrichment_plot_volcanomethods.R
+++ b/components/board.enrichment/R/enrichment_plot_volcanomethods.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_plot_volcanomethods_ui <- function(

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 EnrichmentBoard <- function(id, pgx,

--- a/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
+++ b/components/board.enrichment/R/enrichment_table_enrichment_analysis.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_table_enrichment_analysis_ui <- function(

--- a/components/board.enrichment/R/enrichment_table_genes_in_geneset.R
+++ b/components/board.enrichment/R/enrichment_table_genes_in_geneset.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_table_genes_in_geneset_ui <- function(

--- a/components/board.enrichment/R/enrichment_table_gset_enrich_all_contrasts.R
+++ b/components/board.enrichment/R/enrichment_table_gset_enrich_all_contrasts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_table_gset_enrich_all_contrasts_ui <- function(

--- a/components/board.enrichment/R/enrichment_table_n_sig_gsets.R
+++ b/components/board.enrichment/R/enrichment_table_n_sig_gsets.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 enrichment_table_n_sig_gsets_ui <- function(

--- a/components/board.enrichment/R/enrichment_ui.R
+++ b/components/board.enrichment/R/enrichment_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 EnrichmentInputs <- function(id) {

--- a/components/board.epigenomics/R/__init.R
+++ b/components/board.epigenomics/R/__init.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 MODULE.epigenomics <- list(
   module_menu = function() {

--- a/components/board.epigenomics/R/dataview_table_samples.R
+++ b/components/board.epigenomics/R/dataview_table_samples.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 dataview_table_beta_ui <- function(id,
                                    width,

--- a/components/board.epigenomics/R/epigenomics_plot_beta_dist.R
+++ b/components/board.epigenomics/R/epigenomics_plot_beta_dist.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 epigenomics_plot_beta_dist_ui <- function(id,
                                           label = "",

--- a/components/board.epigenomics/R/epigenomics_plot_boxplot_beta.R
+++ b/components/board.epigenomics/R/epigenomics_plot_boxplot_beta.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 epigenomics_plot_boxplot_beta_ui <- function(id,
                                              label = "",

--- a/components/board.epigenomics/R/epigenomics_plot_methylIdeogram.R
+++ b/components/board.epigenomics/R/epigenomics_plot_methylIdeogram.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 epigenomics_plot_methylIdeogram_ui <- function(id,
                                                label = "",

--- a/components/board.epigenomics/R/epigenomics_server.R
+++ b/components/board.epigenomics/R/epigenomics_server.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 EpigenomicsBoard <- function(id, pgx) {
 

--- a/components/board.epigenomics/R/epigenomics_ui.R
+++ b/components/board.epigenomics/R/epigenomics_ui.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 EpigenomicsInputs <- function(id) {
 

--- a/components/board.expression/R/expression_plot_barplot.R
+++ b/components/board.expression/R/expression_plot_barplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_fc_fc.R
+++ b/components/board.expression/R/expression_plot_fc_fc.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_maplot.R
+++ b/components/board.expression/R/expression_plot_maplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_topfoldchange.R
+++ b/components/board.expression/R/expression_plot_topfoldchange.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_topgenes.R
+++ b/components/board.expression/R/expression_plot_topgenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_volcanoAll.R
+++ b/components/board.expression/R/expression_plot_volcanoAll.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_plot_volcanoMethods.R
+++ b/components/board.expression/R/expression_plot_volcanoMethods.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.expression/R/expression_server.R
+++ b/components/board.expression/R/expression_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ExpressionBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {

--- a/components/board.expression/R/expression_table_FDRtable.R
+++ b/components/board.expression/R/expression_table_FDRtable.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' UI code for table code: expression board

--- a/components/board.expression/R/expression_table_fctable.R
+++ b/components/board.expression/R/expression_table_fctable.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' UI code for table code: expression board

--- a/components/board.expression/R/expression_table_genetable.R
+++ b/components/board.expression/R/expression_table_genetable.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' UI code for table code: expression board

--- a/components/board.expression/R/expression_table_gsettable.R
+++ b/components/board.expression/R/expression_table_gsettable.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' UI code for table code: expression board

--- a/components/board.expression/R/expression_ui.R
+++ b/components/board.expression/R/expression_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ExpressionInputs <- function(id) {

--- a/components/board.featuremap/R/featuremap_plot_gene_sig.R
+++ b/components/board.featuremap/R/featuremap_plot_gene_sig.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 featuremap_plot_gene_sig_ui <- function(

--- a/components/board.featuremap/R/featuremap_plot_gset_sig.R
+++ b/components/board.featuremap/R/featuremap_plot_gset_sig.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 featuremap_plot_gset_sig_ui <- function(

--- a/components/board.featuremap/R/featuremap_plot_table_gene_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_gene_map.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 featuremap_plot_gene_map_ui <- function(

--- a/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
+++ b/components/board.featuremap/R/featuremap_plot_table_geneset_map.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 featuremap_plot_geneset_map_ui <- function(

--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 FeatureMapBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {

--- a/components/board.featuremap/R/featuremap_ui.R
+++ b/components/board.featuremap/R/featuremap_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 FeatureMapInputs <- function(id) {

--- a/components/board.intersection/R/intersection_plot_contrast_correlation.R
+++ b/components/board.intersection/R/intersection_plot_contrast_correlation.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 contrast_correlation_ui <- function(

--- a/components/board.intersection/R/intersection_plot_foldchange_heatmap.R
+++ b/components/board.intersection/R/intersection_plot_foldchange_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 foldchange_heatmap_ui <- function(

--- a/components/board.intersection/R/intersection_plot_scatterplot_pairs.R
+++ b/components/board.intersection/R/intersection_plot_scatterplot_pairs.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 intersection_scatterplot_pairs_ui <- function(

--- a/components/board.intersection/R/intersection_plot_table_venn_diagram.R
+++ b/components/board.intersection/R/intersection_plot_table_venn_diagram.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 intersection_plot_venn_diagram_ui <- function(id,

--- a/components/board.intersection/R/intersection_server.R
+++ b/components/board.intersection/R/intersection_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 IntersectionBoard <- function(

--- a/components/board.intersection/R/intersection_ui.R
+++ b/components/board.intersection/R/intersection_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 IntersectionInputs <- function(id) {

--- a/components/board.loading/R/loading_module_received.R
+++ b/components/board.loading/R/loading_module_received.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_module_received_ui <- function(id, height = 720) {

--- a/components/board.loading/R/loading_module_shared.R
+++ b/components/board.loading/R/loading_module_shared.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_module_shared_ui <- function(id, height = 720) {

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 LoadingBoard <- function(id,

--- a/components/board.loading/R/loading_table_datasets.R
+++ b/components/board.loading/R/loading_table_datasets.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 loading_table_datasets_ui <- function(

--- a/components/board.loading/R/loading_table_datasets_public.R
+++ b/components/board.loading/R/loading_table_datasets_public.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 loading_table_datasets_public_ui <- function(

--- a/components/board.loading/R/loading_tsneplot.R
+++ b/components/board.loading/R/loading_tsneplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 loading_tsne_ui <- function(

--- a/components/board.loading/R/loading_ui.R
+++ b/components/board.loading/R/loading_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 downloadButton2 <- function(outputId, label = "Download", class = NULL, ...) {

--- a/components/board.mofa/R/board_deepnet_server.R
+++ b/components/board.mofa/R/board_deepnet_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DeepNetBoard <- function(id, pgx) {

--- a/components/board.mofa/R/board_deepnet_ui.R
+++ b/components/board.mofa/R/board_deepnet_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DeepNetInputs <- function(id) {

--- a/components/board.mofa/R/board_lasagna_server.R
+++ b/components/board.mofa/R/board_lasagna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 LasagnaBoard <- function(id, pgx) {

--- a/components/board.mofa/R/board_lasagna_ui.R
+++ b/components/board.mofa/R/board_lasagna_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 LasagnaInputs <- function(id) {

--- a/components/board.mofa/R/board_mgsea_server.R
+++ b/components/board.mofa/R/board_mgsea_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.mofa/R/board_mgsea_ui.R
+++ b/components/board.mofa/R/board_mgsea_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MGseaInputs <- function(id) {

--- a/components/board.mofa/R/board_mofa_server.R
+++ b/components/board.mofa/R/board_mofa_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.mofa/R/board_mofa_ui.R
+++ b/components/board.mofa/R/board_mofa_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MofaInputs <- function(id) {

--- a/components/board.mofa/R/board_snf_server.R
+++ b/components/board.mofa/R/board_snf_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.mofa/R/board_snf_ui.R
+++ b/components/board.mofa/R/board_snf_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 SNFInputs <- function(id) {

--- a/components/board.mofa/R/plot_boxplots.R
+++ b/components/board.mofa/R/plot_boxplots.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_boxplots_ui <- function(

--- a/components/board.mofa/R/plot_centrality.R
+++ b/components/board.mofa/R/plot_centrality.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_centrality_ui <- function(

--- a/components/board.mofa/R/plot_correlation_network.R
+++ b/components/board.mofa/R/plot_correlation_network.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_correlation_network_ui <- function(

--- a/components/board.mofa/R/plot_covariate.R
+++ b/components/board.mofa/R/plot_covariate.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_covariate_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_aescatter.R
+++ b/components/board.mofa/R/plot_deepnet_aescatter.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_aescatter_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_biomarkerheatmap.R
+++ b/components/board.mofa/R/plot_deepnet_biomarkerheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_biomarkerheatmap_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_clusters.R
+++ b/components/board.mofa/R/plot_deepnet_clusters.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_clusters_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_confusionmatrix.R
+++ b/components/board.mofa/R/plot_deepnet_confusionmatrix.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_confusionmatrix_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_diagram.R
+++ b/components/board.mofa/R/plot_deepnet_diagram.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_diagram_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_gradients.R
+++ b/components/board.mofa/R/plot_deepnet_gradients.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_gradients_ui <- function(

--- a/components/board.mofa/R/plot_deepnet_lossplot.R
+++ b/components/board.mofa/R/plot_deepnet_lossplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 plot_deepnet_lossplot_ui <- function(

--- a/components/board.mofa/R/plot_dendrogram.R
+++ b/components/board.mofa/R/plot_dendrogram.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_dendrogram_ui <- function(

--- a/components/board.mofa/R/plot_dummy.R
+++ b/components/board.mofa/R/plot_dummy.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_dummy_ui <- function(

--- a/components/board.mofa/R/plot_factorcorheatmap.R
+++ b/components/board.mofa/R/plot_factorcorheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_factorcorheatmap_ui <- function(

--- a/components/board.mofa/R/plot_factorgraph.R
+++ b/components/board.mofa/R/plot_factorgraph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_factorgraph_ui <- function(

--- a/components/board.mofa/R/plot_factortrait.R
+++ b/components/board.mofa/R/plot_factortrait.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_factortrait_ui <- function(

--- a/components/board.mofa/R/plot_heatmap.R
+++ b/components/board.mofa/R/plot_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_heatmap_ui <- function(

--- a/components/board.mofa/R/plot_lasagna3D.R
+++ b/components/board.mofa/R/plot_lasagna3D.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_lasagna3D_ui <- function(

--- a/components/board.mofa/R/plot_lasagna_clustering.R
+++ b/components/board.mofa/R/plot_lasagna_clustering.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_lasagna_clustering_ui <- function(id, ...) {

--- a/components/board.mofa/R/plot_lasagna_network.R
+++ b/components/board.mofa/R/plot_lasagna_network.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_lasagna_network_ui <- function(

--- a/components/board.mofa/R/plot_lasagna_partite.R
+++ b/components/board.mofa/R/plot_lasagna_partite.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_lasagna_partite_ui <- function(

--- a/components/board.mofa/R/plot_loadingheatmap.R
+++ b/components/board.mofa/R/plot_loadingheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_loadingheatmap_ui <- function(

--- a/components/board.mofa/R/plot_mgsea.R
+++ b/components/board.mofa/R/plot_mgsea.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_mgsea_ui <- function(

--- a/components/board.mofa/R/plot_mgsea_enrichment.R
+++ b/components/board.mofa/R/plot_mgsea_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mgsea_plot_enrichment_ui <- function(

--- a/components/board.mofa/R/plot_modulegraph.R
+++ b/components/board.mofa/R/plot_modulegraph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_modulegraph_ui <- function(

--- a/components/board.mofa/R/plot_moduleheatmap.R
+++ b/components/board.mofa/R/plot_moduleheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_moduleheatmap_ui <- function(

--- a/components/board.mofa/R/plot_mofa_enrichment.R
+++ b/components/board.mofa/R/plot_mofa_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_enrichment_ui <- function(

--- a/components/board.mofa/R/plot_mofa_pathwayheatmap.R
+++ b/components/board.mofa/R/plot_mofa_pathwayheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_pathwayheatmap_ui <- function(

--- a/components/board.mofa/R/plot_pathbank.R
+++ b/components/board.mofa/R/plot_pathbank.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2022 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.mofa/R/plot_snf.R
+++ b/components/board.mofa/R/plot_snf.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_snf_ui <- function(

--- a/components/board.mofa/R/plot_snf_graph.R
+++ b/components/board.mofa/R/plot_snf_graph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_snfgraph_ui <- function(

--- a/components/board.mofa/R/plot_snf_heatmap.R
+++ b/components/board.mofa/R/plot_snf_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_snf_heatmap_ui <- function(

--- a/components/board.mofa/R/plot_variance.R
+++ b/components/board.mofa/R/plot_variance.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_variance_ui <- function(

--- a/components/board.mofa/R/plot_weights.R
+++ b/components/board.mofa/R/plot_weights.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_plot_weights_ui <- function(

--- a/components/board.mofa/R/report_mofa.R
+++ b/components/board.mofa/R/report_mofa.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Mechanism-of-action plot UI input function

--- a/components/board.mofa/R/table_deepnet.R
+++ b/components/board.mofa/R/table_deepnet.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 table_deepnet_gradients_ui <- function(

--- a/components/board.mofa/R/table_mgsea.R
+++ b/components/board.mofa/R/table_mgsea.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_table_mgsea_ui <- function(

--- a/components/board.mofa/R/table_mofa_enrichmentgenes.R
+++ b/components/board.mofa/R/table_mofa_enrichmentgenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_table_enrichmentgenes_ui <- function(

--- a/components/board.mofa/R/table_mofa_factorenrichment.R
+++ b/components/board.mofa/R/table_mofa_factorenrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_table_factorenrichment_ui <- function(

--- a/components/board.mofa/R/table_mofa_genetable.R
+++ b/components/board.mofa/R/table_mofa_genetable.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 mofa_table_genetable_ui <- function(

--- a/components/board.pathway/R/pathway_enrichmap.R
+++ b/components/board.pathway/R/pathway_enrichmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.pathway/R/pathway_plot_enrichmap.R
+++ b/components/board.pathway/R/pathway_plot_enrichmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2022 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_plot_go_actmap.R
+++ b/components/board.pathway/R/pathway_plot_go_actmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_plot_go_network.R
+++ b/components/board.pathway/R/pathway_plot_go_network.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_plot_reactome_actmap.R
+++ b/components/board.pathway/R/pathway_plot_reactome_actmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_plot_reactome_graph.R
+++ b/components/board.pathway/R/pathway_plot_reactome_graph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2022 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
+++ b/components/board.pathway/R/pathway_plot_wikipathway_actmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_plot_wikipathway_graph.R
+++ b/components/board.pathway/R/pathway_plot_wikipathway_graph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2022 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 #' Importance plot UI input function

--- a/components/board.pathway/R/pathway_server.R
+++ b/components/board.pathway/R/pathway_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 PathwayBoard <- function(id,

--- a/components/board.pathway/R/pathway_table_go_table.R
+++ b/components/board.pathway/R/pathway_table_go_table.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.pathway/R/pathway_table_reactome.R
+++ b/components/board.pathway/R/pathway_table_reactome.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.pathway/R/pathway_table_wikipathway.R
+++ b/components/board.pathway/R/pathway_table_wikipathway.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.pathway/R/pathway_ui.R
+++ b/components/board.pathway/R/pathway_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 PathwayInputs <- function(id) {

--- a/components/board.pcsf/R/pcsf_panel_gene.R
+++ b/components/board.pcsf/R/pcsf_panel_gene.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.pcsf/R/pcsf_panel_geneset.R
+++ b/components/board.pcsf/R/pcsf_panel_geneset.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.pcsf/R/pcsf_server.R
+++ b/components/board.pcsf/R/pcsf_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 PcsfBoard <- function(id, pgx) {

--- a/components/board.pcsf/R/pcsf_ui.R
+++ b/components/board.pcsf/R/pcsf_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 PcsfInputs <- function(id) {

--- a/components/board.pcsf/R/util_pcsf.R
+++ b/components/board.pcsf/R/util_pcsf.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.signature/R/signature_plot_enplots.R
+++ b/components/board.signature/R/signature_plot_enplots.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.signature/R/signature_plot_markers.R
+++ b/components/board.signature/R/signature_plot_markers.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.signature/R/signature_plot_overlap.R
+++ b/components/board.signature/R/signature_plot_overlap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.signature/R/signature_plot_volcano.R
+++ b/components/board.signature/R/signature_plot_volcano.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 SignatureBoard <- function(id, pgx,

--- a/components/board.signature/R/signature_table_enrich_by_contrasts.R
+++ b/components/board.signature/R/signature_table_enrich_by_contrasts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 signature_table_enrich_by_contrasts_ui <- function(

--- a/components/board.signature/R/signature_table_genes_in_signature.R
+++ b/components/board.signature/R/signature_table_genes_in_signature.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 signature_table_genes_in_signature_ui <- function(

--- a/components/board.signature/R/signature_table_overlap.R
+++ b/components/board.signature/R/signature_table_overlap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 signature_table_overlap_ui <- function(

--- a/components/board.signature/R/signature_ui.R
+++ b/components/board.signature/R/signature_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 style0 <- "font-size: 0.9em; color: #24A; background-color: #dde6f0; border-style: none; padding:0; margin-top: -15px;"

--- a/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
+++ b/components/board.singlecell/R/singlecell_plot_crosstabPlot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Single cell plot UI input function

--- a/components/board.singlecell/R/singlecell_plot_cytoplot.R
+++ b/components/board.singlecell/R/singlecell_plot_cytoplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Single cell plot UI input function

--- a/components/board.singlecell/R/singlecell_plot_icpplot.R
+++ b/components/board.singlecell/R/singlecell_plot_icpplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Single cell plot UI input function

--- a/components/board.singlecell/R/singlecell_plot_mappingplot.R
+++ b/components/board.singlecell/R/singlecell_plot_mappingplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Single cell plot UI input function

--- a/components/board.singlecell/R/singlecell_plot_markersplot.R
+++ b/components/board.singlecell/R/singlecell_plot_markersplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Single cell plot UI input function

--- a/components/board.singlecell/R/singlecell_plot_phenoplot.R
+++ b/components/board.singlecell/R/singlecell_plot_phenoplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Single cell plot UI input function

--- a/components/board.singlecell/R/singlecell_server.R
+++ b/components/board.singlecell/R/singlecell_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.singlecell/R/singlecell_ui.R
+++ b/components/board.singlecell/R/singlecell_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 SingleCellInputs <- function(id) {

--- a/components/board.tcga/R/tcga_plot_survival.R
+++ b/components/board.tcga/R/tcga_plot_survival.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.tcga/R/tcga_server.R
+++ b/components/board.tcga/R/tcga_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## DEAN ATTALI code recommendation:

--- a/components/board.tcga/R/tcga_ui.R
+++ b/components/board.tcga/R/tcga_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## DEAN ATTALI code recommendation:

--- a/components/board.timeseries/R/board_server.R
+++ b/components/board.timeseries/R/board_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.timeseries/R/board_ui.R
+++ b/components/board.timeseries/R/board_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 TimeSeriesInputs <- function(id) {

--- a/components/board.timeseries/R/module_clustering.R
+++ b/components/board.timeseries/R/module_clustering.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.timeseries/R/module_features.R
+++ b/components/board.timeseries/R/module_features.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Expression plot UI input function

--- a/components/board.timeseries/R/module_parcoord.R
+++ b/components/board.timeseries/R/module_parcoord.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 TimeSeriesBoard.parcoord_plot_ui <- function(

--- a/components/board.upload/R/upload_module_batchcorrect.R
+++ b/components/board.upload/R/upload_module_batchcorrect.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 upload_module_computepgx_ui <- function(id) {
   ns <- shiny::NS(id)

--- a/components/board.upload/R/upload_module_makecontrast.R
+++ b/components/board.upload/R/upload_module_makecontrast.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_module_makecontrast_ui <- function(id) {

--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 upload_module_normalization_ui <- function(id, height = "100%") {
   ns <- shiny::NS(id)

--- a/components/board.upload/R/upload_module_normalizationSC.R
+++ b/components/board.upload/R/upload_module_normalizationSC.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 upload_module_normalizationSC_ui <- function(id, height = "100%") {
   ns <- shiny::NS(id)

--- a/components/board.upload/R/upload_module_preview_contrasts.R
+++ b/components/board.upload/R/upload_module_preview_contrasts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_table_preview_counts_ui <- function(id) {

--- a/components/board.upload/R/upload_module_preview_samples.R
+++ b/components/board.upload/R/upload_module_preview_samples.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_table_preview_samples_ui <- function(id) {

--- a/components/board.upload/R/upload_plot_contraststats.R
+++ b/components/board.upload/R/upload_plot_contraststats.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_plot_contraststats_ui <- function(id,

--- a/components/board.upload/R/upload_plot_countstats.R
+++ b/components/board.upload/R/upload_plot_countstats.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_plot_countstats_ui <- function(id,

--- a/components/board.upload/R/upload_plot_pcaplot.R
+++ b/components/board.upload/R/upload_plot_pcaplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.upload/R/upload_plot_phenostats.R
+++ b/components/board.upload/R/upload_plot_phenostats.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 upload_plot_phenostats_ui <- function(id,

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -1,5 +1,5 @@
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 
 UploadBoard <- function(id,
                         pgx_dir,

--- a/components/board.upload/R/upload_ui.R
+++ b/components/board.upload/R/upload_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 UploadUI <- function(id) {

--- a/components/board.upload/R/upload_utils.R
+++ b/components/board.upload/R/upload_utils.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.user/R/appsettings_server.R
+++ b/components/board.user/R/appsettings_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 AppSettingsBoard <- function(id, auth, pgx) {

--- a/components/board.user/R/appsettings_ui.R
+++ b/components/board.user/R/appsettings_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 AppSettingsInputs <- function(id) {

--- a/components/board.user/R/user_table_resources.R
+++ b/components/board.user/R/user_table_resources.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.user/R/userprofile_server.R
+++ b/components/board.user/R/userprofile_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 UserProfileBoard <- function(id, auth, nav_count) {

--- a/components/board.user/R/userprofile_ui.R
+++ b/components/board.user/R/userprofile_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 UserProfileUI <- function(id) {

--- a/components/board.wgcna/R/__init.R
+++ b/components/board.wgcna/R/__init.R
@@ -1,6 +1,6 @@
 #
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MODULE.wgcna <- list(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_dendrograms.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_dendrograms.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_dendrograms_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_modulecorr.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_modulecorr.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_modulecorr_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_moduletrait.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_moduletrait.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_moduletrait_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_power.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_power.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_power_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_preservation.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_preservation.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_preservationDendro_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_sampletree.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_sampletree.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_sampletree_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_traitsignificance.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_plot_traitsignificance.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_plot_traitsignificance_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_server.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ConsensusWGCNA_Board <- function(id, pgx) {

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_table_enrichment.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_table_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_table_enrichment_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_table_modulegenes.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_table_modulegenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 consensusWGCNA_table_modulegenes_ui <- function(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_ui.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ConsensusWGCNA_Inputs <- function(id) {

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MultiWGCNA_Board <- function(id, pgx) {

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_ui.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MultiWGCNA_Inputs <- function(id) {

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_plot_dendrograms.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_plot_dendrograms.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_plot_dendrograms_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_plot_lasagna.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_plot_lasagna.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_plot_lasagna_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_plot_modulecorr.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_plot_modulecorr.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_plot_modulecorr_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_plot_moduletrait.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_plot_moduletrait.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_plot_moduletrait_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_plot_power.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_plot_power.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_plot_power_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_table_crossgenes.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_table_crossgenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_table_crossgenes_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_table_enrichment.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_table_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_table_enrichment_ui <- function(

--- a/components/board.wgcna/R/multiwgcna/multiwgcna_table_modulegenes.R
+++ b/components/board.wgcna/R/multiwgcna/multiwgcna_table_modulegenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 multiwgcna_table_modulegenes_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_dendrograms.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_dendrograms.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_dendrograms_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_eigennetwork.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_eigennetwork.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_eigenNetwork_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_modulecorr.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_modulecorr.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_modulecorr_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_modulenetwork.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_modulenetwork.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_modulenetwork_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_moduletrait.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_moduletrait.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_moduletrait_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_overlap.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_overlap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_overlap_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_power.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_power.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_power_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_preservation.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_preservation.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_preservationDendro_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_sampletree.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_sampletree.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_sampletree_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_summaries.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_summaries.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_summaries_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_traitsignificance.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_plot_traitsignificance.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_plot_traitsignificance_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_server.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 PreservationWGCNA_Board <- function(id, pgx) {

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_table_enrichment.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_table_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_table_enrichment_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_table_modulegenes.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_table_modulegenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 preservationWGCNA_table_modulegenes_ui <- function(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_ui.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 PreservationWGCNA_Inputs <- function(id) {

--- a/components/board.wgcna/R/wgcna_html_module_summary.R
+++ b/components/board.wgcna/R/wgcna_html_module_summary.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_html_module_summary_ui <- function(

--- a/components/board.wgcna/R/wgcna_html_report.R
+++ b/components/board.wgcna/R/wgcna_html_report.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_html_report_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_MMvsGS.R
+++ b/components/board.wgcna/R/wgcna_plot_MMvsGS.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_MMvsGS_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_MTrelationships.R
+++ b/components/board.wgcna/R/wgcna_plot_MTrelationships.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_MTrelationships_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_TOMheatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_TOMheatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_TOMheatmap_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_correlation_network.R
+++ b/components/board.wgcna/R/wgcna_plot_correlation_network.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_correlation_network_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_eigengene_clustering.R
+++ b/components/board.wgcna/R/wgcna_plot_eigengene_clustering.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_eigengene_clustering_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_eigengene_heatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_eigengene_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_eigengene_heatmap_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_enrichment.R
+++ b/components/board.wgcna/R/wgcna_plot_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_enrichment_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_gclustering.R
+++ b/components/board.wgcna/R/wgcna_plot_gclustering.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_gclustering_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_gdendogram.R
+++ b/components/board.wgcna/R/wgcna_plot_gdendogram.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_gdendogram_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_gene_heatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_gene_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_gene_heatmap_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_geneset_heatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_geneset_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_geneset_heatmap_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_heatmap_membership.R
+++ b/components/board.wgcna/R/wgcna_plot_heatmap_membership.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_heatmap_membership_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_membership_v_trait.R
+++ b/components/board.wgcna/R/wgcna_plot_membership_v_trait.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_membership_v_trait_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_module_barplot.R
+++ b/components/board.wgcna/R/wgcna_plot_module_barplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_module_barplot_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_module_graph.R
+++ b/components/board.wgcna/R/wgcna_plot_module_graph.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_module_graph_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_module_heatmap.R
+++ b/components/board.wgcna/R/wgcna_plot_module_heatmap.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_module_heatmap_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_module_membership.R
+++ b/components/board.wgcna/R/wgcna_plot_module_membership.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_module_membership_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_module_significance.R
+++ b/components/board.wgcna/R/wgcna_plot_module_significance.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_module_significance_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_s_independence.R
+++ b/components/board.wgcna/R/wgcna_plot_s_independence.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_s_independence_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_sampledendrogram.R
+++ b/components/board.wgcna/R/wgcna_plot_sampledendrogram.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_sampledendrogram_ui <- function(

--- a/components/board.wgcna/R/wgcna_plot_topgenes.R
+++ b/components/board.wgcna/R/wgcna_plot_topgenes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_plot_topgenes_ui <- function(

--- a/components/board.wgcna/R/wgcna_server.R
+++ b/components/board.wgcna/R/wgcna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.wgcna/R/wgcna_table_enrichment.R
+++ b/components/board.wgcna/R/wgcna_table_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_table_enrichment_ui <- function(

--- a/components/board.wgcna/R/wgcna_table_genes.R
+++ b/components/board.wgcna/R/wgcna_table_genes.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_table_genes_ui <- function(

--- a/components/board.wgcna/R/wgcna_ui.R
+++ b/components/board.wgcna/R/wgcna_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 WgcnaInputs <- function(id) {

--- a/components/board.wordcloud/R/wordcloud_plot_enrichment.R
+++ b/components/board.wordcloud/R/wordcloud_plot_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wordcloud_plot_enrichment_ui <- function(

--- a/components/board.wordcloud/R/wordcloud_plot_wordcloud.R
+++ b/components/board.wordcloud/R/wordcloud_plot_wordcloud.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.wordcloud/R/wordcloud_plot_wordtsne.R
+++ b/components/board.wordcloud/R/wordcloud_plot_wordtsne.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wordcloud_plot_wordtsne_ui <- function(

--- a/components/board.wordcloud/R/wordcloud_server.R
+++ b/components/board.wordcloud/R/wordcloud_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 WordCloudBoard <- function(id, pgx) {

--- a/components/board.wordcloud/R/wordcloud_table_enrichment.R
+++ b/components/board.wordcloud/R/wordcloud_table_enrichment.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wordcloud_table_enrichment_ui <- function(

--- a/components/board.wordcloud/R/wordcloud_table_leading_edge.R
+++ b/components/board.wordcloud/R/wordcloud_table_leading_edge.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wordcloud_table_leading_edge_ui <- function(

--- a/components/board.wordcloud/R/wordcloud_ui.R
+++ b/components/board.wordcloud/R/wordcloud_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 WordCloudInputs <- function(id) {

--- a/components/modules/AuthenticationModule.R
+++ b/components/modules/AuthenticationModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 AuthenticationUI <- function(id) {

--- a/components/modules/AuthenticationModule_functions.R
+++ b/components/modules/AuthenticationModule_functions.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/AuthenticationModule_ui.R
+++ b/components/modules/AuthenticationModule_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## ================================================================================

--- a/components/modules/DatasetReport.R
+++ b/components/modules/DatasetReport.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DatasetReportUI <- function(id) {

--- a/components/modules/InfoModals.R
+++ b/components/modules/InfoModals.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/InviteFriend.R
+++ b/components/modules/InviteFriend.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 InviteFriendUI <- function(id) {

--- a/components/modules/NormalizeCountsModule.R
+++ b/components/modules/NormalizeCountsModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/PlotDownloadLogger.R
+++ b/components/modules/PlotDownloadLogger.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/PollModule.R
+++ b/components/modules/PollModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/QuestionWidget.R
+++ b/components/modules/QuestionWidget.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/ReportDownloadLogger.R
+++ b/components/modules/ReportDownloadLogger.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/TimerModule.R
+++ b/components/modules/TimerModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #

--- a/components/modules/UpgradeLogger.R
+++ b/components/modules/UpgradeLogger.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/UpgradeModule.R
+++ b/components/modules/UpgradeModule.R
@@ -1,6 +1,6 @@
 #
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 UpgradeModuleUI <- function(id) {

--- a/components/modules/UserAccessControl.R
+++ b/components/modules/UserAccessControl.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## ACCESS_LOGFILE = file.path(ETC,"access.log")

--- a/components/modules/UsersMapModule.R
+++ b/components/modules/UsersMapModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2020-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 UsersMapInputs <- function(id) {

--- a/components/modules/WelcomeBoard.R
+++ b/components/modules/WelcomeBoard.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 WelcomeBoardInputs <- function(id) {

--- a/components/ui/bs-components.R
+++ b/components/ui/bs-components.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Various Bootstrap goodies.

--- a/components/ui/ui-ColorDefaults.R
+++ b/components/ui/ui-ColorDefaults.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## ---------------------------------------------------------------

--- a/components/ui/ui-DropDownMenu.R
+++ b/components/ui/ui-DropDownMenu.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DropdownMenu <- function(..., size = "default", status = "default", icon = NULL, circle = TRUE, border = "default", width = "") {

--- a/components/ui/ui-EditorContent.R
+++ b/components/ui/ui-EditorContent.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Wrap an editor modal body with a top "Reset to defaults" button and a

--- a/components/ui/ui-EditorHelpers.R
+++ b/components/ui/ui-EditorHelpers.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## ---------------------------------------------------------------

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/ui/ui-TableModule2.R
+++ b/components/ui/ui-TableModule2.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/ui/ui-alerts.R
+++ b/components/ui/ui-alerts.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 BIGOMICS_CONTACT_US_URL <- "https://bigomics.ch/contact-us/"

--- a/components/ui/ui-bigdashplus.R
+++ b/components/ui/ui-bigdashplus.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/ui/ui-boardHeader.R
+++ b/components/ui/ui-boardHeader.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/ui/ui-code.R
+++ b/components/ui/ui-code.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## textInput <- function(inputId, label, value = "") {

--- a/components/ui/ui-colors.R
+++ b/components/ui/ui-colors.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/ui/ui-defaults.R
+++ b/components/ui/ui-defaults.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## From https://github.com/plotly/plotly.js/blob/master/src/components/modebar/buttons.js

--- a/components/ui/ui-links.R
+++ b/components/ui/ui-links.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 tagsub <- function(s) {

--- a/components/ui/ui-modalUI.R
+++ b/components/ui/ui-modalUI.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ui.showSmallModal <- function(msg = "Please wait...", timer = 0) {

--- a/components/ui/ui-startupModal.R
+++ b/components/ui/ui-startupModal.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ui.startupModal <- function(id, messages, title = NULL) {

--- a/components/ui/ui-tooltip.R
+++ b/components/ui/ui-tooltip.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 withTooltip <- function(

--- a/components/ui/ui-utils.R
+++ b/components/ui/ui-utils.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/ui/ui-vizpanels.R
+++ b/components/ui/ui-vizpanels.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/dev/01_start.R
+++ b/dev/01_start.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 # Building a Prod-Ready, Robust Shiny Application.

--- a/dev/02_doc.R
+++ b/dev/02_doc.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 # Building a Prod-Ready, Robust Shiny Application.

--- a/dev/03_cicd.R
+++ b/dev/03_cicd.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 # Building a Prod-Ready, Robust Shiny Application.

--- a/dev/04_deploy.R
+++ b/dev/04_deploy.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 # Building a Prod-Ready, Robust Shiny Application.

--- a/dev/05_run.R
+++ b/dev/05_run.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 # Sass code compilation

--- a/dev/board.launch/global.R
+++ b/dev/board.launch/global.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/dev/board.launch/ui.R
+++ b/dev/board.launch/ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 app_ui <- function() {

--- a/dev/create_source_all.R
+++ b/dev/create_source_all.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/dev/dev-utils.R
+++ b/dev/dev-utils.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##appdir="~/R/golem/omics.app";wd="packages/board1"

--- a/dev/functions.R
+++ b/dev/functions.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 require <- function(pkg) (pkg %in% installed.packages()[,'Package'])

--- a/dev/init_annothub.R
+++ b/dev/init_annothub.R
@@ -3,7 +3,7 @@
 ##
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 if(1) {

--- a/dev/sass.R
+++ b/dev/sass.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 output <- sass::sass(

--- a/dev/write_description.R
+++ b/dev/write_description.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 ## Start from base image, update git code and add data

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 ## Start from base image, update git code and add data

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2020 BigOmics Analytics Sagl. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics Sagl. All rights reserved.
 ##
 
 ## Start from base image, update git code and add data

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 if(requireNamespace('spelling', quietly = TRUE))

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 shinytest2::test_app()

--- a/tools/examples/ex-vizboards.R
+++ b/tools/examples/ex-vizboards.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 library(shiny)

--- a/tools/scripts/pgx-GSE100509-merscov.R
+++ b/tools/scripts/pgx-GSE100509-merscov.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE102908-ibet.R
+++ b/tools/scripts/pgx-GSE102908-ibet.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE10846-dlbcl.R
+++ b/tools/scripts/pgx-GSE10846-dlbcl.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE110496-dengue.R
+++ b/tools/scripts/pgx-GSE110496-dengue.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE114716-ipilimumab.R
+++ b/tools/scripts/pgx-GSE114716-ipilimumab.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE141499-tcellmyc.R
+++ b/tools/scripts/pgx-GSE141499-tcellmyc.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE157905-lenvatinib.R
+++ b/tools/scripts/pgx-GSE157905-lenvatinib.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE1739-sars.R
+++ b/tools/scripts/pgx-GSE1739-sars.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE17400-sarscov.R
+++ b/tools/scripts/pgx-GSE17400-sarscov.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE21802-h1n1.R
+++ b/tools/scripts/pgx-GSE21802-h1n1.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE22886-immune.R
+++ b/tools/scripts/pgx-GSE22886-immune.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE28492-roche.R
+++ b/tools/scripts/pgx-GSE28492-roche.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE30589-sarscov.R
+++ b/tools/scripts/pgx-GSE30589-sarscov.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE32591-lupusnephritis.R
+++ b/tools/scripts/pgx-GSE32591-lupusnephritis.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE33267-sars.R
+++ b/tools/scripts/pgx-GSE33267-sars.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE37827-sars.R
+++ b/tools/scripts/pgx-GSE37827-sars.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE45042-corona.R
+++ b/tools/scripts/pgx-GSE45042-corona.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE47960-sars.R
+++ b/tools/scripts/pgx-GSE47960-sars.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE53784-wnvjev.R
+++ b/tools/scripts/pgx-GSE53784-wnvjev.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE56192-merscov.R
+++ b/tools/scripts/pgx-GSE56192-merscov.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE56677-merscov.R
+++ b/tools/scripts/pgx-GSE56677-merscov.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE5972-sars.R
+++ b/tools/scripts/pgx-GSE5972-sars.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE65574-mers.R
+++ b/tools/scripts/pgx-GSE65574-mers.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE72056-scmelanoma.R
+++ b/tools/scripts/pgx-GSE72056-scmelanoma.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE73024-debio1347.R
+++ b/tools/scripts/pgx-GSE73024-debio1347.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE86529-merscov.R
+++ b/tools/scripts/pgx-GSE86529-merscov.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE88808-prostate.R
+++ b/tools/scripts/pgx-GSE88808-prostate.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE92332-scintestine.R
+++ b/tools/scripts/pgx-GSE92332-scintestine.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE93156-idelalisib.R
+++ b/tools/scripts/pgx-GSE93156-idelalisib.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE98588-dlbcl.R
+++ b/tools/scripts/pgx-GSE98588-dlbcl.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-GSE98638-scliver.R
+++ b/tools/scripts/pgx-GSE98638-scliver.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-geiger2016-arginine.R
+++ b/tools/scripts/pgx-geiger2016-arginine.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-getGEO.R
+++ b/tools/scripts/pgx-getGEO.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-gtex-tissue.R
+++ b/tools/scripts/pgx-gtex-tissue.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-rieckmann2017-immprot.R
+++ b/tools/scripts/pgx-rieckmann2017-immprot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-tcga-brca.R
+++ b/tools/scripts/pgx-tcga-brca.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-tcga-brca2.R
+++ b/tools/scripts/pgx-tcga-brca2.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-tcga-prad.R
+++ b/tools/scripts/pgx-tcga-prad.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/scripts/pgx-tcga-survival.R
+++ b/tools/scripts/pgx-tcga-survival.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ##===================================================================

--- a/tools/utils/code-analyzer.R
+++ b/tools/utils/code-analyzer.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/tools/utils/init-pgxfolder.R
+++ b/tools/utils/init-pgxfolder.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 RDIR="../R"

--- a/tools/utils/testBoard.R
+++ b/tools/utils/testBoard.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 library(shiny)

--- a/tools/utils/testPlotModule.R
+++ b/tools/utils/testPlotModule.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 if(interactive()) {

--- a/tools/utils/update-pgxfolder.R
+++ b/tools/utils/update-pgxfolder.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 RDIR = "../R"


### PR DESCRIPTION
## Summary

Bumps all **BigOmics-owned copyright headers** across the codebase so their end year reads **2026**. Start year and entity name (`SA`/`Sagl`) are preserved; this is purely a year refresh.

| Pattern | Result | Files |
|---------|--------|-------|
| `2018-2023` / `2018-2024` / `2018-2025` / `2018-2022` / `2018-2020` | `…-2026` | 428 |
| `2020-2024` (NOTICE.md) | `2020-2026` | 1 |
| `2020` single-year (UsersMapModule.R) | `2020-2026` | 1 |
| `(c) 2023` (`bin/PARAMS.yml`, `bin/pgxcreate`, `bin/pgxcreate_op.R`) | `(c) 2023-2026` | 3 |

**433 files** changed, copyright-line only — no functional changes.

**Left untouched:** third-party notices (Twitter Inc., Scott Jehl, Greg Franko, OpenStreetMap/Carto attributions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)