### PR TITLE
feat: send raw counts + preprocess settings to createPGX (bulk upload)

### DIFF
--- a/bin/pgxcreate_op.R
+++ b/bin/pgxcreate_op.R
@@ -25,6 +25,7 @@ pgx <- playbase::pgx.createPGX(
   organism = params$organism,
   counts = params$counts,
   X = params$countsX,
+  preprocess = params$preprocess,
   norm_method = params$norm_method,
   samples = params$samples,
   contrasts = params$contrasts,

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -10,6 +10,9 @@ upload_module_computepgx_server <- function(
   id,
   countsRT,
   countsX,
+  preprocess = shiny::reactive(NULL),
+  rawCountsRT = shiny::reactive(NULL),
+  rawAnnotRT = shiny::reactive(NULL),
   norm_method,
   samplesRT,
   azimuth_ref,
@@ -1054,6 +1057,22 @@ upload_module_computepgx_server <- function(
           annot_table <- NULL
         }
 
+        ## Data sent to createPGX. Bulk: send RAW counts + preprocess settings so a
+        ## script/endpoint reproduces the app exactly (X is rebuilt inside createPGX
+        ## via playbase::pgx.preprocess). scRNA: keep its own pipeline unchanged
+        ## (X is unused by createSingleCellPGX).
+        if (upload_datatype() == "scRNA-seq") {
+          pgx_counts <- counts
+          pgx_countsX <- countsX
+          pgx_annot <- annot_table
+          pgx_preprocess <- NULL
+        } else {
+          pgx_counts <- rawCountsRT()
+          pgx_countsX <- NULL
+          pgx_annot <- rawAnnotRT()
+          pgx_preprocess <- preprocess()
+        }
+
         ## -----------------------------------------------------------
         ## Set statistical methods and run parameters
         ## -----------------------------------------------------------
@@ -1188,13 +1207,14 @@ upload_module_computepgx_server <- function(
         params <- list(
           organism = upload_organism(),
           samples = samples,
-          counts = counts,
-          countsX = countsX,
+          counts = pgx_counts,
+          countsX = pgx_countsX,
+          preprocess = pgx_preprocess,
           azimuth_ref = azimuth_ref(),
           contrasts = contrasts,
           probe_type = probetype(),
           # ------- extra tables ---------
-          annot_table = annot_table,
+          annot_table = pgx_annot,
           custom.geneset = custom_geneset,
           custom_fc = custom_fc,
           #-------- preprocess options ---------

--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -1359,6 +1359,29 @@ upload_module_normalization_server <- function(
         return(ll)
       })
 
+      ## Single options list that reproduces this module's normalization
+      ## (imputedX -> normalizedX -> cleanX) inside playbase::pgx.preprocess().
+      ## The compute path sends these settings + RAW counts instead of the
+      ## precomputed X, so a script/endpoint gets an identical result.
+      ## Batch correction is NOT here: it runs inside pgx.createPGX (bc_method).
+      preprocess <- reactive({
+        list(
+          datatype = upload_datatype(),
+          is_npx = isTRUE(is.olink()) || isTRUE(is.nulisa()),
+          zero_as_na = zero_as_na(),
+          normalize = isTRUE(input$normalize),
+          norm_method = input$normalization_method,
+          ref_gene = if (identical(input$normalization_method, "reference")) input$ref_gene else NULL,
+          filter_missing = isTRUE(input$filtermissing),
+          filter_threshold = input$filterthreshold,
+          impute = isTRUE(input$impute),
+          impute_method = input$impute_method,
+          remove_outliers = isTRUE(input$remove_outliers),
+          outlier_threshold = input$outlier_threshold,
+          meth_type = meth_type()
+        )
+      })
+
       return(
         list(
           counts = counts,
@@ -1367,7 +1390,8 @@ upload_module_normalization_server <- function(
           imputation_method = imputation_method,
           bc_method = bc_method,
           remove_outliers = remove_outliers,
-          annot = annot
+          annot = annot,
+          preprocess = preprocess
         )
       ) ## pointing to reactive
     } ## end-of-server

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -1327,6 +1327,7 @@ UploadBoard <- function(id,
       if (input$selected_datatype == "scRNA-seq") {
         compute_input$counts <- sc_normalized$counts()
         compute_input$X <- sc_normalized$X()
+        compute_input$preprocess <- NULL ## scRNA has its own pipeline; X unused by createPGX
         compute_input$norm_method <- sc_normalized$norm_method()
         compute_input$samples <- sc_normalized$samples()
         compute_input$azimuth_ref <- sc_normalized$azimuth_ref()
@@ -1336,6 +1337,7 @@ UploadBoard <- function(id,
       } else {
         compute_input$counts <- normalized$counts()
         compute_input$X <- normalized$X()
+        compute_input$preprocess <- normalized$preprocess()
         compute_input$norm_method <- normalized$norm_method()
         compute_settings$imputation_method <- normalized$imputation_method()
         compute_settings$bc_method <- normalized$bc_method()
@@ -1348,6 +1350,9 @@ UploadBoard <- function(id,
       id = "compute",
       countsRT = shiny::reactive(compute_input$counts),
       countsX = shiny::reactive(compute_input$X),
+      preprocess = shiny::reactive(compute_input$preprocess),
+      rawCountsRT = shiny::reactive(checked_samples_counts()$COUNTS),
+      rawAnnotRT = shiny::reactive(checked_annot()$matrix),
       norm_method = shiny::reactive(compute_input$norm_method),
       samplesRT = shiny::reactive(compute_input$samples),
       azimuth_ref = shiny::reactive(compute_input$azimuth_ref),


### PR DESCRIPTION
Depends on bigomics/playbase#493 — merge and rebuild playbase first.

The upload flow used to precompute the normalized matrix X in the normalization
module and pass it to `pgx.createPGX(X=...)`; a script/endpoint that only sent raw
counts got a plain log2 instead, so results diverged. The bulk path now sends RAW
counts + a serializable `preprocess` settings list, and createPGX rebuilds X via
`playbase::pgx.preprocess` — one implementation for app / script / endpoint.

- `upload_module_normalization.R`: expose one `preprocess` options reactive from the
  module's own inputs. Preview panels unchanged.
- `upload_server.R`: thread `preprocess` + the same RAW counts/annot the module
  consumes into the compute module.
- `upload_module_computepgx.R`: bulk → counts=raw, annot=raw, countsX=NULL,
  preprocess=opts; scRNA → unchanged (X is unused by createSingleCellPGX). countsX()
  still feeds DE method-selection and NA warnings.
- `pgxcreate_op.R`: pass `preprocess=params$preprocess`.

scRNA-seq path untouched. Verified with a Shiny `testServer` harness: the module's
real computed X equals `pgx.preprocess(raw, module$preprocess())` exactly across 9
setting combinations (norm methods, normalize-off, outlier removal, zero-as-NA,
imputation, missingness filter).