### PR TITLE
Reactome pathway board: native diagrams, no live reactome.org call

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -197,6 +197,13 @@ opt.file <- file.path(ETC, "OPTIONS")
 if (!file.exists(opt.file)) stop("FATAL ERROR: cannot find OPTIONS file")
 opt <- playbase::pgx.readOptions(file = opt.file, default = opt.default) ## global!
 
+## Base URL of the Reactome native-diagram SVG mirror, consumed by
+## playbase::getReactomeSVG. Prefer the environment variable (deployment); fall
+## back to the REACTOME_SVG_URL key in etc/OPTIONS. Empty = feature disabled.
+if (Sys.getenv("REACTOME_SVG_URL") == "" && !is.null(opt$REACTOME_SVG_URL)) {
+  Sys.setenv(REACTOME_SVG_URL = opt$REACTOME_SVG_URL)
+}
+
 message("\n************************************************")
 message("************* SETTING DEFAULTS ***************")
 message("************************************************")

--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -197,13 +197,6 @@ opt.file <- file.path(ETC, "OPTIONS")
 if (!file.exists(opt.file)) stop("FATAL ERROR: cannot find OPTIONS file")
 opt <- playbase::pgx.readOptions(file = opt.file, default = opt.default) ## global!
 
-## Base URL of the Reactome native-diagram SVG mirror, consumed by
-## playbase::getReactomeSVG. Prefer the environment variable (deployment); fall
-## back to the REACTOME_SVG_URL key in etc/OPTIONS. Empty = feature disabled.
-if (Sys.getenv("REACTOME_SVG_URL") == "" && !is.null(opt$REACTOME_SVG_URL)) {
-  Sys.setenv(REACTOME_SVG_URL = opt$REACTOME_SVG_URL)
-}
-
 message("\n************************************************")
 message("************* SETTING DEFAULTS ***************")
 message("************************************************")

