### PR TITLE
fix: include feature name in data view expression CSV/Excel export

### DIFF
--- a/components/board.dataview/R/dataview_plot_expression.R
+++ b/components/board.dataview/R/dataview_plot_expression.R
@@ -103,7 +103,7 @@ dataview_plot_expression_server <- function(id,
       }
 
       pd <- list(
-        df = data.frame(x = gx, samples = samples, group = grp),
+        df = data.frame(feature = gene, x = gx, samples = samples, group = grp),
         geneplot_type = input$geneplot_type,
         groupby = groupby,
         ylab = ylab,


### PR DESCRIPTION
client request

Data view expression plot downloads (violin/box/barplot) were missing the feature name in the exported CSV/Excel — you got value/sample/group columns with no indication of which gene/protein they belonged to