### PR TITLE
Bring back dataset-sharing notifications on edgy

### DIFF
--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -52,6 +52,7 @@ app_ui <- function(x) {
       shiny::tags$head(shiny::tags$script(src = "static/copy-info-helper.js")),
       shiny::tags$script(src = "custom/close-message.js"),
       shiny::tags$head(shiny::tags$script(src = "static/add-tick-helper.js")),
+      shiny::tags$head(shiny::tags$script(src = "static/shared-badges.js")),
       shiny::tags$head(shiny::tags$script(src = "custom/dropdown-helper.js")),
       shiny::tags$head(shiny::tags$link(rel = "stylesheet", href = "custom/styles.min.css")),
       shiny::tags$head(shiny::tags$link(rel = "shortcut icon", href = "custom/favicon.ico")),

--- a/components/app/R/www/shared-badges.js
+++ b/components/app/R/www/shared-badges.js
@@ -1,27 +1,21 @@
-// Update the "pending received datasets" indicators in the navbar:
-//  - numeric badge on the "Sharing" sub-item
-//  - small red dot on the parent "Datasets" dropdown toggle
+// Update the "pending received datasets" count badge in two places:
+//  - the "Library" pill in the left sidebar (#app-sidebar)
+//  - the "Shared datasets" inner tab title (#load-tabs)
 // Called from loading_module_received.R via shinyjs::runjs("updateSharedBadges(n)").
 function updateSharedBadges(n) {
-  var sub = document.querySelector('a[data-target="sharing-tab"]');
-  if (sub) {
-    var oldSub = sub.querySelector('.shared-pending-badge');
-    if (oldSub) oldSub.remove();
+  var targets = [
+    document.querySelector('#app-sidebar a[data-value="Library"]'),
+    document.querySelector('#load-tabs a[data-value="sharing_tab"]')
+  ];
+  targets.forEach(function (el) {
+    if (!el) return;
+    var old = el.querySelector('.shared-pending-badge');
+    if (old) old.remove();
     if (n > 0) {
       var b = document.createElement('span');
       b.className = 'shared-pending-badge';
       b.textContent = n;
-      sub.appendChild(b);
-    }
-  }
-  document.querySelectorAll('.nav-link.dropdown-toggle').forEach(function (el) {
-    if (el.textContent.trim().indexOf('Datasets') !== 0) return;
-    var oldDot = el.querySelector('.shared-pending-dot');
-    if (oldDot) oldDot.remove();
-    if (n > 0) {
-      var d = document.createElement('span');
-      d.className = 'shared-pending-dot';
-      el.appendChild(d);
+      el.appendChild(b);
     }
   });
 }

--- a/components/board.loading/R/loading_module_received.R
+++ b/components/board.loading/R/loading_module_received.R
@@ -30,17 +30,21 @@ upload_module_received_server <- function(id,
                                           auth,
                                           pgx_shared_dir,
                                           reload_pgxdir,
-                                          current_page) {
+                                          current_page,
+                                          goto_sharing_tab = NULL) {
   shiny::moduleServer(
     id, function(input, output, session) {
       ns <- session$ns ## NAMESPACE
 
       nr_ds_received <- reactiveVal(0)
 
-      # callbackR for the "New dataset received" modal: jump to Shared datasets
+      # callbackR for the "New dataset received" modal: jump to Shared datasets.
+      # The old bigdash "sharing-tab" board was folded into the Library board's
+      # inner tabset during the UI reshuffle, so navigation is delegated to the
+      # LoadingBoard via goto_sharing_tab().
       show_shared_tab <- function(value) {
-        if (isTRUE(value)) {
-          bigdash.selectTab(session, "sharing-tab")
+        if (isTRUE(value) && !is.null(goto_sharing_tab)) {
+          goto_sharing_tab()
         }
       }
 

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -37,13 +37,22 @@ LoadingBoard <- function(id,
     ## Received/shared UI
     ## -------------------------------------------------------------------
 
+    ## Navigate to the "Shared datasets" inner tab of the Library board. The old
+    ## bigdash "sharing-tab" board was folded into this tabset during the UI
+    ## reshuffle, so bigdash.selectTab() no longer reaches it.
+    goto_sharing_tab <- function() {
+      bslib::nav_select("app-sidebar", "Library", session = parent)
+      shiny::updateTabsetPanel(session, "tabs", selected = "sharing_tab")
+    }
+
     pgxreceived <- upload_module_received_server(
       id = "received",
       auth = auth,
       pgx_shared_dir = pgx_shared_dir,
       ##      max_datasets = auth$options$MAX_DATASETS,  ## wrong and not needed...
       reload_pgxdir = reload_pgxdir,
-      current_page = current_page
+      current_page = current_page,
+      goto_sharing_tab = goto_sharing_tab
     )
 
     pgxshared <- upload_module_shared_server(


### PR DESCRIPTION
The dataset-sharing feature (notification + navigation + navbar badge when someone shares a dataset with you) lives on **devel**, but the **edgy** UI reshuffle broke it. This brings it back.

**What edgy broke:**
- The "New dataset received!" popup's *Go to shared datasets* button called `bigdash.selectTab(session, "sharing-tab")`, but that bigdash board was folded into the Library board's inner tabset — so the button did nothing.
- The pending-count badge died twice over: `ui.R` dropped the `<script src="static/shared-badges.js">` tag, and the badge JS still targeted the old bigdash navbar (`a[data-target="sharing-tab"]` / "Datasets" dropdown) that no longer exists.

**Fix:**
- Navigation now delegates to `LoadingBoard` → jumps to Library board + `sharing_tab` inner tab.
- Badge JS retargeted to the **Library** sidebar pill and the **Shared datasets** tab title; re-added the dropped script tag. CSS `.shared-pending-badge` was already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)