### PR TITLE
feat(pcsf): export PCSF network to Cytoscape (CX2)

### DIFF
--- a/components/board.pcsf/R/pcsf_panel_gene.R
+++ b/components/board.pcsf/R/pcsf_panel_gene.R
@@ -47,7 +47,7 @@ pcsf_genepanel_networkplot_ui <- function(id, caption, info.text, height, width)
     height = height,
     width = width,
     options = plot_opts,
-    download.fmt = c("png", "pdf", "svg"),
+    download.fmt = c("png", "pdf", "svg", "cx2"),
   )
 }
 
@@ -338,6 +338,27 @@ pcsf_genepanel_server <- function(id,
       return(plt)
     }
 
+    ## CX2 export for Cytoscape (mirrors visnetwork.RENDER attributes)
+    cx2_content <- function(file) {
+      res <- gene_pcsf()
+      g <- res$graph
+      contrast <- r_contrast()
+      shiny::req(contrast)
+      F <- playbase::pgx.getMetaMatrix(pgx, level = "gene")$fc
+      fx <- F[igraph::V(g)$name, contrast]
+      fx[is.na(fx)] <- 0
+      igraph::V(g)$foldchange <- fx
+      igraph::V(g)$prize <- abs(fx)
+      igraph::V(g)$label <- playbase::probe2symbol(
+        igraph::V(g)$name, pgx$genes, "gene_name", fill_na = TRUE
+      )
+      if (!is.null(res$layout)) {
+        igraph::V(g)$x <- res$layout[, 1]
+        igraph::V(g)$y <- res$layout[, 2]
+      }
+      pcsf.write_cx2(g, file)
+    }
+
     PlotModuleServer(
       "plotmodule",
       func = visnetwork.RENDER,
@@ -345,7 +366,10 @@ pcsf_genepanel_server <- function(id,
       pdf.width = 10,
       pdf.height = 10,
       add.watermark = watermark,
-      vis.delay = 5 ## important! graph physics needs to settle
+      vis.delay = 5, ## important! graph physics needs to settle
+      download.handlers = list(
+        cx2 = list(ext = "cx2", content = cx2_content)
+      )
     )
 
     ## -----------------------------------------------------------------

--- a/components/board.pcsf/R/pcsf_panel_geneset.R
+++ b/components/board.pcsf/R/pcsf_panel_geneset.R
@@ -47,7 +47,7 @@ pcsf_gsetpanel_networkplot_ui <- function(id, caption, info.text, height, width)
     height = height,
     width = width,
     options = plot_opts,
-    download.fmt = c("png", "pdf", "svg"),
+    download.fmt = c("png", "pdf", "svg", "cx2"),
   )
 }
 
@@ -327,6 +327,24 @@ pcsf_gsetpanel_server <- function(id,
       return(plt)
     }
 
