### PR TITLE
fix(dataview): stop the "type for more genes" hint from being selectable

### DIFF
--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -80,14 +80,14 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         sel.feature <- features[1]
         i <- match(sel.feature, features)
         features <- c(features[i], features[-i])
-        if (length(features) > 1000) {
-          features <- c(
-            features[1:1000], tspan("(type for more genes...)", js = FALSE),
-            features[1001:length(features)]
-          )
-        }
 
         names(features) <- playbase::probe2symbol(features, pgx$genes, labeltype(), fill_na = TRUE)
+
+        # non-selectable hint that more genes are searchable by typing (see render/onItemAdd guard in ui)
+        if (length(features) > 1000) {
+          hint <- setNames("__more_genes__", tspan("(type for more genes...)", js = FALSE))
+          features <- c(features[1:1000], hint, features[1001:length(features)])
+        }
 
         shiny::updateSelectizeInput(
           session, "search_gene",

--- a/components/board.dataview/R/dataview_ui.R
+++ b/components/board.dataview/R/dataview_ui.R
@@ -15,7 +15,16 @@ DataViewInputs <- function(id) {
   ns <- shiny::NS(id) ## namespace
 
   bigdash::tabSettings(
-    withTooltip(shiny::selectizeInput(ns("search_gene"), tspan("Gene:"), choices = NULL, options = list(maxOptions = 1001)),
+    withTooltip(shiny::selectizeInput(ns("search_gene"), tspan("Gene:"), choices = NULL, options = list(
+      maxOptions = 1001,
+      # grey out the "(type for more...)" hint and block clicking it
+      render = I("{ option: function(item, escape) {
+        var style = item.value === '__more_genes__' ? ' style=\"pointer-events:none;opacity:0.55;font-style:italic\"' : '';
+        return '<div class=\"option\"' + style + '>' + escape(item.label) + '</div>';
+      } }"),
+      # block keyboard-selecting the hint
+      onItemAdd = I("function(value) { if (value === '__more_genes__') this.removeItem(value, true); }")
+    )),
       "Type a gene of interest.",
       placement = "top"
     ),


### PR DESCRIPTION
from marketing team:

A client selected "(type for more genes...)" in the DataView gene picker and got broken plots — it was a genuine selectable option

Kept the hint (clients need it), just made it unclickable:
- greyed + pointer-events:none so it can't be clicked
