### PR TITLE
feat: add AI usage telemetry

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-5.0.001-alpha+feat/ai-reports260616
+5.0.001-alpha+feat/token-telemetry260623

--- a/components/app_copilot/R/CopilotBoardServer.R
+++ b/components/app_copilot/R/CopilotBoardServer.R
@@ -115,7 +115,14 @@ CopilotBoardServer <- function(
     chat_event_rv             <- shiny::reactiveVal(NULL)
 
     # ---- Non-reactive state ----
-    chat_store <- omicsagentovi::SessionStore(session_dir = chat_dir)
+    # Chats live in a per-user db so enterprise members sharing a chats/
+    # folder don't collide. 
+    chat_db_name <- .ai_tel_sessions_db_name(email)
+    .detect_legacy_sessions(chat_dir, email)
+    chat_store <- omicsagentovi::SessionStore(
+      session_dir = chat_dir,
+      db_name     = chat_db_name
+    )
 
     # ---- Evidence module (constructed first so $append_artifact is available
     # when run/restore bindings factories run) ----
@@ -142,6 +149,27 @@ CopilotBoardServer <- function(
       style                     = style,
       custom                    = custom
     )
+
+    # ---- Telemetry: collect on save tick ----
+    # The save controller bumps history_invalidation_tick AFTER session_save()
+    # commits (post onFlushed), so by the time this fires the assistant turns
+    # are on disk and a read-only scan sees them. The collect call is a tiny
+    # SYNCHRONOUS main-thread op — deliberately NO future_promise / ExtendedTask:
+    # the SQLite pointer + Shiny session closures would break under future
+    # serialization (bad_weak_ptr), exactly as copilot_save_controller documents.
+    # tryCatch keeps any telemetry failure from disrupting the chat UI.
+    shiny::observeEvent(history_invalidation_tick(), {
+      if (is.null(email) || length(email) != 1L || is.na(email) ||
+          !nzchar(email)) {
+        return(invisible(NULL))
+      }
+      tryCatch(
+        ai_telemetry_collect_chat(session_dir = chat_dir, user_email = email),
+        error = function(e) {
+          log_info("copilot.telemetry_collect_failed", msg = conditionMessage(e))
+        }
+      )
+    }, ignoreInit = TRUE)
 
     # ---- Restore controller ----
     restore_ctrl <- copilot_restore_controller(
@@ -218,6 +246,7 @@ CopilotBoardServer <- function(
     history  <- CopilotHistoryServer(
       "history",
       session_dir               = chat_dir,
+      db_name                   = chat_db_name,
       history_invalidation_tick = shiny::reactive(history_invalidation_tick())
     )
 
@@ -343,7 +372,8 @@ CopilotBoardServer <- function(
       # the radios reflect the restored session (and the next Agent build —
       # e.g. tier change after restore — uses the restored style).
       meta <- tryCatch(
-        omicsagentovi::ovi_session_meta(session_id = sid, session_dir = chat_dir),
+        omicsagentovi::ovi_session_meta(session_id = sid, session_dir = chat_dir,
+                                        db_name = chat_db_name),
         error = function(e) NULL
       )
       if (!is.null(meta)) {
@@ -369,7 +399,8 @@ CopilotBoardServer <- function(
       sid <- history$on_delete()
       shiny::req(sid)
       tryCatch(
-        omicsagentovi::ovi_session_delete(session_id = sid, session_dir = chat_dir),
+        omicsagentovi::ovi_session_delete(session_id = sid, session_dir = chat_dir,
+                                          db_name = chat_db_name),
         error = function(e) {
           shiny::showNotification(
             paste("Delete failed:", conditionMessage(e)),

--- a/components/app_copilot/R/CopilotHistoryServer.R
+++ b/components/app_copilot/R/CopilotHistoryServer.R
@@ -41,6 +41,9 @@ CopilotHistoryUI <- function(id) {
 #'
 #' @param id Shiny module id.
 #' @param session_dir character(1) path to the SessionStore directory.
+#' @param db_name character(1) filename of the SessionStore database within
+#'   `session_dir`. Defaults to `"sessions.sqlite"`; the orchestrator passes
+#'   the per-user name so briefings read the same db the chat is saved to.
 #' @param history_invalidation_tick Optional reactive (or reactiveVal). When
 #'   provided, the panel takes a dependency on it so the session list
 #'   refreshes after save or delete. Renamed from `refresh_trigger`.
@@ -50,6 +53,7 @@ CopilotHistoryUI <- function(id) {
 #'      the caller is expected to read them, act, then reset to NULL.
 #' @export
 CopilotHistoryServer <- function(id, session_dir,
+                                 db_name = "sessions.sqlite",
                                  history_invalidation_tick = NULL) {
   shiny::moduleServer(id, function(input, output, session) {
 
@@ -60,7 +64,7 @@ CopilotHistoryServer <- function(id, session_dir,
     .sessions <- shiny::reactive({
       if (!is.null(history_invalidation_tick)) history_invalidation_tick()
       df <- tryCatch(
-        omicsagentovi::ovi_sessions(session_dir = session_dir),
+        omicsagentovi::ovi_sessions(session_dir = session_dir, db_name = db_name),
         error = function(e) data.frame()
       )
       if (!is.data.frame(df) || nrow(df) == 0L) {
@@ -81,7 +85,7 @@ CopilotHistoryServer <- function(id, session_dir,
     .briefings <- shiny::reactive({
       df <- .sessions()
       if (nrow(df) == 0L) return(character(0))
-      db_path <- file.path(session_dir, "sessions.sqlite")
+      db_path <- file.path(session_dir, db_name)
       if (!file.exists(db_path)) return(rep("", nrow(df)))
       tryCatch({
         con <- DBI::dbConnect(RSQLite::SQLite(), db_path, flags = RSQLite::SQLITE_RO)

--- a/components/app_copilot/R/copilot_restore_controller.R
+++ b/components/app_copilot/R/copilot_restore_controller.R
@@ -101,7 +101,8 @@ copilot_restore_controller <- function(
         session_id  = session_id,
         session_dir = store@session_dir,
         bindings    = bindings,
-        restore_pgx = "never"
+        restore_pgx = "never",
+        db_name     = basename(store@db_path)
       )
     }, seed = TRUE)
   })
@@ -269,7 +270,8 @@ copilot_restore_controller <- function(
             session_id  = session_id,
             session_dir = store@session_dir,
             bindings    = bindings,
-            restore_pgx = "never"
+            restore_pgx = "never",
+            db_name     = basename(store@db_path)
           ),
           error = function(e) {
             log_info("copilot.restore_sync_failed", msg = conditionMessage(e))

--- a/components/app_copilot/R/copilot_save_controller.R
+++ b/components/app_copilot/R/copilot_save_controller.R
@@ -35,13 +35,16 @@
 # Delete oldest sessions when the store exceeds max_history entries.
 # ovi_sessions() returns rows ordered by updated_at DESC so the tail is oldest.
 .prune_sessions <- function(store, max_history) {
-  rows <- omicsagentovi::ovi_sessions(session_dir = store@session_dir)
+  db_name <- basename(store@db_path)
+  rows <- omicsagentovi::ovi_sessions(
+    session_dir = store@session_dir, db_name = db_name)
   if (nrow(rows) <= max_history) return(invisible(NULL))
   n_delete <- nrow(rows) - max_history
   to_delete <- tail(rows$session_id, n_delete)
   for (sid in to_delete) {
     tryCatch(
-      omicsagentovi::ovi_session_delete(sid, session_dir = store@session_dir),
+      omicsagentovi::ovi_session_delete(
+        sid, session_dir = store@session_dir, db_name = db_name),
       error = function(e) {
         log_info("copilot.prune_failed", sid = sid, msg = conditionMessage(e))
       }

--- a/components/app_studio/R/aireport_server.R
+++ b/components/app_studio/R/aireport_server.R
@@ -561,6 +561,22 @@ AiReportServer <- function(id, pgx, save_pgx = NULL) {
           }
 
           report_jobs$done <- report_jobs$done + 1L
+
+          # Telemetry: log one event per report generation on the main thread.
+          # TODO(telemetry): tokens unavailable until playbase returns usage from
+          # pgx.update_reports() (computed in the future worker, not returned here).
+          # TODO(telemetry): thread auth$email for attribution (no auth in StudioServer scope).
+          tryCatch(
+            ai_telemetry_record(
+              source     = "report",
+              session_id = paste0(session$token, ":", result$module),
+              user_email = NA_character_,
+              model      = llm_model,
+              usage      = NULL
+            ),
+            error = function(e) NULL
+          )
+
           report_progress(paste("Finished", report_module_labels(result$module)))
           info("[AiReportServer] report job complete: module=", result$module,
             " done=", report_jobs$done, "/", report_jobs$total,

--- a/components/board.wgcna/R/wgcna_module_ai_summary.R
+++ b/components/board.wgcna/R/wgcna_module_ai_summary.R
@@ -44,6 +44,7 @@ wgcna_module_ai_summary_ui <- function(id,
 #' @param r_module Reactive returning the selected module name.
 #' @param parent_session Parent Shiny session with AI user options.
 #' @param watermark Logical; add watermark in PlotModule.
+#' @param user_email Optional user email for telemetry attribution.
 #'
 #' @return Reactive returning the latest omicsai result, or NULL.
 wgcna_module_ai_summary_server <- function(id,
@@ -51,7 +52,8 @@ wgcna_module_ai_summary_server <- function(id,
                                            pgx,
                                            r_module,
                                            parent_session,
-                                           watermark = FALSE) {
+                                           watermark = FALSE,
+                                           user_email = NULL) {
   # Build prompt data from the currently selected module and live WGCNA object.
   summary_params <- shiny::reactive({
     res <- wgcna()
@@ -88,13 +90,17 @@ wgcna_module_ai_summary_server <- function(id,
   })
 
   # Render the serial on-demand AI summary card; no PGX write-back happens here.
+  # The card emits one telemetry event per generation tagged source="wgcna_summary".
+  # TODO(telemetry): thread auth$email for attribution (no auth in WgcnaBoard scope).
   AiTextCardServer(
     id = id,
     params_reactive = shiny::reactive(list()),
     template_reactive = template,
     config_reactive = config,
     cache = omicsai::omicsai_cache_init("mem"),
-    watermark = watermark
+    watermark = watermark,
+    user_email = user_email,
+    telemetry_source = "wgcna_summary"
   )
 }
 

--- a/components/modules/AiCards.R
+++ b/components/modules/AiCards.R
@@ -31,6 +31,8 @@ get_ai_model <- function(parent_session) {
 #' @param config_reactive Reactive returning an `omicsai_config`.
 #' @param cache Optional omicsai cache object.
 #' @param watermark Logical; add watermark in PlotModule.
+#' @param user_email Optional user email for telemetry attribution.
+#' @param telemetry_source Telemetry `source` tag for this card's generations.
 #'
 #' @return Reactive returning the latest omicsai result, or NULL.
 AiTextCardServer <- function(id,
@@ -38,7 +40,9 @@ AiTextCardServer <- function(id,
                              template_reactive,
                              config_reactive,
                              cache = NULL,
-                             watermark = FALSE) {
+                             watermark = FALSE,
+                             user_email = NULL,
+                             telemetry_source = "card") {
   shiny::moduleServer(id, function(input, output, session) {
     # Prepare card-local state and cache for one on-demand text result.
     module_cache <- if (is.null(cache)) omicsai::omicsai_cache_init("mem") else cache
@@ -97,6 +101,19 @@ AiTextCardServer <- function(id,
       } else {
         rv$status <- "done"
         rv$result <- result
+
+        # Telemetry must never break the card: usage is omicsai's object/list,
+        # passed straight through (no field remapping).
+        tryCatch(
+          ai_telemetry_record(
+            source     = telemetry_source,
+            session_id = session$token,
+            user_email = user_email %||% NA_character_,
+            model      = model,
+            usage      = result$metadata$usage
+          ),
+          error = function(e) NULL
+        )
       }
       info("[AiTextCardServer] text generation finished: id=", id,
            " status=", rv$status,

--- a/components/modules/AiTelemetry.R
+++ b/components/modules/AiTelemetry.R
@@ -1,0 +1,490 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
+##
+
+## AI usage telemetry — a flat, append-only, frozen-priced event table.
+##
+## One row per AI call lands in a single common SQLite store
+## (etc/ai_telemetry.sqlite, carrying a user_email column) that ships to
+## BigOmics servers for downstream analytics. Two ingestion paths feed it:
+##
+##   * ai_telemetry_collect_chat()  — PULL: scans assistant turns in a user's
+##     chat store (sessions-<user>.sqlite) and appends one event per turn.
+##     Idempotent via INSERT OR IGNORE on event_id = "<session>#t<turn_idx>".
+##   * ai_telemetry_record()        — PUSH: one-shot sink for reports / cards /
+##     wgcna summaries that generate AI text outside the chat flow.
+##
+## Token parsing is delegated wholesale to omicsai / omicsagentovi:
+##   omicsagentovi::turn_from_payload() reconstructs an ellmer::Turn from the
+##   stored payload, and omicsai::omicsai_turn_usage() returns a typed S7
+##   <omicsai_usage> (slots read with @, never $). We never re-implement the
+##   provider-specific json.usage path parsing here.
+
+## ---------------------------------------------------------------------------
+## Default paths
+##
+## ETC is the app-wide config dir (components/app/R/global.R), but it is unbound
+## when this file is sourced standalone (tests, CLI). Resolve lazily so the
+## signatures stay valid at source time and fall back to a relative "etc".
+
+.ai_tel_default_db <- function() {
+  file.path(if (exists("ETC")) ETC else "etc", "ai_telemetry.sqlite")
+}
+
+.ai_tel_default_pricing <- function() {
+  file.path(if (exists("ETC")) ETC else "etc", "model_pricing.yml")
+}
+
+## ---------------------------------------------------------------------------
+## .2 — DB layer: schema + open
+
+#' Create the ai_usage_events table and set WAL pragmas
+#'
+#' Idempotent (CREATE TABLE IF NOT EXISTS). busy_timeout is essential here —
+#' unlike a per-session chat store this common db has many concurrent writers.
+#' @param con An open DBI connection.
+#' @return invisible(con)
+.ai_tel_ensure_schema <- function(con) {
+  DBI::dbExecute(con, "PRAGMA journal_mode = WAL")
+  DBI::dbExecute(con, "PRAGMA synchronous = NORMAL")
+  DBI::dbExecute(con, "PRAGMA busy_timeout = 5000")
+  DBI::dbExecute(con, "
+    CREATE TABLE IF NOT EXISTS ai_usage_events (
+      event_id        TEXT PRIMARY KEY,
+      source          TEXT,
+      session_id      TEXT,
+      turn_idx        INTEGER,
+      user_email      TEXT,
+      model           TEXT,
+      created_at      REAL,
+      recorded_at     REAL,
+      tool_count      INTEGER,
+      input_fresh     INTEGER,
+      input_cached    INTEGER,
+      output          INTEGER,
+      reasoning       INTEGER,
+      total           INTEGER,
+      cache_hit_rate  REAL,
+      approx_price_usd REAL,
+      pricing_version TEXT
+    )")
+  invisible(con)
+}
+
+#' Open the common telemetry db (read-write) and ensure its schema
+#'
+#' Caller owns the connection and must DBI::dbDisconnect() it.
+#' @param db_path Path to the SQLite file. Created if missing.
+#' @param create When TRUE, ensure the parent dir + schema exist.
+#' @return An open DBI connection.
+ai_telemetry_open <- function(db_path = .ai_tel_default_db(), create = TRUE) {
+  if (create) {
+    dir <- dirname(db_path)
+    if (!dir.exists(dir)) dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  }
+  con <- DBI::dbConnect(RSQLite::SQLite(), db_path)
+  if (create) .ai_tel_ensure_schema(con)
+  con
+}
+
+## ---------------------------------------------------------------------------
+## .1 — Pricing table + resolver
+
+# Parsed-YAML cache, keyed by "<path>@<mtime>" so a changed file reloads but
+# repeated calls within a session do not re-read from disk.
+.ai_tel_pricing_cache <- new.env(parent = emptyenv())
+
+#' Load (and cache) the pricing YAML.
+#' @return The parsed list, or NULL when the file is missing / unreadable.
+.ai_tel_load_pricing <- function(path) {
+  if (is.null(path) || !file.exists(path)) return(NULL)
+  key <- paste0(path, "@", as.numeric(file.info(path)$mtime))
+  cached <- .ai_tel_pricing_cache[[key]]
+  if (!is.null(cached)) return(cached)
+  parsed <- tryCatch(yaml::read_yaml(path), error = function(e) NULL)
+  if (!is.null(parsed)) .ai_tel_pricing_cache[[key]] <- parsed
+  parsed
+}
+
+#' Resolve per-1M-token rates for a model string
+#'
+#' Glob-matches `model` against the YAML keys. Precedence: an exact key wins,
+#' then the most-specific matching glob (longest non-"*" pattern), then the
+#' "*" catch-all. Matches both the session string ("openai:gpt-5.4-nano") and
+#' the dated per-turn model ("gpt-5.4-nano-2026-03-17").
+#' @param model Character model string.
+#' @param path  Path to model_pricing.yml.
+#' @return list(input, cached, output, version), or NULL when unresolved.
+ai_telemetry_pricing <- function(model, path = .ai_tel_default_pricing()) {
+  spec <- .ai_tel_load_pricing(path)
+  if (is.null(spec) || is.null(spec$models) || is.null(model) || is.na(model)) {
+    return(NULL)
+  }
+  keys <- names(spec$models)
+  hit <- NULL
+
+  # 1. exact match
+  if (model %in% keys) {
+    hit <- model
+  } else {
+    # 2. most-specific glob (exclude bare "*"; longest pattern wins)
+    globs <- setdiff(keys, "*")
+    matched <- globs[vapply(globs, function(k) {
+      grepl(utils::glob2rx(k), model)
+    }, logical(1))]
+    if (length(matched)) {
+      hit <- matched[which.max(nchar(matched))]
+    } else if ("*" %in% keys) {
+      # 3. catch-all
+      hit <- "*"
+    }
+  }
+  if (is.null(hit)) return(NULL)
+
+  rates <- spec$models[[hit]]
+  list(
+    input   = rates$input,
+    cached  = rates$cached,
+    output  = rates$output,
+    version = spec$version
+  )
+}
+
+#' Compute the frozen USD price for one usage record
+#'
+#' price = input_fresh/1e6*input + input_cached/1e6*cached +
+#'         (output + reasoning)/1e6*output
+#' NA token counts are treated as 0. Returns NA when pricing is unresolved.
+#' @param usage list/omicsai_usage-like with input_fresh, input_cached, output,
+#'   reasoning fields.
+#' @param model Model string (used to resolve pricing when not supplied).
+#' @param pricing Pre-resolved pricing list (default: resolve from model).
+#' @return numeric(1) USD, rounded to 6 dp.
+ai_telemetry_price <- function(usage, model, pricing = ai_telemetry_pricing(model)) {
+  if (is.null(pricing)) return(NA_real_)
+  known <- function(x) !(is.null(x) || length(x) != 1L || is.na(x))
+  # No token detail at all (e.g. the report future-worker path) -> price is
+  # unknown, NOT zero: a $0 row would understate cost in downstream analytics.
+  if (!any(known(usage$input_fresh), known(usage$input_cached),
+           known(usage$output), known(usage$reasoning))) {
+    return(NA_real_)
+  }
+  z <- function(x) if (is.null(x) || length(x) != 1L || is.na(x)) 0 else as.numeric(x)
+  price <-
+    z(usage$input_fresh)  / 1e6 * z(pricing$input) +
+    z(usage$input_cached) / 1e6 * z(pricing$cached) +
+    (z(usage$output) + z(usage$reasoning)) / 1e6 * z(pricing$output)
+  round(price, 6)
+}
+
+## ---------------------------------------------------------------------------
+## .3 — Turn parser
+
+#' Parse a stored assistant turn payload into a flat usage row
+#'
+#' Reconstructs an ellmer::Turn via omicsagentovi::turn_from_payload() and reads
+#' tokens with omicsai::omicsai_turn_usage() (passing the session model so the
+#' provider — hence cache/reasoning JSON paths — resolves correctly).
+#'
+#' Never throws on a malformed turn: on failure it returns NA token fields with
+#' a best-effort tool_count so collect_chat() can still record the event.
+#'
+#' @param payload_json The raw JSON string from turns.payload_json, OR an
+#'   already-parsed payload list.
+#' @param session_model The model from the sessions row (used for pricing and
+#'   provider resolution).
+#' @return list(model, input_fresh, input_cached, output, reasoning, total,
+#'   cache_hit_rate, tool_count)
+.ai_tel_parse_turn <- function(payload_json, session_model = NULL) {
+  na_row <- function(model = session_model, tool_count = 0L) {
+    list(
+      model          = model,
+      input_fresh    = NA_integer_,
+      input_cached   = NA_integer_,
+      output         = NA_integer_,
+      reasoning      = NA_integer_,
+      total          = NA_integer_,
+      cache_hit_rate = NA_real_,
+      tool_count     = tool_count
+    )
+  }
+
+  payload <- if (is.character(payload_json)) {
+    tryCatch(jsonlite::fromJSON(payload_json, simplifyVector = FALSE),
+             error = function(e) NULL)
+  } else {
+    payload_json
+  }
+  if (!is.list(payload)) return(na_row())
+
+  # tool_count is cheap + robust; compute it before the riskier usage path.
+  tool_count <- tryCatch(
+    sum(vapply(payload$contents, function(c) identical(c$type, "tool_request"),
+               logical(1))),
+    error = function(e) 0L
+  )
+  tool_count <- as.integer(tool_count %||% 0L)
+
+  model <- payload$json$model %||% session_model
+
+  # JSON storage loses the numeric-NA distinction on `tokens` (stored as "NA"
+  # strings). Mirror session-store.R restore: flatten + coerce back to numeric
+  # NA before turn_from_payload(). See omicsagentovi/R/session-store.R ~L1116.
+  tok <- payload$tokens
+  if (!is.null(tok)) {
+    flat <- suppressWarnings(as.numeric(unlist(tok)))
+    payload$tokens <- if (length(flat)) flat else NULL
+  }
+
+  u <- tryCatch({
+    turn <- omicsagentovi::turn_from_payload(payload)
+    omicsai::omicsai_turn_usage(turn, model = session_model)
+  }, error = function(e) NULL)
+
+  if (is.null(u)) return(na_row(model = model, tool_count = tool_count))
+
+  list(
+    model          = model,
+    input_fresh    = u@input_tokens_fresh,
+    input_cached   = u@input_tokens_cached,
+    output         = u@output_tokens,
+    reasoning      = u@reasoning_tokens,
+    total          = u@total_tokens,
+    cache_hit_rate = u@cache_hit_rate,
+    tool_count     = tool_count
+  )
+}
+
+## ---------------------------------------------------------------------------
+## Usage normalisation (shared by record() and the insert helper)
+
+# Coerce an omicsai_usage S7 object / legacy list / NULL into the four token
+# fields the pricing + schema use. S7 is accessed with @ (the $ accessor
+# silently returns NULL on S7), legacy lists with $, NULL maps to all-NA.
+.ai_tel_usage_fields <- function(usage) {
+  if (is.null(usage)) {
+    return(list(input_fresh = NA_integer_, input_cached = NA_integer_,
+                output = NA_integer_, reasoning = NA_integer_,
+                total = NA_integer_, cache_hit_rate = NA_real_))
+  }
+  if (S7::S7_inherits(usage, omicsai::omicsai_usage)) {
+    return(list(
+      input_fresh    = usage@input_tokens_fresh,
+      input_cached   = usage@input_tokens_cached,
+      output         = usage@output_tokens,
+      reasoning      = usage@reasoning_tokens,
+      total          = usage@total_tokens,
+      cache_hit_rate = usage@cache_hit_rate
+    ))
+  }
+  # legacy list shape from .omicsai_extract_usage()
+  list(
+    input_fresh    = usage$input_tokens_fresh,
+    input_cached   = usage$input_tokens_cached,
+    output         = usage$output_tokens,
+    reasoning      = usage$reasoning_tokens,
+    total          = usage$total_tokens,
+    cache_hit_rate = usage$cache_hit_rate
+  )
+}
+
+# Single INSERT OR IGNORE for one event row. Returns the number of rows
+# actually written (0 when the event_id already exists). Assumes `con` already
+# has the schema. NA-safe via as.integer/as.numeric on each field.
+.ai_tel_insert_event <- function(con, fields) {
+  i <- function(x) if (is.null(x) || length(x) != 1L) NA_integer_ else suppressWarnings(as.integer(x))
+  n <- function(x) if (is.null(x) || length(x) != 1L) NA_real_ else suppressWarnings(as.numeric(x))
+  s <- function(x) if (is.null(x) || length(x) != 1L || is.na(x)) NA_character_ else as.character(x)
+
+  DBI::dbExecute(con, "
+    INSERT OR IGNORE INTO ai_usage_events
+      (event_id, source, session_id, turn_idx, user_email, model,
+       created_at, recorded_at, tool_count,
+       input_fresh, input_cached, output, reasoning, total,
+       cache_hit_rate, approx_price_usd, pricing_version)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    params = list(
+      s(fields$event_id), s(fields$source), s(fields$session_id),
+      i(fields$turn_idx), s(fields$user_email), s(fields$model),
+      n(fields$created_at), n(fields$recorded_at), i(fields$tool_count),
+      i(fields$input_fresh), i(fields$input_cached), i(fields$output),
+      i(fields$reasoning), i(fields$total),
+      n(fields$cache_hit_rate), n(fields$approx_price_usd),
+      s(fields$pricing_version)
+    ))
+  changed <- DBI::dbGetQuery(con, "SELECT changes() AS c")$c
+  as.integer(changed %||% 0L)
+}
+
+## ---------------------------------------------------------------------------
+## .7 — record(): one-shot push sink
+
+#' Record a single one-shot AI usage event (reports / cards / wgcna summaries)
+#'
+#' Opens the common db, ensures the schema, prices the usage, and writes one row
+#' with INSERT OR IGNORE. The connection is closed before returning.
+#'
+#' @param source    Source tag, e.g. "report", "card", "wgcna_summary".
+#' @param session_id Session id (one-shot calls supply their own).
+#' @param user_email From auth$email; may be NA.
+#' @param model     Model string (used for pricing + provider resolution).
+#' @param usage     omicsai_usage S7 / legacy list / NULL.
+#' @param turn_idx  Turn index, or NA for one-shot (drives event_id form).
+#' @param tool_count Number of tool calls in the turn.
+#' @param created_at Call time (POSIXct or numeric).
+#' @param db_path    Telemetry db path.
+#' @return invisible(event_id)
+ai_telemetry_record <- function(source, session_id, user_email, model, usage,
+                                turn_idx = NA, tool_count = 0L,
+                                created_at = Sys.time(),
+                                db_path = .ai_tel_default_db()) {
+  # One-shot push events (cards/reports/summaries) have no re-scan, so each
+  # record() call is a DISTINCT event. Keying on session_id alone would collapse
+  # every generation in a Shiny session into one row (INSERT OR IGNORE drops the
+  # rest) — so include the call timestamp (µs) for per-call uniqueness. The chat
+  # PULL path stays deterministic ("<session>#t<turn>") to preserve idempotency.
+  event_id <- if (is.na(turn_idx)) {
+    paste0(source, ":", session_id, ":", sprintf("%.6f", as.numeric(created_at)))
+  } else {
+    paste0(session_id, "#t", turn_idx)
+  }
+
+  uf <- .ai_tel_usage_fields(usage)
+  pricing <- ai_telemetry_pricing(model)
+  price <- ai_telemetry_price(uf, model, pricing)
+
+  fields <- c(
+    list(
+      event_id        = event_id,
+      source          = source,
+      session_id      = session_id,
+      turn_idx        = turn_idx,
+      user_email      = user_email,
+      model           = model,
+      created_at      = as.numeric(created_at),
+      recorded_at     = as.numeric(Sys.time()),
+      tool_count      = tool_count,
+      approx_price_usd = price,
+      pricing_version = pricing$version
+    ),
+    uf
+  )
+
+  con <- ai_telemetry_open(db_path, create = TRUE)
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  .ai_tel_insert_event(con, fields)
+
+  invisible(event_id)
+}
+
+## ---------------------------------------------------------------------------
+## .5 — collect_chat(): idempotent pull from a user's chat store
+
+#' Ingest a user's assistant chat turns into the common telemetry db
+#'
+#' Reads sessions-<user>.sqlite read-only (WAL: readers never block writers),
+#' joins each assistant turn to its session model, prices it, and appends one
+#' event per turn with INSERT OR IGNORE (event_id = "<session>#t<turn_idx>").
+#' Fully synchronous and re-runnable — running twice yields the same row count.
+#'
+#' @param session_dir The user's chats/ directory.
+#' @param user_email  From auth$email.
+#' @param db_path     Telemetry db path.
+#' @return integer count of newly inserted rows.
+ai_telemetry_collect_chat <- function(session_dir, user_email,
+                                      db_path = .ai_tel_default_db()) {
+  chat_db <- .detect_legacy_sessions(session_dir, user_email)
+  if (!file.exists(chat_db)) return(0L)
+
+  ro <- DBI::dbConnect(RSQLite::SQLite(), chat_db, flags = RSQLite::SQLITE_RO)
+  on.exit(DBI::dbDisconnect(ro), add = TRUE)
+
+  rows <- tryCatch(
+    DBI::dbGetQuery(ro, "
+      SELECT t.session_id, t.turn_idx, t.payload_json, s.model
+        FROM turns t
+        LEFT JOIN sessions s ON s.session_id = t.session_id
+       WHERE t.role = 'assistant'"),
+    error = function(e) NULL
+  )
+  if (is.null(rows) || nrow(rows) == 0L) return(0L)
+
+  con <- ai_telemetry_open(db_path, create = TRUE)
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  n_new <- 0L
+  for (k in seq_len(nrow(rows))) {
+    session_id <- rows$session_id[[k]]
+    turn_idx   <- rows$turn_idx[[k]]
+    model_in   <- rows$model[[k]]
+    parsed <- .ai_tel_parse_turn(rows$payload_json[[k]], session_model = model_in)
+
+    pricing <- ai_telemetry_pricing(parsed$model)
+    price <- ai_telemetry_price(parsed, parsed$model, pricing)
+
+    fields <- list(
+      event_id         = paste0(session_id, "#t", turn_idx),
+      source           = "chat",
+      session_id       = session_id,
+      turn_idx         = turn_idx,
+      user_email       = user_email,
+      model            = parsed$model,
+      created_at       = NA_real_,
+      recorded_at      = as.numeric(Sys.time()),
+      tool_count       = parsed$tool_count,
+      input_fresh      = parsed$input_fresh,
+      input_cached     = parsed$input_cached,
+      output           = parsed$output,
+      reasoning        = parsed$reasoning,
+      total            = parsed$total,
+      cache_hit_rate   = parsed$cache_hit_rate,
+      approx_price_usd = price,
+      pricing_version  = pricing$version
+    )
+    n_new <- n_new + .ai_tel_insert_event(con, fields)
+  }
+  as.integer(n_new)
+}
+
+## ---------------------------------------------------------------------------
+## App-scope helpers: chat-db naming + one-shot legacy migration.
+## Single source of truth for the per-user chat filename; the Shiny worker
+## (CopilotBoardServer / SessionStore wiring) calls these.
+
+#' Per-user chat-store filename
+#'
+#' user_dir is already pgx_dir/<email> so the email is filesystem-safe, but
+#' defensively neutralise path separators and control characters.
+#' @param email User email.
+#' @return "sessions-<fs-safe email>.sqlite"
+.ai_tel_sessions_db_name <- function(email) {
+  if (is.null(email) || length(email) != 1L || is.na(email) || !nzchar(email)) {
+    return("sessions.sqlite")
+  }
+  safe <- gsub("[/\\\\[:cntrl:]]", "_", email)
+  paste0("sessions-", safe, ".sqlite")
+}
+
+#' Resolve the per-user chat db, migrating a legacy sessions.sqlite once
+#'
+# DELETE AFTER ~2026-07-23 once dev team migrated (epic omicsplayground-iyp.4).
+# AI usage has been internal-only so a single rename pass is safe: if the legacy
+# shared sessions.sqlite exists and the per-user target does not, rename it
+# (plus its -wal/-shm/-journal sidecars) into place.
+#'
+#' @param chat_dir The user's chats/ directory.
+#' @param email    User email.
+#' @return Path to the resolved per-user db.
+.detect_legacy_sessions <- function(chat_dir, email) {
+  target <- file.path(chat_dir, .ai_tel_sessions_db_name(email))
+  legacy <- file.path(chat_dir, "sessions.sqlite")
+  if (file.exists(legacy) && !file.exists(target)) {
+    file.rename(legacy, target)
+    for (ext in c("-wal", "-shm", "-journal")) {
+      side_old <- paste0(legacy, ext)
+      if (file.exists(side_old)) file.rename(side_old, paste0(target, ext))
+    }
+  }
+  target
+}

--- a/etc/model_pricing.yml
+++ b/etc/model_pricing.yml
@@ -1,0 +1,56 @@
+# Model pricing for AI telemetry (etc/ai_telemetry.sqlite)
+#
+# Rates are USD per 1,000,000 tokens, split into:
+#   input  — fresh (non-cached) input tokens
+#   cached — input tokens served from the provider prompt cache
+#   output — output tokens (reasoning tokens are billed at the output rate)
+#
+# IMPORTANT: these rates are REPRESENTATIVE PLACEHOLDERS. Several of the models
+# listed here post-date the provider price sheets available at authoring time.
+# Before relying on `approx_price_usd` for billing/analytics, update every entry
+# from the official provider pricing page and bump `version`.
+#
+# Keys are glob patterns matched (longest/most-specific wins) against BOTH the
+# session model string ("openai:gpt-5.4-nano") and the dated per-turn model from
+# the provider JSON ("gpt-5.4-nano-2026-03-17"). The trailing "*" entry is the
+# catch-all fallback.
+
+version: "2026-06-23"
+
+models:
+  "*gpt-5.4-nano*":
+    input: 0.05
+    cached: 0.005
+    output: 0.40
+  "*gpt-5.4-mini*":
+    input: 0.25
+    cached: 0.025
+    output: 2.00
+  "*gpt-5.4*":
+    input: 1.25
+    cached: 0.125
+    output: 10.00
+  "*gpt-4o-mini*":
+    input: 0.15
+    cached: 0.075
+    output: 0.60
+  "*gpt-4o*":
+    input: 2.50
+    cached: 1.25
+    output: 10.00
+  "*claude*haiku*":
+    input: 0.80
+    cached: 0.08
+    output: 4.00
+  "*claude*sonnet*":
+    input: 3.00
+    cached: 0.30
+    output: 15.00
+  "*claude*opus*":
+    input: 15.00
+    cached: 1.50
+    output: 75.00
+  "*":
+    input: 1.00
+    cached: 0.10
+    output: 4.00

--- a/tests/testthat/test-ai-telemetry.R
+++ b/tests/testthat/test-ai-telemetry.R
@@ -1,0 +1,171 @@
+## Tests for the AI telemetry core module (components/modules/AiTelemetry.R).
+## Covers pricing resolution + math, DB schema/idempotency, the turn parser,
+## record() push sink, and collect_chat() idempotent pull.
+
+source(file.path(rprojroot::find_root(rprojroot::has_file("DESCRIPTION")),
+                 "components", "modules", "AiTelemetry.R"))
+
+# A pricing YAML written into `dir` so tests don't depend on etc/.
+.write_pricing_yaml <- function(dir) {
+  path <- file.path(dir, "model_pricing.yml")
+  writeLines(c(
+    'version: "test-2026-06-23"',
+    "models:",
+    '  "*gpt-5.4-nano*":',
+    "    input: 0.05",
+    "    cached: 0.005",
+    "    output: 0.40",
+    '  "*":',
+    "    input: 1.0",
+    "    cached: 0.1",
+    "    output: 2.0"
+  ), path)
+  path
+}
+
+# Build a faithful assistant payload via the real codec round-trip, so the
+# parser is exercised against exactly what sessions.sqlite stores. ellmer
+# normalises tokens to c(fresh, output, cached); reasoning is carried only in
+# json$usage, so this also exercises the json fallback for reasoning_tokens.
+.synthetic_payload <- function() {
+  turn <- ellmer::Turn(
+    role = "assistant",
+    contents = list(
+      ellmer::ContentText(text = "hello"),
+      ellmer::ContentToolRequest(id = "t1", name = "query_de", arguments = list())
+    ),
+    tokens = c(13966, 37, 2000)
+  )
+  S7::prop(turn, "json") <- list(
+    model = "gpt-5.4-nano-2026-03-17",
+    usage = list(
+      input_tokens_details  = list(cached_tokens = 2000),
+      output_tokens_details = list(reasoning_tokens = 10)
+    )
+  )
+  omicsagentovi::turn_to_payload(turn)
+}
+
+test_that("pricing resolves both the session and dated model to the same rates", {
+  d <- tempfile("pdir"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  yml <- .write_pricing_yaml(d)
+  a <- ai_telemetry_pricing("openai:gpt-5.4-nano", path = yml)
+  b <- ai_telemetry_pricing("gpt-5.4-nano-2026-03-17", path = yml)
+  expect_equal(a$input, 0.05)
+  expect_equal(a[c("input", "cached", "output")], b[c("input", "cached", "output")])
+  expect_equal(a$version, "test-2026-06-23")
+})
+
+test_that("catch-all glob is used only when nothing more specific matches", {
+  d <- tempfile("pdir"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  yml <- .write_pricing_yaml(d)
+  expect_equal(ai_telemetry_pricing("some-unknown-model", path = yml)$input, 1.0)
+})
+
+test_that("price matches a hand-computed reference", {
+  pricing <- list(input = 0.05, cached = 0.005, output = 0.40, version = "x")
+  usage <- list(input_fresh = 13966, input_cached = 2000, output = 37, reasoning = 10)
+  ref <- 13966/1e6*0.05 + 2000/1e6*0.005 + (37 + 10)/1e6*0.40
+  expect_equal(ai_telemetry_price(usage, "m", pricing), round(ref, 6))
+})
+
+test_that("price is NA (not 0) when no token detail is known", {
+  pricing <- list(input = 0.05, cached = 0.005, output = 0.40, version = "x")
+  usage <- list(input_fresh = NA, input_cached = NA, output = NA, reasoning = NA)
+  expect_true(is.na(ai_telemetry_price(usage, "m", pricing)))
+})
+
+test_that("price is NA when pricing is unresolved", {
+  expect_true(is.na(ai_telemetry_price(list(output = 5), "m", pricing = NULL)))
+})
+
+test_that("opening a fresh db creates the table and re-open is idempotent", {
+  db <- tempfile("tel", fileext = ".sqlite"); on.exit(unlink(db))
+  con <- ai_telemetry_open(db)
+  expect_true("ai_usage_events" %in% DBI::dbListTables(con))
+  DBI::dbDisconnect(con)
+  con2 <- ai_telemetry_open(db)
+  expect_true("ai_usage_events" %in% DBI::dbListTables(con2))
+  DBI::dbDisconnect(con2)
+})
+
+test_that("parser extracts tokens, cache, reasoning and tool_count", {
+  skip_if_not(requireNamespace("omicsai", quietly = TRUE))
+  skip_if_not(requireNamespace("omicsagentovi", quietly = TRUE))
+  p <- .ai_tel_parse_turn(.synthetic_payload(), session_model = "openai:gpt-5.4-nano")
+  expect_equal(p$tool_count, 1L)
+  expect_equal(p$model, "gpt-5.4-nano-2026-03-17")
+  expect_equal(p$input_fresh, 13966L)
+  expect_equal(p$output, 37L)
+  expect_equal(p$input_cached, 2000L)  # recovered from json$usage
+  expect_equal(p$reasoning, 10L)
+})
+
+test_that("parser never throws on malformed input", {
+  p <- .ai_tel_parse_turn("{ not valid json", session_model = "m")
+  expect_true(is.na(p$total))
+  expect_equal(p$tool_count, 0L)
+})
+
+test_that("record() writes one event with the expected id and source", {
+  d <- tempfile("recdir"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  db <- file.path(d, "ai_telemetry.sqlite")
+  usage <- list(input_tokens_fresh = 100, input_tokens_cached = 0,
+                output_tokens = 50, reasoning_tokens = 0)
+  ai_telemetry_record("report", "sess-1", "u@x.com", "openai:gpt-5.4-nano",
+                      usage, db_path = db)
+  con <- DBI::dbConnect(RSQLite::SQLite(), db); on.exit(DBI::dbDisconnect(con), add = TRUE)
+  rows <- DBI::dbGetQuery(con, "SELECT * FROM ai_usage_events")
+  expect_equal(nrow(rows), 1L)
+  expect_equal(rows$source, "report")
+  expect_match(rows$event_id, "^report:sess-1:")  # source:session:timestamp
+})
+
+test_that("two one-shot events in the same session produce two rows (no collapse)", {
+  d <- tempfile("recdir2"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  db <- file.path(d, "ai_telemetry.sqlite")
+  usage <- list(input_tokens_fresh = 100, output_tokens = 50)
+  t0 <- as.POSIXct(1750000000, origin = "1970-01-01", tz = "UTC")
+  # Same source + session_id (a stable Shiny session token), distinct calls.
+  ai_telemetry_record("card", "tok-1", "u@x.com", "openai:gpt-5.4-nano", usage,
+                      created_at = t0,     db_path = db)
+  ai_telemetry_record("card", "tok-1", "u@x.com", "openai:gpt-5.4-nano", usage,
+                      created_at = t0 + 1, db_path = db)
+  con <- DBI::dbConnect(RSQLite::SQLite(), db); on.exit(DBI::dbDisconnect(con), add = TRUE)
+  n <- DBI::dbGetQuery(con, "SELECT COUNT(*) n FROM ai_usage_events")$n
+  expect_equal(n, 2L)  # would be 1 under the old session-only event_id
+})
+
+test_that("sessions db name + legacy migration helper", {
+  expect_equal(.ai_tel_sessions_db_name("a@b.com"), "sessions-a@b.com.sqlite")
+  expect_equal(.ai_tel_sessions_db_name(NA), "sessions.sqlite")
+
+  d <- tempfile("chatdir"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  legacy <- file.path(d, "sessions.sqlite")
+  writeLines("x", legacy)
+  resolved <- .detect_legacy_sessions(d, "a@b.com")
+  expect_equal(basename(resolved), "sessions-a@b.com.sqlite")
+  expect_true(file.exists(resolved))
+  expect_false(file.exists(legacy))
+})
+
+test_that("collect_chat is idempotent over a synthetic chat store", {
+  skip_if_not(requireNamespace("omicsai", quietly = TRUE))
+  skip_if_not(requireNamespace("omicsagentovi", quietly = TRUE))
+  d <- tempfile("chats"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  chat_db <- file.path(d, .ai_tel_sessions_db_name("u@x.com"))
+  cc <- DBI::dbConnect(RSQLite::SQLite(), chat_db)
+  DBI::dbExecute(cc, "CREATE TABLE sessions (session_id TEXT PRIMARY KEY, model TEXT)")
+  DBI::dbExecute(cc, "CREATE TABLE turns (session_id TEXT, turn_idx INTEGER, role TEXT, payload_json TEXT, PRIMARY KEY (session_id, turn_idx))")
+  DBI::dbExecute(cc, "INSERT INTO sessions VALUES ('s1', 'openai:gpt-5.4-nano')")
+  pj <- jsonlite::toJSON(.synthetic_payload(), auto_unbox = TRUE, null = "null")
+  DBI::dbExecute(cc, "INSERT INTO turns VALUES ('s1', 1, 'assistant', ?)", params = list(pj))
+  DBI::dbExecute(cc, "INSERT INTO turns VALUES ('s1', 2, 'user', '{}')")
+  DBI::dbDisconnect(cc)
+
+  db <- file.path(d, "ai_telemetry.sqlite")
+  n1 <- ai_telemetry_collect_chat(d, "u@x.com", db_path = db)
+  n2 <- ai_telemetry_collect_chat(d, "u@x.com", db_path = db)
+  expect_equal(n1, 1L)   # only the assistant turn
+  expect_equal(n2, 0L)   # idempotent re-run
+})


### PR DESCRIPTION
## Summary

This PR will allow us to monitor token usage per user with two db:
- data/user@email.sql
- etc/ai_telemetry.sql

The main logic lives in `components/modules/AiTelemetry.R`.

- `ai_telemetry_collect_chat():` runs on the copilot save tick, gather token usage per turn.
- `ai_telemetry_record()` writes token usage in db.

## Verify

Add:
```
USER$username <- "test"
USER$email <- "test@bigomics.com"
```

1. Start new session with Obi-Two. Send message. New db should appear with token count.
2. Repeat operation, new rows added.
3. Reopen old session, new rows added*.

*Note, token usage comes per turn to avoid issues with reopening sessions. Aggregation should be done in our side.

## Dependency

Merge omicsagentovi `feat/session-store-db-name` first.