+    ## CX2 export for Cytoscape (mirrors visnetwork.RENDER attributes)
+    cx2_content <- function(file) {
+      res <- gset_pcsf()
+      g <- res$graph
+      contrast <- r_contrast()
+      shiny::req(contrast)
+      F <- playbase::pgx.getMetaMatrix(pgx, level = "geneset")$fc
+      fx <- F[igraph::V(g)$name, contrast]
+      fx[is.na(fx)] <- 0
+      igraph::V(g)$foldchange <- fx
+      igraph::V(g)$prize <- abs(fx)
+      if (!is.null(res$layout)) {
+        igraph::V(g)$x <- res$layout[, 1]
+        igraph::V(g)$y <- res$layout[, 2]
+      }
+      pcsf.write_cx2(g, file)
+    }
+
     PlotModuleServer(
       "plotmodule",
       func = visnetwork.RENDER,
@@ -334,7 +352,10 @@ pcsf_gsetpanel_server <- function(id,
       pdf.width = 10,
       pdf.height = 10,
       add.watermark = watermark,
-      vis.delay = 5 ## important! graph physics needs to settle
+      vis.delay = 5, ## important! graph physics needs to settle
+      download.handlers = list(
+        cx2 = list(ext = "cx2", content = cx2_content)
+      )
     )
 
     ## -----------------------------------------------------------------

--- a/components/board.pcsf/R/util_pcsf.R
+++ b/components/board.pcsf/R/util_pcsf.R
@@ -4,6 +4,95 @@
 ##
 
 
+#' Write an igraph network to a CX2 file (Cytoscape Exchange Format v2)
+#'
+#' @description Serialize an igraph object to CX2 JSON, the format accepted by
+#'   both Cytoscape Web (which does not import GraphML) and Cytoscape Desktop.
+#'   Node `x`/`y` attributes, if present, are written as layout coordinates;
+#'   all other vertex/edge attributes are emitted with declared datatypes.
+#'
+#' @param g igraph object
+#' @param file output file path
+#'
+#' @export
+pcsf.write_cx2 <- function(g, file) {
+  vattr <- igraph::vertex_attr(g)
+  eattr <- igraph::edge_attr(g)
+  n <- igraph::vcount(g)
+  m <- igraph::ecount(g)
+  ids <- seq_len(n) - 1L ## 0-based node ids
+
+  cx_type <- function(v) {
+    if (is.logical(v)) {
+      "boolean"
+    } else if (is.integer(v)) {
+      "integer"
+    } else if (is.numeric(v)) {
+      "double"
+    } else {
+      "string"
+    }
+  }
+
+  ## x/y become layout coordinates; everything else is a node attribute
+  has_xy <- all(c("x", "y") %in% names(vattr))
+  node_attrs <- setdiff(names(vattr), c("x", "y"))
+
+  ## igraph layouts span only a few units, but Cytoscape reads x/y as pixels,
+  ## so without rescaling all nodes collapse into the centre. Scale the bounding
+  ## box (aspect-ratio preserved) to ~75px node spacing, and flip Y because
+  ## Cytoscape's Y axis points down (keeps the view matching the app).
+  if (has_xy) {
+    px <- as.numeric(vattr$x)
+    py <- as.numeric(vattr$y)
+    span <- max(diff(range(px, na.rm = TRUE)), diff(range(py, na.rm = TRUE)))
+    if (!is.finite(span) || span == 0) span <- 1
+    scale <- 75 * sqrt(max(n, 1)) / span
+    px <- (px - min(px, na.rm = TRUE)) * scale
+    py <- (py - min(py, na.rm = TRUE)) * scale
+    py <- max(py, na.rm = TRUE) - py
+  }
+
+  node_decl <- lapply(node_attrs, function(a) list(d = cx_type(vattr[[a]])))
+  names(node_decl) <- node_attrs
+  edge_decl <- lapply(names(eattr), function(a) list(d = cx_type(eattr[[a]])))
+  names(edge_decl) <- names(eattr)
+
+  nodes <- lapply(seq_len(n), function(i) {
+    v <- lapply(node_attrs, function(a) vattr[[a]][i])
+    names(v) <- node_attrs
+    node <- list(id = ids[i], v = v)
+    if (has_xy) {
+      node$x <- px[i]
+      node$y <- py[i]
+    }
+    node
+  })
+
+  el <- igraph::as_edgelist(g, names = FALSE) ## 1-based row indices
+  edges <- lapply(seq_len(m), function(j) {
+    v <- lapply(names(eattr), function(a) eattr[[a]][j])
+    names(v) <- names(eattr)
+    list(id = j - 1L, s = ids[el[j, 1]], t = ids[el[j, 2]], v = v)
+  })
+
+  cx <- list(
+    list(CXVersion = "2.0", hasFragments = FALSE),
+    list(metaData = list(
+      list(name = "attributeDeclarations", elementCount = 1L),
+      list(name = "nodes", elementCount = n),
+      list(name = "edges", elementCount = m)
+    )),
+    list(attributeDeclarations = list(list(nodes = node_decl, edges = edge_decl))),
+    list(nodes = nodes),
+    list(edges = edges),
+    list(status = list(list(success = TRUE, error = "")))
+  )
+
+  jsonlite::write_json(cx, path = file, auto_unbox = TRUE, digits = NA)
+}
+
+
 #' @param x
 #'
 #' @return

--- a/components/ui/ui-PlotModule.R
+++ b/components/ui/ui-PlotModule.R
@@ -571,6 +571,7 @@ PlotModuleServer <- function(id,
                              download.csv = NULL,
                              download.excel = NULL,
                              download.obj = NULL,
+                             download.handlers = NULL,
                              download.contrast.name = NULL,
                              pdf.width = 8,
                              pdf.height = 6,
@@ -1166,6 +1167,29 @@ PlotModuleServer <- function(id,
         )
       }
 
+      ## generic custom-format handlers (e.g. GraphML for Cytoscape)
+      custom.handlers <- list()
+      if (!is.null(download.handlers)) {
+        custom.handlers <- lapply(names(download.handlers), function(fmt) {
+          spec <- download.handlers[[fmt]]
+          ext <- if (!is.null(spec$ext)) spec$ext else fmt
+          shiny::downloadHandler(
+            filename = function() paste0(filename, ".", ext),
+            content = function(file) {
+              shiny::withProgress(
+                {
+                  spec$content(file)
+                  record_plot_download(substr(ns(""), 1, nchar(ns("")) - 1))
+                },
+                message = paste("Exporting to", toupper(fmt)),
+                value = 0.8
+              )
+            }
+          )
+        })
+        names(custom.handlers) <- names(download.handlers)
+      }
+
       ## --------------------------------------------------------------------------------
       ## ------------------------ OUTPUT ------------------------------------------------
       ## --------------------------------------------------------------------------------
@@ -1191,6 +1215,9 @@ PlotModuleServer <- function(id,
           }
           if (input$downloadOption == "obj") {
             output$download <- download.obj
+          }
+          if (input$downloadOption %in% names(custom.handlers)) {
+            output$download <- custom.handlers[[input$downloadOption]]
           }
         })
       } else {
@@ -1236,6 +1263,12 @@ PlotModuleServer <- function(id,
               "download",
               card
             )]] <- download.obj
+          }
+          if (input$downloadOption %in% names(custom.handlers)) {
+            output[[paste0(
+              "download",
+              card
+            )]] <- custom.handlers[[input$downloadOption]]
           }
         })
       }


### PR DESCRIPTION
Adds a "CX2" download option to the PCSF gene and geneset network plots. Exports the live graph nodes, edges, fold-change/prize, labels, weights, layout as a CX2 file that imports straight into Cytoscape

<img width="1897" height="1033" alt="image" src="https://github.com/user-attachments/assets/f0cab868-acd5-4f35-a404-f284f7af65f3" />
