### PR TITLE
fix(correlation): sync legend toggling across scatter subplots

### DIFF
--- a/components/board.correlation/R/correlation_plot_scattercorr.R
+++ b/components/board.correlation/R/correlation_plot_scattercorr.R
@@ -190,18 +190,25 @@ correlation_plot_scattercorr_server <- function(id,
             gene2,
             " Expression:</b> %{y}<extra></extra>"
           )
-        ) %>%
-          # Add the points
-          plotly::add_trace(
-            x = x,
-            y = y,
-            color = pheno,
-            colors = COL,
-            type = "scatter",
-            mode = "markers",
-            marker = list(size = markersize),
-            showlegend = (i == 1)
-          ) %>%
+        )
+        # Add the points. One trace per group with a shared legendgroup so
+        # that toggling a group in the legend hides/shows it across all subplots.
+        for (j in seq_along(levels(pheno))) {
+          g <- levels(pheno)[j]
+          sel.j <- which(pheno == g)
+          plt <- plt %>%
+            plotly::add_trace(
+              x = x[sel.j],
+              y = y[sel.j],
+              name = g,
+              legendgroup = g,
+              type = "scatter",
+              mode = "markers",
+              marker = list(size = markersize, color = COL[j]),
+              showlegend = (i == 1)
+            )
+        }
+        plt <- plt %>%
           # Add the regression line
           plotly::add_trace(
             data = newdata,


### PR DESCRIPTION
on correlation plot, click only hid points of first plot

### before
<img width="702" height="826" alt="image" src="https://github.com/user-attachments/assets/54d91685-79fc-4db8-87c1-dcc03e8fe323" />


### after
<img width="712" height="832" alt="image" src="https://github.com/user-attachments/assets/e9177235-21fd-4911-9ece-f936fb96052a" />
