### PR TITLE
feat: record deduplicated token telemetry for AI reports

### DIFF
--- a/components/app_studio/R/aireport_server.R
+++ b/components/app_studio/R/aireport_server.R
@@ -563,17 +563,12 @@ AiReportServer <- function(id, pgx, save_pgx = NULL) {
 
           report_jobs$done <- report_jobs$done + 1L
 
-          # Telemetry: log one event per report generation on the main thread.
-          # TODO(telemetry): tokens unavailable until playbase returns usage from
-          # pgx.update_reports() (computed in the future worker, not returned here).
-          # TODO(telemetry): thread auth$email for attribution (no auth in StudioServer scope).
+          # Telemetry: record one event per report from the persisted pgx$ai slot.
+          # Dataset-keyed event_id makes this idempotent across sessions/reloads.
           tryCatch(
-            ai_telemetry_record(
-              source     = "report",
-              session_id = paste0(session$token, ":", result$module),
-              user_email = NA_character_,
-              model      = llm_model,
-              usage      = NULL
+            ai_telemetry_record_reports(
+              shiny::isolate(shiny::reactiveValuesToList(pgx)),
+              user_email = NA_character_
             ),
             error = function(e) NULL
           )

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -358,6 +358,15 @@ LoadingBoard <- function(id,
               credentials = cred_fn
             )
             updated <- shiny::isolate(ai_report_copy_into_reactive(pgx, pgx_list))
+            if (isTRUE(updated)) {
+              tryCatch(
+                ai_telemetry_record_reports(
+                  shiny::isolate(shiny::reactiveValuesToList(pgx)),
+                  user_email = auth$email
+                ),
+                error = function(e) NULL
+              )
+            }
             if (isTRUE(updated) && isTRUE(is_user_dir) && !is.null(save_pgx)) {
               save_pgx(pgx)
             }

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1485,6 +1485,10 @@ upload_module_computepgx_server <- function(
         if (file.exists(result_pgx)) {
           pgx <- playbase::pgx.load(result_pgx) ## always pgx
           computedPGX(pgx)
+          tryCatch(
+            ai_telemetry_record_reports(pgx, user_email = auth$email),
+            error = function(e) NULL
+          )
         } else {
           info("[computePGX:on_process_completed] : ERROR: Result file not found")
         }

--- a/components/modules/AiReports.R
+++ b/components/modules/AiReports.R
@@ -178,7 +178,9 @@ ai_report_update_text <- function(pgx, reports) {
     value <- tryCatch(as.character(reports[[slot]])[[1L]],
       error = function(e) NA_character_)
     if (is.na(value)) next
-    ai[[slot]]$report <- value
+    ai[[slot]]$report    <- value
+    ai[[slot]]$edited    <- TRUE
+    ai[[slot]]$edited_at <- as.numeric(Sys.time())
   }
 
   pgx$ai <- ai

--- a/components/modules/AiTelemetry.R
+++ b/components/modules/AiTelemetry.R
@@ -488,3 +488,66 @@ ai_telemetry_collect_chat <- function(session_dir, user_email,
   }
   target
 }
+
+## ---------------------------------------------------------------------------
+## .8 — record_reports(): reconcile helper for AI report slots
+
+#' Record telemetry for all AI report slots that carry usage data
+#'
+#' Scans \code{pgx$ai} and calls \code{ai_telemetry_record()} once per slot
+#' that has a non-NULL \code{usage} field. Uses the slot's \code{created_at}
+#' epoch and a dataset-keyed \code{session_id} so the resulting
+#' \code{event_id = "report:<dataset_id>:<module>:<created_at>"} is stable
+#' across sessions and reloads — INSERT OR IGNORE deduplicates replays.
+#'
+#' Safe to call multiple times on the same pgx; tolerate \code{user_email = NA}.
+#' Errors are logged but never propagate (fire-and-forget).
+#'
+#' @param pgx       PGX object as a plain list (not reactive).
+#' @param user_email User email from auth\$email; may be NA.
+#' @param db_path   Telemetry db path.
+#' @return Invisible character vector of event ids recorded (may be empty).
+ai_telemetry_record_reports <- function(pgx, user_email,
+                                        db_path = .ai_tel_default_db()) {
+  if (is.null(pgx) || !is.list(pgx)) return(invisible(character(0)))
+  ai <- if (is.list(pgx$ai)) pgx$ai else NULL
+  if (is.null(ai)) return(invisible(character(0)))
+
+  dataset_id <- if (!is.null(pgx$name) && nzchar(pgx$name %||% "")) pgx$name else ""
+  slots      <- names(ai)
+  recorded   <- character(0)
+
+  for (module in slots) {
+    slot <- ai[[module]]
+    if (!is.list(slot)) next
+    usage <- slot$usage
+    if (is.null(usage)) next
+
+    model      <- usage$model %||% NA_character_
+    created_at <- slot$created_at %||% as.numeric(Sys.time())
+
+    # Build a stable, dataset-keyed session_id so the sink's formula produces:
+    #   event_id = "report:<dataset_id>:<module>:<created_at_us>"
+    session_id <- paste0(dataset_id, ":", module)
+
+    ev_id <- tryCatch(
+      ai_telemetry_record(
+        source     = "report",
+        session_id = session_id,
+        user_email = user_email,
+        model      = model,
+        usage      = usage,
+        created_at = structure(created_at, class = c("POSIXct", "POSIXt")),
+        db_path    = db_path
+      ),
+      error = function(e) {
+        warning("[ai_telemetry_record_reports] failed for module '", module,
+                "': ", conditionMessage(e), call. = FALSE)
+        NULL
+      }
+    )
+    if (!is.null(ev_id)) recorded <- c(recorded, ev_id)
+  }
+
+  invisible(recorded)
+}

--- a/tests/testthat/test-ai-reports.R
+++ b/tests/testthat/test-ai-reports.R
@@ -111,6 +111,36 @@ test_that("ai_report_update_text edits pgx$ai reports only", {
   expect_equal(updated$wgcna$report$report, "old wgcna")
 })
 
+test_that("ai_report_update_text sets edited=TRUE without touching created_at", {
+  created_epoch <- 1750000000
+
+  pgx <- list(ai = list(
+    combined = list(
+      report     = "original",
+      prompt     = "p",
+      usage      = list(total = 100L, model = "m"),
+      created_at = created_epoch,
+      edited     = FALSE,
+      edited_at  = ""
+    )
+  ))
+
+  before <- Sys.time()
+  updated <- ai_report_update_text(pgx, c(combined = "edited text"))
+  after  <- Sys.time()
+
+  slot <- updated$ai$combined
+  expect_equal(slot$report, "edited text")
+  expect_true(isTRUE(slot$edited))
+  expect_gte(slot$edited_at, as.numeric(before))
+  expect_lte(slot$edited_at, as.numeric(after))
+  # created_at must be untouched
+  expect_equal(slot$created_at, created_epoch)
+  # usage must be untouched
+  expect_equal(slot$usage$total, 100L)
+  expect_equal(slot$prompt, "p")
+})
+
 test_that("ai_report_merge_into_reactive preserves existing pgx$ai slots", {
   pgx_rv <- new.env(parent = emptyenv())
   pgx_rv$ai <- list(

--- a/tests/testthat/test-ai-telemetry.R
+++ b/tests/testthat/test-ai-telemetry.R
@@ -1,9 +1,14 @@
 ## Tests for the AI telemetry core module (components/modules/AiTelemetry.R).
 ## Covers pricing resolution + math, DB schema/idempotency, the turn parser,
-## record() push sink, and collect_chat() idempotent pull.
+## record() push sink, collect_chat() idempotent pull, and record_reports().
 
-source(file.path(rprojroot::find_root(rprojroot::has_file("DESCRIPTION")),
-                 "components", "modules", "AiTelemetry.R"))
+# AiTelemetry.R (sourced below into globalenv) uses %||%, whose canonical
+# definition lives in components/app/R/utils/utils.R. source() defaults to the
+# global env, so pull in that real definition rather than re-defining the
+# operator here (project rule: never shim %||%).
+.opg_root <- rprojroot::find_root(rprojroot::has_file("DESCRIPTION"))
+source(file.path(.opg_root, "components", "app", "R", "utils", "utils.R"))
+source(file.path(.opg_root, "components", "modules", "AiTelemetry.R"))
 
 # A pricing YAML written into `dir` so tests don't depend on etc/.
 .write_pricing_yaml <- function(dir) {
@@ -147,6 +152,91 @@ test_that("sessions db name + legacy migration helper", {
   expect_equal(basename(resolved), "sessions-a@b.com.sqlite")
   expect_true(file.exists(resolved))
   expect_false(file.exists(legacy))
+})
+
+test_that("ai_telemetry_record_reports skips NULL-usage slots and records others", {
+  d <- tempfile("repdir"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  db <- file.path(d, "ai_telemetry.sqlite")
+
+  # usage mirrors what playbase stores: omicsai's native .omicsai_extract_usage()
+  # field names + model. The sink reads these exact names, so the token columns
+  # must populate — a renamed shape (total=/input=/output=) silently NA-fills.
+  mk_usage <- function(total, fresh, cached, output) list(
+    total_tokens = total, input_tokens = fresh + cached,
+    input_tokens_fresh = fresh, input_tokens_cached = cached,
+    output_tokens = output, reasoning_tokens = 0L, cache_hit_rate = 0,
+    model = "openai:gpt-5.4-nano")
+
+  pgx <- list(
+    name = "test-dataset",
+    ai = list(
+      de = list(
+        report     = "DE report",
+        usage      = mk_usage(50L, 30L, 0L, 20L),
+        created_at = 1750000000
+      ),
+      combined = list(
+        report = "Combined report",
+        usage  = NULL          # no usage — must be skipped
+      ),
+      pathways = list(
+        report     = "Pathway report",
+        usage      = mk_usage(80L, 55L, 5L, 20L),
+        created_at = 1750000100
+      )
+    )
+  )
+
+  ids <- ai_telemetry_record_reports(pgx, user_email = NA_character_, db_path = db)
+  con <- DBI::dbConnect(RSQLite::SQLite(), db); on.exit(DBI::dbDisconnect(con), add = TRUE)
+  rows <- DBI::dbGetQuery(con, paste(
+    "SELECT event_id, source, model, total, input_fresh, input_cached, output",
+    "FROM ai_usage_events ORDER BY event_id"))
+
+  # Only 2 slots have usage
+  expect_equal(nrow(rows), 2L)
+  expect_true(all(rows$source == "report"))
+  # Both event_ids are dataset-keyed
+  expect_true(all(grepl("^report:test-dataset:", rows$event_id)))
+  # Regression guard: token columns must be populated, not NA (the field-name bug).
+  de_row <- rows[grepl(":de:", rows$event_id), ]
+  expect_equal(de_row$total, 50L)
+  expect_equal(de_row$input_fresh, 30L)
+  expect_equal(de_row$output, 20L)
+  expect_equal(de_row$model, "openai:gpt-5.4-nano")
+  expect_false(anyNA(rows$total))
+})
+
+test_that("ai_telemetry_record_reports is idempotent — second call inserts no new rows", {
+  d <- tempfile("repdir2"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  db <- file.path(d, "ai_telemetry.sqlite")
+
+  pgx <- list(
+    name = "my-ds",
+    ai = list(
+      de = list(
+        report     = "DE report",
+        usage      = list(total = 50L, input = 30L, output = 20L,
+                          model = "openai:gpt-5.4-nano"),
+        created_at = 1750000000
+      )
+    )
+  )
+
+  ai_telemetry_record_reports(pgx, user_email = "u@x.com", db_path = db)
+  ai_telemetry_record_reports(pgx, user_email = "u@x.com", db_path = db)
+
+  con <- DBI::dbConnect(RSQLite::SQLite(), db); on.exit(DBI::dbDisconnect(con), add = TRUE)
+  n <- DBI::dbGetQuery(con, "SELECT COUNT(*) n FROM ai_usage_events")$n
+  expect_equal(n, 1L)
+})
+
+test_that("ai_telemetry_record_reports tolerates NULL/empty pgx gracefully", {
+  d <- tempfile("repdir3"); dir.create(d); on.exit(unlink(d, recursive = TRUE))
+  db <- file.path(d, "ai_telemetry.sqlite")
+  expect_silent(ai_telemetry_record_reports(NULL, NA_character_, db_path = db))
+  expect_silent(ai_telemetry_record_reports(list(), NA_character_, db_path = db))
+  expect_silent(ai_telemetry_record_reports(list(ai = list()), NA_character_, db_path = db))
 })
 
 test_that("collect_chat is idempotent over a synthetic chat store", {


### PR DESCRIPTION
## What

Copilot chat token usage is tracked (#1806), but AI **reports** spent tokens
invisibly. This records one deduplicated, priced token event per report
generation, across all generation sites.

**NOTE**:
Depends on  **playbase `feat: thread AI-report token usage onto the pgx report slot`** (PR https://github.com/bigomics/playbase/pull/497)

## Changes

- **`ai_telemetry_record_reports()`** (`AiTelemetry.R`) — reconcile helper that scans `pgx$ai` and emits one event per report keyed `report:<dataset>:<module>:<created_at>`. `INSERT OR IGNORE` collapses replays across sessions/reloads; NULL-usage slots are skipped; fire-and-forget so a telemetry failure never breaks report display.
- **Three generation checkpoints wired** — AI Studio, upload finish, and the loading generation path — each records from the persisted slot.
- **Manual edits marked** (`edited`/`edited_at` in `ai_report_update_text`) so a save never mints a new token event; `created_at`/`usage` are untouched.

## Testing

- `test-ai-telemetry.R` (35) + `test-ai-reports.R` (92) green, including a regression guard asserting the token columns populate (not just row count).
- Reviewed: field-name contract, `event_id` idempotency, `created_at` round-trip, slot-swap preservation, fire-and-forget isolation — 0 issues.