--- a/components/board.pathway/R/pathway_plot_reactome_graph.R
+++ b/components/board.pathway/R/pathway_plot_reactome_graph.R
@@ -108,15 +108,13 @@ functional_plot_reactome_graph_server <- function(id,
         pathway.name <- df[sel.row, "pathway"]
         pw.genes <- unlist(playdata::getGSETS(as.character(pathway.name)))
 
-        ## Render from the locally bundled SBGN files (board.pathway/inst/sbgn).
-        ## reactome.org's live SVG exporter is Cloudflare-blocked for server-side
-        ## fetches; the reactome table above is already filtered to pathways that
-        ## have a local SBGN file, so this resolves for every selectable row.
-        sbgn.dir <- pgx.system.file("sbgn/", package = "pathway")
-        sbgn.dir <- normalizePath(sbgn.dir)
+        ## Fetch the native Reactome diagram SVG from our mirror. reactome.org's
+        ## live exporter is Cloudflare-blocked for server-side fetches; the table
+        ## above is filtered to pathways that resolve to a diagram, so this
+        ## returns an image for every selectable row (see playbase::getReactomeSVG).
         imgfile <- playbase::getPathwayImage(
           pathway.id,
-          val = fc, sbgn.dir = sbgn.dir, as.img = TRUE
+          val = fc, as.img = TRUE
         )
 
         return(imgfile)

--- a/components/board.pathway/R/pathway_plot_reactome_graph.R
+++ b/components/board.pathway/R/pathway_plot_reactome_graph.R
@@ -122,25 +122,10 @@ functional_plot_reactome_graph_server <- function(id,
 
       plot_RENDER <- function() {
         img <- get_image()
-
-        ## nothing selected yet -> keep the panel blank (get_image returns src = "")
-        if (!is.null(img) && !is.null(img$src) && !nzchar(img$src)) {
-          shiny::req(FALSE)
-        }
-
-        ## selected, but no local diagram could be rendered -> note instead of a crash
+        ## blank until a pathway with an available diagram is selected; the
+        ## reactome table is already filtered to resolvable pathways.
+        shiny::req(img$src, file.exists(img$src))
         filename <- img$src
-        if (is.null(filename) || !file.exists(filename)) {
-          note <- paste0(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="110">',
-            '<text x="15" y="45" font-family="sans-serif" font-size="15">',
-            "<tspan x=\"15\">Reactome diagram is not available for this pathway.</tspan>",
-            "<tspan x=\"15\" dy=\"28\">Use the link in the table to open it on reactome.org.</tspan>",
-            "</text></svg>"
-          )
-          return(svgPanZoom::svgPanZoom(note, controlIconsEnabled = FALSE, viewBox = FALSE))
-        }
-
         img.svg <- readChar(filename, nchars = file.info(filename)$size)
         pz <- svgPanZoom::svgPanZoom(
           img.svg,

--- a/components/board.pathway/R/pathway_plot_reactome_graph.R
+++ b/components/board.pathway/R/pathway_plot_reactome_graph.R
@@ -108,12 +108,15 @@ functional_plot_reactome_graph_server <- function(id,
         pathway.name <- df[sel.row, "pathway"]
         pw.genes <- unlist(playdata::getGSETS(as.character(pathway.name)))
 
-        ## folder with predownloaded SBGN files
-        # sbgn.dir <- pgx.system.file("sbgn/", package = "pathway")
-        # sbgn.dir <- normalizePath(sbgn.dir) ## absolute path
-        imgfile <- playbase::getReactomeSVG(
+        ## Render from the locally bundled SBGN files (board.pathway/inst/sbgn).
+        ## reactome.org's live SVG exporter is Cloudflare-blocked for server-side
+        ## fetches; the reactome table above is already filtered to pathways that
+        ## have a local SBGN file, so this resolves for every selectable row.
+        sbgn.dir <- pgx.system.file("sbgn/", package = "pathway")
+        sbgn.dir <- normalizePath(sbgn.dir)
+        imgfile <- playbase::getPathwayImage(
           pathway.id,
-          val = fc, as.img = TRUE
+          val = fc, sbgn.dir = sbgn.dir, as.img = TRUE
         )
 
         return(imgfile)
@@ -121,8 +124,25 @@ functional_plot_reactome_graph_server <- function(id,
 
       plot_RENDER <- function() {
         img <- get_image()
-        shiny::req(img$src)
+
+        ## nothing selected yet -> keep the panel blank (get_image returns src = "")
+        if (!is.null(img) && !is.null(img$src) && !nzchar(img$src)) {
+          shiny::req(FALSE)
+        }
+
+        ## selected, but no local diagram could be rendered -> note instead of a crash
         filename <- img$src
+        if (is.null(filename) || !file.exists(filename)) {
+          note <- paste0(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="110">',
+            '<text x="15" y="45" font-family="sans-serif" font-size="15">',
+            "<tspan x=\"15\">Reactome diagram is not available for this pathway.</tspan>",
+            "<tspan x=\"15\" dy=\"28\">Use the link in the table to open it on reactome.org.</tspan>",
+            "</text></svg>"
+          )
+          return(svgPanZoom::svgPanZoom(note, controlIconsEnabled = FALSE, viewBox = FALSE))
+        }
+
         img.svg <- readChar(filename, nchars = file.info(filename)$size)
         pz <- svgPanZoom::svgPanZoom(
           img.svg,

--- a/components/board.pathway/R/pathway_server.R
+++ b/components/board.pathway/R/pathway_server.R
@@ -80,8 +80,9 @@ PathwayBoard <- function(id,
       }
 
       ## ----- get REACTOME id
-      sbgn.dir <- pgx.system.file("sbgn/", package = "pathway")
-      reactome.available <- gsub("^.*reactome_|.sbgn$", "", dir(sbgn.dir, pattern = "*.sbgn"))
+      ## pathways for which we can show a native Reactome diagram; sub-pathways
+      ## resolve to an ancestor's diagram (see playbase::reactomeDiagrams).
+      reactome.available <- playbase::reactomeDiagrams()
       reactome.gsets <- grep("R-HSA", rownames(pgx$gsetX), value = TRUE)
       reactome.ids <- gsub(".*R-HSA", "R-HSA", reactome.gsets)
 


### PR DESCRIPTION
### What
The Reactome graph panel fetched diagrams live from `reactome.org/ContentService/exporter/diagram/*.svg`, now behind a Cloudflare bot challenge (403 server-side) — the panel crashed. This switches to Reactome's own pre-rendered diagram SVGs, served locally from playdata, and degrades gracefully.

### How
- `get_image` obtains the diagram via `playbase::getPathwayImage` (which serves the native SVG bundled in playdata), instead of the blocked live exporter.
- The reactome table is filtered by `playbase::reactomeDiagrams()` (pathways that resolve to a diagram, incl. sub-pathways → ancestor diagram).
- `plot_RENDER` guards on the resolved file (`req(img$src, file.exists(img$src))`), so an unavailable diagram is a graceful blank panel rather than a crash — the table filter already guarantees selectable pathways resolve.

### Depends on
- playbase PR bigomics/playbase#495 and the playdata PR shipping the SVGs + map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)