### PR TITLE
fix(upload): show compute busy bar only during computation

### DIFF
--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -781,7 +781,6 @@ UploadBoard <- function(id,
     })
 
     observeEvent(input$start_upload, {
-      show_computing_spinner(value=99)
       recompute_pgx(NULL) ## need to reset ???
     })
 


### PR DESCRIPTION
now the top red bar appears when compute starts, not when we open the upload modal.

without this, if you open the upload modal and close it, the red bar stays there, its better to just display it when actual compute is happening