### PR TITLE
feat(volcano): add axis-limit controls to the volcano plot editor

### DIFF
--- a/components/board.enrichment/R/enrichment_plot_volcano.R
+++ b/components/board.enrichment/R/enrichment_plot_volcano.R
@@ -129,6 +129,7 @@ enrichment_plot_volcano_server <- function(id,
     plotly.RENDER <- function(marker.size = 3, lab.cex = 1) {
       pd <- plot_data()
       shiny::req(pd)
+      al <- extract_axis_limits(input)
       playbase::plotlyVolcano( ## in use
         x = pd[["x"]],
         y = pd[["y"]],
@@ -147,7 +148,9 @@ enrichment_plot_volcano_server <- function(id,
         displayModeBar = FALSE,
         showlegend = FALSE,
         color_up_down = TRUE,
-        colors = extract_volcano_colors(input)
+        colors = extract_volcano_colors(input),
+        xlim = al$xlim,
+        ylim = if (!is.null(al$ymax)) c(0, al$ymax) else NULL
       ) %>%
         plotly::layout(margin = list(l = 0, r = 0, t = 0, b = 0))
     }
@@ -188,6 +191,9 @@ enrichment_plot_volcano_server <- function(id,
       ## Editor: ggprism settings
       gp <- extract_ggprism_params(input)
 
+      ## Editor: axis limits
+      al <- extract_axis_limits(input)
+
       p <- playbase::ggVolcano(
         x = pd[["x"]],
         y = pd[["y"]],
@@ -205,6 +211,8 @@ enrichment_plot_volcano_server <- function(id,
         axis.text.size = ls$axis_text_size,
         showlegend = FALSE,
         colors = plot_colors,
+        xlim = al$xlim,
+        ylim = al$ymax,
         box.padding = ls$box_padding,
         min.segment.length = ls$min_segment_length,
         label.box = ls$label_box,
@@ -229,6 +237,7 @@ enrichment_plot_volcano_server <- function(id,
     base.RENDER.modal <- function() {
       pd <- plot_data()
       shiny::req(pd)
+      al <- extract_axis_limits(input)
 
       playbase::ggVolcano(
         x = pd[["x"]],
@@ -245,7 +254,9 @@ enrichment_plot_volcano_server <- function(id,
         label.cex = 6,
         axis.text.size = 24,
         showlegend = FALSE,
-        title = NULL
+        title = NULL,
+        xlim = al$xlim,
+        ylim = al$ymax
       )
     }
 

--- a/components/board.expression/R/expression_plot_volcano.R
+++ b/components/board.expression/R/expression_plot_volcano.R
@@ -133,6 +133,7 @@ expression_plot_volcano_server <- function(id,
     plotly.RENDER <- function(marker.size = 4, lab.cex = 1) {
       pd <- plot_data()
       shiny::req(pd)
+      al <- extract_axis_limits(input)
       plt <- playbase::plotlyVolcano(
         x = pd[["x"]],
         y = pd[["y"]],
@@ -152,7 +153,9 @@ expression_plot_volcano_server <- function(id,
         marker.size = marker.size,
         showlegend = FALSE,
         color_up_down = TRUE,
-        colors = extract_volcano_colors(input)
+        colors = extract_volcano_colors(input),
+        xlim = al$xlim,
+        ylim = if (!is.null(al$ymax)) c(0, al$ymax) else NULL
       )
       plt
     }
@@ -194,6 +197,9 @@ expression_plot_volcano_server <- function(id,
       ## ggprism settings
       gp <- extract_ggprism_params(input)
 
+      ## Axis limits
+      al <- extract_axis_limits(input)
+
       p <- playbase::ggVolcano(
         x = pd[["x"]],
         y = pd[["y"]],
@@ -211,6 +217,8 @@ expression_plot_volcano_server <- function(id,
         title = NULL,
         axis.text.size = ls$axis_text_size,
         colors = plot_colors,
+        xlim = al$xlim,
+        ylim = al$ymax,
         box.padding = ls$box_padding,
         min.segment.length = ls$min_segment_length,
         label.box = ls$label_box,
@@ -237,6 +245,7 @@ expression_plot_volcano_server <- function(id,
 
       names <- pd$features
       ls <- extract_label_settings(input)
+      al <- extract_axis_limits(input)
 
       playbase::ggVolcano(
         x = pd[["x"]],
@@ -254,6 +263,8 @@ expression_plot_volcano_server <- function(id,
         marker.size = 1.8,
         showlegend = FALSE,
         title = NULL,
+        xlim = al$xlim,
+        ylim = al$ymax,
         box.padding = ls$box_padding,
         min.segment.length = ls$min_segment_length,
         label.box = ls$label_box,

--- a/components/ui/ui-EditorContent.R
+++ b/components/ui/ui-EditorContent.R
@@ -111,6 +111,20 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
               ns = ns_parent
             )
           ),
+          bslib::accordion_panel(
+            "Axis Limits",
+            checkboxInput(ns_parent("axis_limits_checkbox"), "Custom axis limits", value = FALSE),
+            conditionalPanel(
+              condition = "input.axis_limits_checkbox",
+              ns = ns_parent,
+              bslib::layout_column_wrap(
+                width = 1 / 2,
+                numericInput(ns_parent("xlim_max"), "X max (±)", value = NA, min = 0, step = 0.5),
+                numericInput(ns_parent("ylim_max"), "Y max", value = NA, min = 0, step = 1)
+              ),
+              shiny::helpText("X axis spans ± the value. Leave a field blank to auto-scale that axis.")
+            )
+          ),
 
           # Additional Settings
           bslib::accordion_panel(

--- a/components/ui/ui-EditorHelpers.R
+++ b/components/ui/ui-EditorHelpers.R
@@ -461,6 +461,30 @@ extract_label_settings <- function(input, defaults = list()) {
 }
 
 
+#' Extract custom axis limits from Shiny input (volcano editor).
+#'
+#' Reads the \code{axis_limits_checkbox} toggle and the \code{xlim_max} /
+#' \code{ylim_max} numeric inputs. The x-axis is symmetric (the view spans
+#' \code{c(-xlim_max, xlim_max)}); the y-axis is capped at \code{ylim_max}
+#' with the lower bound left at 0. Either field may be left blank to keep
+#' that axis auto-scaled.
+#'
+#' @param input Shiny input object.
+#' @return Named list with \code{xlim} (length-2 numeric vector or NULL) and
+#'   \code{ymax} (single numeric or NULL).
+extract_axis_limits <- function(input) {
+  use  <- isTRUE(input$axis_limits_checkbox)
+  xmax <- input$xlim_max
+  ymax <- input$ylim_max
+  ok_x <- use && !is.null(xmax) && !is.na(xmax) && xmax > 0
+  ok_y <- use && !is.null(ymax) && !is.na(ymax) && ymax > 0
+  list(
+    xlim = if (ok_x) c(-xmax, xmax) else NULL,
+    ymax = if (ok_y) ymax else NULL
+  )
+}
+
+
 #' Hyperbolic significance mask matching playbase::ggVolcano.
 #'
 #' Returns a logical vector flagging points that lie above the hyperbola


### PR DESCRIPTION
as per client request, add axis limits control on volcano plots

<img width="1907" height="1001" alt="image" src="https://github.com/user-attachments/assets/1c1d0d28-ad95-4644-bbc4-2ed167f864cf" />

requires playbase pr https://github.com/bigomics/playbase/pull/481