### PR TITLE
fix(correlation): decouple table search from plots, add row-select dr…

### DIFF
--- a/components/board.correlation/R/correlation_plot_barplot.R
+++ b/components/board.correlation/R/correlation_plot_barplot.R
@@ -82,18 +82,18 @@ correlation_plot_barplot_server <- function(id,
     plot_data <- shiny::reactive({
       df <- getPartialCorrelation()
       R <- getGeneCorr()
-
-      sel <- cor_table$rownames_current()
-      shiny::req(sel)
-
-      ## cor_table!=R mismatch!!!
-      if (length(sel) > nrow(R)) {
-        return(NULL)
-      }
+      shiny::req(R)
 
       NTOP <- 40 ## how many genes to show in barplot
-      sel <- intersect(sel, rownames(R))
-      sel <- head(sel, NTOP)
+      ## Top-N correlated features, ranked by correlation. Independent of the
+      ## table search/filter.
+      sel <- head(rownames(R), NTOP)
+
+      ## Force-inject the table-selected feature, even when it falls outside the
+      ## top-N, so the selection always has a bar to highlight.
+      selected <- intersect(cor_table$rownames_selected(), rownames(R))
+      if (length(selected) > 0) sel <- unique(c(sel, selected))
+
       rho <- R[sel, "cor"]
       if (length(sel) == 1) names(rho) <- sel
 
@@ -106,6 +106,13 @@ correlation_plot_barplot_server <- function(id,
         "correlation" = rho,
         "partial correlation" = prho
       )
+
+      ## Remember the selected feature (as plotted symbol label) for highlighting.
+      if (length(selected) > 0) {
+        attr(pd, "highlight") <- playbase::probe2symbol(
+          selected[1], pgx$genes, labeltype(), fill_na = TRUE
+        )
+      }
 
       return(pd)
     })
@@ -130,6 +137,7 @@ correlation_plot_barplot_server <- function(id,
     render_barplot <- function() {
       pd <- plot_data()
       shiny::req(pd)
+      highlight <- attr(pd, "highlight") ## table-selected feature, if any
 
       ## Editor: bar ordering
       bars_order <- input$bars_order
@@ -152,16 +160,24 @@ correlation_plot_barplot_server <- function(id,
         showlegend = FALSE
       )
 
-      ## Editor: palette override
+      ## Editor: palette override; highlight the table-selected feature's bars
       n_series <- 2
       COL <- resolve_palette_colors(input, n_series)
-      if (!is.null(COL)) {
+      do_highlight <- !is.null(highlight) && highlight %in% rownames(pd)
+      if (!is.null(COL) || do_highlight) {
         fig <- plotly::plotly_build(fig)
         bar_idx <- 1
         for (i in seq_along(fig$x$data)) {
           if (!is.null(fig$x$data[[i]]$type) && fig$x$data[[i]]$type == "bar") {
-            fig$x$data[[i]]$marker$color <- COL[bar_idx]
-            bar_idx <- min(bar_idx + 1, n_series)
+            if (!is.null(COL)) {
+              fig$x$data[[i]]$marker$color <- COL[bar_idx]
+              bar_idx <- min(bar_idx + 1, n_series)
+            }
+            if (do_highlight) {
+              xv <- as.character(fig$x$data[[i]]$x)
+              fig$x$data[[i]]$marker$line$width <- ifelse(xv == highlight, 2, 0)
+              fig$x$data[[i]]$marker$line$color <- "black"
+            }
           }
         }
       }

--- a/components/board.correlation/R/correlation_plot_scattercorr.R
+++ b/components/board.correlation/R/correlation_plot_scattercorr.R
@@ -106,12 +106,20 @@ correlation_plot_scattercorr_server <- function(id,
       this.gene <- sel_gene()
       NTOP <- 50
       R <- getGeneCorr()
-      sel <- cor_table$rownames_current()
-      sel <- head(intersect(sel, rownames(R)), NTOP)
+
+      ## Decoupled from the table search/filter. With a table row selected, show
+      ## a single scatter (settings feature vs the selected feature); otherwise
+      ## show the top-N correlated features as a grid.
+      selected <- intersect(cor_table$rownames_selected(), rownames(R))
+      if (length(selected) > 0) {
+        sel <- selected[1]
+      } else {
+        sel <- head(rownames(R), NTOP)
+      }
       shiny::req(sel)
       rho <- R[sel, "cor"]
 
-      if (length(rho) == 1) names(rho) <- rownames(R)[1]
+      if (length(rho) == 1) names(rho) <- sel
       pp <- unique(c(this.gene, names(rho)))
       X <- pgx$X[pp, , drop = FALSE]
 
@@ -301,7 +309,9 @@ correlation_plot_scattercorr_server <- function(id,
     }
 
     cor_scatter.PLOTFUN <- function() {
-      if (input$layout == "3x3") {
+      if (length(cor_table$rownames_selected()) > 0) {
+        nrow <- ncol <- 1 ## single scatter for the table-selected feature
+      } else if (input$layout == "3x3") {
         nrow <- ncol <- 3
       } else if (input$layout == "4x4") {
         nrow <- ncol <- 4
@@ -319,7 +329,9 @@ correlation_plot_scattercorr_server <- function(id,
     }
 
     cor_scatter.PLOTFUN2 <- function() {
-      if (input$layout == "3x3") {
+      if (length(cor_table$rownames_selected()) > 0) {
+        nrow <- ncol <- 1 ## single scatter for the table-selected feature
+      } else if (input$layout == "3x3") {
         nrow <- 3
         ncol <- 5
       } else if (input$layout == "4x4") {

--- a/components/board.correlation/R/correlation_table_corr.R
+++ b/components/board.correlation/R/correlation_table_corr.R
@@ -85,7 +85,7 @@ correlation_table_corr_server <- function(id,
         df,
         rownames = FALSE, #
         extensions = c("Buttons", "Scroller"),
-        selection = list(mode = "single", target = "row", selected = 1),
+        selection = list(mode = "single", target = "row"),
         class = "compact cell-border stripe hover",
         plugins = "scrollResize",
         fillContainer = TRUE,
@@ -120,7 +120,7 @@ correlation_table_corr_server <- function(id,
       "table",
       func = cor_table.RENDER,
       func2 = cor_table.RENDER_modal,
-      selector = "none"
+      selector = "single"
     )
   }) ## end of moduleServer
 }


### PR DESCRIPTION
bug fix + client request

correlation table's search/sort modified scatter grid and the barplot (through `rownames_current()`), quite strange behaviour. also when filtering just for one feature the table, the scatter plot displayed was just the selected gene (on settings right bar) against itself (correlation 1)

added the option to click on the table to select which feature to show only on the scatter + highligted it on barplot

<img width="1920" height="1080" alt="after_selected" src="https://github.com/user-attachments/assets/5238774e-9d2b-4d9f-853b-0bb3e170c7ab" />
