### PR TITLE
feat: add durable AI module summaries to WGCNA boards

### DIFF
--- a/components/app/R/opg_server.R
+++ b/components/app/R/opg_server.R
@@ -415,7 +415,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
       info("[SERVER:UI:2] reacted: calling WGCNA module")
       mod <- MODULE.wgcna
       insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX)
+      mod$module_server(PGX, save_pgx = env$save_pgx)
       loaded$wgcna <- 1
       tab_control()
     }

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -899,6 +899,8 @@ app_server <- function(input, output, session) {
     try(playbase::pgx.save(pgx_obj, file = full), silent = TRUE)
     invisible(TRUE)
   }
+  ## Expose to lazily-loaded boards (e.g. WGCNA summary cards) via the shared env.
+  env$save_pgx <- save_current_pgx
 
   env$load <- LoadingBoard(
     id = "load",

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -1185,6 +1185,11 @@ upload_module_computepgx_server <- function(
               credentials = cred_fn
             )
           )
+          # Precompute durable per-module WGCNA summaries alongside the reports,
+          # using the same authenticated model config. pgx.update_wgcna_summaries
+          # is a no-op when WGCNA was not among the selected extra methods, so
+          # this is safe to set unconditionally whenever AI reports are on.
+          ai_features$wgcna_summaries <- ai_features$reports
         }
 
         ## Define create_pgx function arguments

--- a/components/board.wgcna/R/__init.R
+++ b/components/board.wgcna/R/__init.R
@@ -56,9 +56,10 @@ MODULE.wgcna <- list(
       )
     )
   },
-  module_server = function(PGX) {
+  module_server = function(PGX, save_pgx = NULL) {
     WgcnaBoard("wgcna",
-      pgx = PGX
+      pgx = PGX,
+      save_pgx = save_pgx
     )
 
     ConsensusWGCNA_Board(
@@ -73,7 +74,8 @@ MODULE.wgcna <- list(
 
     MultiWGCNA_Board(
       "mwgcna",
-      pgx = PGX
+      pgx = PGX,
+      save_pgx = save_pgx
     )
   },
   module_help = function() {

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_server.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_server.R
@@ -260,13 +260,17 @@ ConsensusWGCNA_Board <- function(id, pgx) {
       mwgcna = r_wgcna
     )
 
-    # Enrichment plot
-    wgcna_html_module_summary_server(
+    # Module summary (ephemeral: the consensus object is computed live from
+    # user input and never persisted, so summaries are generated on demand).
+    wgcna_module_ai_summary_server(
       "consensusWGCNAmoduleSummary",
       wgcna = r_wgcna,
-      multi = FALSE,
+      pgx = pgx,
       r_module = shiny::reactive(input$module),
-      watermark = WATERMARK
+      parent_session = session,
+      watermark = WATERMARK,
+      variant = NULL,
+      board_type = "consensus"
     )
 
     consensusWGCNA_plot_traitsignificance_server(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_ui.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_ui.R
@@ -162,7 +162,7 @@ ConsensusWGCNA_UI <- function(id) {
           bslib::layout_columns(
             col_widths = c(3, 4, 5),
             height = "100vh",
-            wgcna_html_module_summary_ui(
+            wgcna_module_ai_summary_ui(
               id = ns("consensusWGCNAmoduleSummary"),
               title = "Summary",
               info.text = "Summary. Description of the selected WGCNA module. The WGCNA module and phenotype/trait of interest can both be selected in the drop-down menu on the right.",

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
@@ -3,7 +3,7 @@
 ## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
 ##
 
-MultiWGCNA_Board <- function(id, pgx) {
+MultiWGCNA_Board <- function(id, pgx, save_pgx = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
     fullH <- 700 ## full height of page
@@ -225,14 +225,18 @@ MultiWGCNA_Board <- function(id, pgx) {
       r_module = reactive(input$module)
     )
 
-    # Enrichment plot
-    wgcna_html_module_summary_server(
+    # Module summary (durable: precomputed per layer x module, stored in
+    # pgx$ai$wgcna_mox$extras; Regenerate overrides the stored entry).
+    wgcna_module_ai_summary_server(
       "multiwgcnaSummary",
       wgcna = r_multiwgcna,
-      multi = TRUE,
-      r_annot = reactive(pgx$genes),
+      pgx = pgx,
       r_module = shiny::reactive(input$module),
-      watermark = WATERMARK
+      parent_session = session,
+      watermark = WATERMARK,
+      variant = "wgcna_mox",
+      board_type = "multiomics",
+      save_pgx = save_pgx
     )
 
     return(NULL)

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_ui.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_ui.R
@@ -201,13 +201,14 @@ MultiWGCNA_UI <- function(id) {
           bslib::layout_columns(
             col_widths = c(3, 4, 5),
             height = "100vh",
-            wgcna_html_module_summary_ui(
+            wgcna_module_ai_summary_ui(
               id = ns("multiwgcnaSummary"),
               title = "Summary",
-              info.text = "Summary. Description about selected WGCNA module. The data type and its WGCNA modules can be selected under 'Module' in the drop-down menu on the right.",
+              info.text = "AI-generated summary of the selected WGCNA module. The data type and its WGCNA modules can be selected under 'Module' in the drop-down menu on the right.",
               caption = "Information about the selected WGCNA module.",
               height = c("100%", TABLE_HEIGHT_MODAL),
-              width = c("auto", "100%")
+              width = c("auto", "100%"),
+              show_save = TRUE
             ),
             bslib::layout_columns(
               col_widths = c(12),

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_server.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_server.R
@@ -220,6 +220,19 @@ PreservationWGCNA_Board <- function(id, pgx) {
       rmodule = reactive(input$module)
     )
 
+    # Module summary (ephemeral: the preservation object is computed live from
+    # user input and never persisted, so summaries are generated on demand).
+    wgcna_module_ai_summary_server(
+      "preservationSummary",
+      wgcna = r_wgcna,
+      pgx = pgx,
+      r_module = shiny::reactive(input$module),
+      parent_session = session,
+      watermark = WATERMARK,
+      variant = NULL,
+      board_type = "preservation"
+    )
+
     return(NULL)
   })
 } ## end of Board

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_ui.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_ui.R
@@ -166,8 +166,16 @@ PreservationWGCNA_UI <- function(id) {
           height = "calc(100vh - 180px)",
           row_heights = c("auto", 1),
           bslib::layout_columns(
-            col_widths = c(7, 5),
+            col_widths = c(3, 4, 5),
             height = "100vh",
+            wgcna_module_ai_summary_ui(
+              id = ns("preservationSummary"),
+              title = "Summary",
+              info.text = "AI-generated summary of the selected WGCNA module. The WGCNA module and trait of interest can be selected in the drop-down menu on the right.",
+              caption = "Information about the selected WGCNA module.",
+              height = c("100%", TABLE_HEIGHT_MODAL),
+              width = c("auto", "100%")
+            ),
             bslib::layout_columns(
               col_widths = c(12),
               preservationWGCNA_table_modulegenes_ui(

--- a/components/board.wgcna/R/wgcna_module_ai_summary.R
+++ b/components/board.wgcna/R/wgcna_module_ai_summary.R
@@ -5,7 +5,8 @@
 
 #' WGCNA module AI summary UI
 #'
-#' Renders an on-demand AI summary card for the selected WGCNA module.
+#' Renders an AI summary card for the selected WGCNA module. Used by all four
+#' WGCNA tabs (standard, consensus, preservation, multi-omics).
 #'
 #' @param id Shiny module namespace ID.
 #' @param label Optional PlotModule label.
@@ -22,29 +23,46 @@ wgcna_module_ai_summary_ui <- function(id,
                                        info.text = "",
                                        caption = "",
                                        height,
-                                       width) {
+                                       width,
+                                       show_save = FALSE) {
   AiTextCardUI(
     id = id,
     title = title,
     caption = caption,
     info.text = info.text,
     height = height,
-    width = width
+    width = width,
+    show_save = show_save
   )
 }
 
 #' WGCNA module AI summary server
 #'
-#' Builds current-module evidence from the live WGCNA object and generates a
-#' fresh AI summary on demand. Results are not written back to PGX.
+#' Serves the per-module AI summary card in two modes:
+#'
+#' * **Durable** (`variant = "wgcna"` / `"wgcna_mox"`): reads the precomputed
+#'   summary from `pgx$ai$<variant>$extras$<module>` and renders it instantly.
+#'   "Regenerate" runs a fresh summary and writes it back into the pgx so it
+#'   overrides the stored one, mirroring the AI Studio reports.
+#' * **Ephemeral** (`variant = NULL`, consensus / preservation): the WGCNA
+#'   object is computed live from user input and never persisted, so the summary
+#'   is generated on demand and not stored.
+#'
+#' All prompt assembly is delegated to `playbase::wgcna.module_summary_prompt()`
+#' so the board keeps no parallel module-data extraction code.
 #'
 #' @param id Shiny module namespace ID.
 #' @param wgcna Reactive returning the current WGCNA object.
-#' @param pgx Current PGX object.
+#' @param pgx Current PGX object (reactiveValues).
 #' @param r_module Reactive returning the selected module name.
 #' @param parent_session Parent Shiny session with AI user options.
 #' @param watermark Logical; add watermark in PlotModule.
 #' @param user_email Optional user email for telemetry attribution.
+#' @param variant Storage slot for durable summaries (`"wgcna"` /
+#'   `"wgcna_mox"`), or `NULL` for ephemeral (consensus / preservation).
+#' @param board_type WGCNA flavour selecting the prompt/extraction: `"standard"`,
+#'   `"multiomics"`, `"consensus"`, or `"preservation"`. Playbase handles each
+#'   object's shape (including multi-omics layer resolution) internally.
 #'
 #' @return Reactive returning the latest omicsai result, or NULL.
 wgcna_module_ai_summary_server <- function(id,
@@ -53,45 +71,82 @@ wgcna_module_ai_summary_server <- function(id,
                                            r_module,
                                            parent_session,
                                            watermark = FALSE,
-                                           user_email = NULL) {
-  # Build prompt data from the currently selected module and live WGCNA object.
-  summary_params <- shiny::reactive({
+                                           user_email = NULL,
+                                           variant = NULL,
+                                           board_type = "standard",
+                                           save_pgx = NULL) {
+  # The whole WGCNA object is passed to playbase, which selects the right
+  # extractor per board_type (multi-omics resolves the owning layer and computes
+  # cross-omics coordination from all layers, so it needs the full object).
+  wgcna_for_module <- shiny::reactive({
     res <- wgcna()
     module <- r_module()
     shiny::req(res, module)
-    wgcna_module_summary_params(res, module, pgx)
+    list(obj = res, annot = res$annot %||% pgx$genes)
   })
 
-  # Assemble the structured omicsai prompt into system and user-message parts.
+  # Assemble the summary prompt from playbase (single source of truth). The
+  # board_type routes consensus / preservation objects to their own extractors.
   prompt_parts <- shiny::reactive({
-    params <- summary_params()
-    organism <- tryCatch(pgx$organism, error = function(e) NULL)
-    prompt <- omicsai::summary_prompt(
-      role = omicsai::frag("system_base"),
-      task = NULL,
-      species = omicsai::omicsai_species_prompt(organism),
-      context = omicsai::frag("wgcna/wgcna_interpretation"),
-      data = omicsai::frag("wgcna/wgcna_module_data", params)
+    wm <- wgcna_for_module()
+    playbase::wgcna.module_summary_prompt(
+      pgx, wm$obj, r_module(),
+      annot = wm$annot, board_type = board_type
     )
-    omicsai::build_prompt(prompt)
   })
 
-  # Pass the already-built user message through the generic AI text card.
+  # The card's live/regenerate path uses the already-built board message plus a
+  # config carrying the WGCNA system prompt.
   template <- shiny::reactive(prompt_parts()$board)
-
-  # Keep model selection tied to app Settings while using the WGCNA system prompt.
   config <- shiny::reactive({
-    model <- get_ai_model(parent_session)
-    system_prompt <- prompt_parts()$system
     omicsai::omicsai_config(
-      model = model,
-      system_prompt = system_prompt
+      model = get_ai_model(parent_session),
+      system_prompt = prompt_parts()$system
     )
   })
 
-  # Render the serial on-demand AI summary card; no PGX write-back happens here.
-  # The card emits one telemetry event per generation tagged source="wgcna_summary".
-  # TODO(telemetry): thread auth$email for attribution (no auth in WgcnaBoard scope).
+  # Durable variants: seed the card from the stored summary and persist any
+  # regeneration back into the pgx. Ephemeral variants pass NULL for both.
+  prefetch_reactive <- NULL
+  on_generated <- NULL
+  if (!is.null(variant)) {
+    prefetch_reactive <- shiny::reactive({
+      module <- r_module()
+      shiny::req(module)
+      pgx$ai[[variant]]$extras[[module]]
+    })
+    on_generated <- function(result) {
+      module <- shiny::isolate(r_module())
+      if (is.null(module)) return(invisible(NULL))
+      entry <- list(
+        summary    = result$text,
+        prompt     = shiny::isolate(tryCatch(
+          paste0("# SYSTEM\n\n", prompt_parts()$system,
+                 "\n\n---\n\n# BOARD\n\n", prompt_parts()$board),
+          error = function(e) NULL
+        )),
+        usage      = result$metadata$usage,
+        model      = result$metadata$model %||% NA_character_,
+        created_at = as.numeric(Sys.time()),
+        edited     = FALSE,
+        edited_at  = ""
+      )
+      if (is.null(pgx$ai)) pgx$ai <- list()
+      if (is.null(pgx$ai[[variant]])) pgx$ai[[variant]] <- list()
+      if (is.null(pgx$ai[[variant]]$extras)) pgx$ai[[variant]]$extras <- list()
+      pgx$ai[[variant]]$extras[[module]] <- entry
+    }
+  }
+
+  # Persist the in-memory pgx (with any regenerated summaries) to disk, mirroring
+  # the AI Studio "Save edits" action. Only durable variants with a save handler
+  # get a Save control; ephemeral consensus/preservation cards leave it NULL.
+  on_save <- NULL
+  if (!is.null(variant) && !is.null(save_pgx)) {
+    on_save <- function() save_pgx(pgx)
+  }
+
+  # Render the on-demand AI summary card. Telemetry is tagged per variant.
   AiTextCardServer(
     id = id,
     params_reactive = shiny::reactive(list()),
@@ -100,273 +155,17 @@ wgcna_module_ai_summary_server <- function(id,
     cache = omicsai::omicsai_cache_init("mem"),
     watermark = watermark,
     user_email = user_email,
-    telemetry_source = "wgcna_summary",
+    telemetry_source = paste0(variant %||% "wgcna", "_summary"),
     # Block generation when AI is off (deployment licence or the Settings
     # "Enable AI" switch, published on session$userData by AppSettingsBoard).
+    # Displaying a stored durable summary bypasses this gate (no generation).
     enabled_reactive = shiny::reactive(
       isTRUE(opt$ENABLE_AI) &&
         !isFALSE(getUserOption(parent_session, "ai_enabled"))
     ),
-    disabled_message = "Please enable AI to generate module summaries."
-  )
-}
-
-#' Build prompt parameters for one WGCNA module
-#'
-#' @param wgcna WGCNA result object.
-#' @param module Character module name such as `"MEblue"`.
-#' @param pgx Current PGX object.
-#'
-#' @return Named list matching `omicsai` prompt `wgcna/wgcna_module_data`.
-wgcna_module_summary_params <- function(wgcna, module, pgx) {
-  # Normalize source tables before mapping them into the omicsai prompt schema.
-  input <- .wgcna_module_input_data(wgcna, module)
-
-  # Keep this list aligned with inst/prompts/wgcna/wgcna_module_data.md.
-  list(
-    ME_color = module,
-    n_genes = length(input$module_genes),
-    tier = .wgcna_module_tier(input$module_traits, module, input$gse),
-    eigengene_profile_qualitative = .wgcna_module_eigengene_profile(wgcna, module, pgx),
-    top_pos_trait = .wgcna_module_trait(input$module_traits, module, "positive"),
-    top_pos_verbal = .wgcna_module_trait(input$module_traits, module, "positive", verbal = TRUE),
-    top_neg_trait = .wgcna_module_trait(input$module_traits, module, "negative"),
-    top_neg_verbal = .wgcna_module_trait(input$module_traits, module, "negative", verbal = TRUE),
-    n_sig_terms = sum(input$gse$q.value < 0.05, na.rm = TRUE),
-    n_total_terms = nrow(input$gse),
-    enrichment_themes_table = .wgcna_module_enrichment_table(input$gse),
-    n_hub = 50L,
-    hub_genes_table = .wgcna_module_hub_table(
-      wgcna,
-      module,
-      pgx,
-      input$module_traits,
-      input$top
-    ),
-    gene_families_summary = "",
-    enrichment_overlaps = .wgcna_module_enrichment_overlaps(input$gse)
-  )
-}
-
-# Normalize WGCNA module aliases and table shapes for prompt assembly.
-# This is necessary because precomputed and live WGCNA objects expose different shapes.
-.wgcna_module_input_data <- function(wgcna, module) {
-  module_key <- module
-  module_alt <- sub("^ME", "", module)
-  module_genes <- wgcna$me.genes[[module_key]]
-  if (is.null(module_genes) && module_alt != module_key) {
-    module_genes <- wgcna$me.genes[[module_alt]]
-  }
-  if (is.null(module_genes)) {
-    module_genes <- character(0)
-  }
-  module_traits <- tryCatch(playbase:::wgcna.get_modTraits(wgcna), error = function(e) NULL)
-  top <- tryCatch(
-    playbase::wgcna.getTopGenesAndSets(
-      wgcna,
-      annot = wgcna$annot,
-      ntop = 40,
-      level = "gene",
-      rename = "gene_title"
-    ),
-    error = function(e) list(pheno = list(), genes = list(), sets = list())
-  )
-  top_genes <- top$genes[[module_key]]
-  top_sets <- top$sets[[module_key]]
-  if (is.null(top_genes) && module_alt != module_key) {
-    top_genes <- top$genes[[module_alt]]
-  }
-  if (is.null(top_sets) && module_alt != module_key) {
-    top_sets <- top$sets[[module_alt]]
-  }
-  top$genes[[module_key]] <- if (is.null(top_genes)) character(0) else top_genes
-  top$sets[[module_key]] <- if (is.null(top_sets)) character(0) else top_sets
-
-  if (is.data.frame(wgcna$gse)) {
-    gse <- wgcna$gse[wgcna$gse$module %in% c(module_key, module_alt), , drop = FALSE]
-  } else {
-    gse <- wgcna$gse[[module_key]]
-    if (is.null(gse) && module_alt != module_key) {
-      gse <- wgcna$gse[[module_alt]]
-    }
-  }
-  if (!is.data.frame(gse)) {
-    gse <- data.frame()
-  }
-  if (nrow(gse) > 0 && !"score" %in% colnames(gse) &&
-      all(c("odd.ratio", "p.value") %in% colnames(gse))) {
-    gse$odd.ratio[is.infinite(gse$odd.ratio)] <- 99
-    gse$score <- gse$odd.ratio * -log10(gse$p.value)
-  }
-
-  list(
-    module_genes = module_genes,
-    module_traits = module_traits,
-    top = top,
-    gse = gse
-  )
-}
-
-# Classify module signal from trait correlation and significant enrichment count.
-# This helps us give the prompt a compact strength label instead of raw thresholds.
-.wgcna_module_tier <- function(module_traits, module, gse) {
-  max_cor <- 0
-  if (!is.null(module_traits) && module %in% rownames(module_traits)) {
-    max_cor <- max(abs(module_traits[module, ]), na.rm = TRUE)
-  }
-  n_sig <- if ("q.value" %in% colnames(gse)) sum(gse$q.value < 0.05, na.rm = TRUE) else 0L
-  if (max_cor >= 0.7 || n_sig >= 10L) return("strong signal")
-  if (max_cor >= 0.5 || n_sig >= 3L) return("moderate signal")
-  "weak signal"
-}
-
-# Summarize eigengene group means for the selected module.
-# This helps us expose module directionality without passing full sample matrices.
-.wgcna_module_eigengene_profile <- function(wgcna, module, pgx) {
-  datME <- if (!is.null(wgcna$datME)) wgcna$datME else wgcna$net$MEs
-  groups <- pgx$samples$group
-  if (is.null(datME) || !module %in% colnames(datME) || is.null(groups)) {
-    return("not available")
-  }
-  group_means <- sort(tapply(datME[, module], groups, mean), decreasing = TRUE)
-  paste(
-    sprintf("%s: %+.2f", names(group_means), group_means),
-    collapse = "; "
-  )
-}
-
-# Return the strongest positive or negative trait above the reporting threshold.
-# Separating the code here keeps trait picking consistent across summary fields.
-.wgcna_module_trait <- function(module_traits,
-                                module,
-                                direction = c("positive", "negative"),
-                                verbal = FALSE) {
-  direction <- match.arg(direction)
-  if (is.null(module_traits) || !module %in% rownames(module_traits)) {
-    return("")
-  }
-  cors <- module_traits[module, ]
-  cors <- cors[!is.na(cors)]
-  cors <- if (identical(direction, "positive")) cors[cors >= 0.5] else cors[cors <= -0.5]
-  if (length(cors) == 0) {
-    return("")
-  }
-  value <- if (identical(direction, "positive")) max(cors) else min(cors)
-  trait <- names(cors)[which(cors == value)[1]]
-  if (isTRUE(verbal)) sprintf("r = %+.2f", value) else trait
-}
-
-# Format the top significant enrichment terms for the omicsai data fragment.
-# This helps us keep WGCNA-specific prompt wording out of generic formatters.
-.wgcna_module_enrichment_table <- function(gse) {
-  needed <- c("geneset", "score", "q.value")
-  if (!is.data.frame(gse) || nrow(gse) == 0 || !all(needed %in% colnames(gse))) {
-    return("No enrichment terms available.")
-  }
-  sig <- gse[!is.na(gse$q.value) & gse$q.value < 0.05, , drop = FALSE]
-  if (nrow(sig) == 0) {
-    return("No enrichment terms passed q < 0.05.")
-  }
-  sig <- sig[order(sig$q.value, -sig$score), , drop = FALSE]
-  df <- data.frame(
-    theme = head(sig$geneset, 20),
-    score = head(sig$score, 20),
-    q = head(sig$q.value, 20),
-    stringsAsFactors = FALSE
-  )
-  paste(omicsai::omicsai_format_mdtable(df, formatters = list(
-    score = function(x) omicsai::omicsai_format_num(x, 2),
-    q = omicsai::omicsai_format_pvalue
-  )), collapse = "\n")
-}
-
-# Format hub genes using gene stats when a correlated trait is available.
-# This is necessary because hub ranking depends on the selected module and trait.
-.wgcna_module_hub_table <- function(wgcna, module, pgx, module_traits, top) {
-  trait <- .wgcna_module_trait(module_traits, module, "positive")
-  if (!nzchar(trait)) {
-    trait <- .wgcna_module_trait(module_traits, module, "negative")
-  }
-  genes <- top$genes[[module]]
-  if (length(genes) == 0) {
-    module_alt <- sub("^ME", "", module)
-    genes <- wgcna$me.genes[[module]]
-    if (is.null(genes) && module_alt != module) {
-      genes <- wgcna$me.genes[[module_alt]]
-    }
-  }
-  if (is.null(genes)) {
-    genes <- character(0)
-  }
-  stats <- if (nzchar(trait)) {
-    tryCatch(
-      playbase::wgcna.getGeneStats(wgcna, module = module, trait = trait, plot = FALSE),
-      error = function(e) NULL
-    )
-  } else {
-    NULL
-  }
-  if (is.data.frame(stats) && nrow(stats) > 0 && "moduleMembership" %in% colnames(stats)) {
-    stats <- stats[order(-abs(stats$moduleMembership)), , drop = FALSE]
-    genes <- head(stats$feature, 50)
-  } else {
-    genes <- head(genes, 50)
-  }
-  symbols <- .wgcna_module_symbols(genes, pgx$genes)
-  funcs <- .wgcna_module_functions(genes, pgx$genes)
-  paste(omicsai::omicsai_format_mdtable(data.frame(
-    gene = symbols,
-    known_function = funcs,
-    stringsAsFactors = FALSE
-  )), collapse = "\n")
-}
-
-# Resolve feature IDs to gene symbols.
-# This helps us let the AI summary mention readable annotated gene names.
-.wgcna_module_symbols <- function(features, annot) {
-  symbols <- tryCatch(
-    playbase::probe2symbol(features, annot, "symbol"),
-    error = function(e) features
-  )
-  symbols[is.na(symbols) | symbols == ""] <- features[is.na(symbols) | symbols == ""]
-  symbols
-}
-
-# Resolve feature IDs to short gene descriptions.
-# This helps us include compact biological context for hub genes.
-.wgcna_module_functions <- function(features, annot) {
-  out <- rep("function not annotated", length(features))
-  if (is.null(annot) || is.null(rownames(annot))) {
-    return(out)
-  }
-  col <- intersect(c("gene_title", "gene_name", "description"), colnames(annot))
-  if (length(col) == 0) {
-    return(out)
-  }
-  idx <- match(features, rownames(annot))
-  ok <- !is.na(idx)
-  out[ok] <- as.character(annot[idx[ok], col[1]])
-  out[is.na(out) | out == ""] <- "function not annotated"
-  substr(out, 1, 90)
-}
-
-# Format overlap gene lists for top enrichment terms.
-# This helps us keep overlap wording tailored to the WGCNA prompt.
-.wgcna_module_enrichment_overlaps <- function(gse) {
-  if (!is.data.frame(gse) || nrow(gse) == 0 || !"genes" %in% colnames(gse)) {
-    return("")
-  }
-  sig <- if ("q.value" %in% colnames(gse)) {
-    gse[!is.na(gse$q.value) & gse$q.value < 0.05, , drop = FALSE]
-  } else {
-    gse
-  }
-  if (nrow(sig) == 0) {
-    return("")
-  }
-  sig <- head(sig, 5)
-  paste(
-    sprintf("- %s: %s", sig$geneset, sig$genes),
-    collapse = "\n"
+    disabled_message = "Please enable AI to generate module summaries.",
+    prefetch_reactive = prefetch_reactive,
+    on_generated = on_generated,
+    on_save = on_save
   )
 }

--- a/components/board.wgcna/R/wgcna_server.R
+++ b/components/board.wgcna/R/wgcna_server.R
@@ -4,7 +4,7 @@
 ##
 
 
-WgcnaBoard <- function(id, pgx) {
+WgcnaBoard <- function(id, pgx, save_pgx = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
     fullH <- 700 ## full height of page
@@ -302,14 +302,17 @@ WgcnaBoard <- function(id, pgx) {
       selected_module = shiny::reactive(input$selected_module)
     )
 
-    # Module summary
+    # Module summary (durable: precomputed at compute time, stored in
+    # pgx$ai$wgcna$extras; Regenerate overrides the stored entry).
     wgcna_module_ai_summary_server(
       "moduleSummary",
       wgcna = wgcna,
       pgx = pgx,
       r_module = shiny::reactive(input$selected_module),
       parent_session = session,
-      watermark = WATERMARK
+      watermark = WATERMARK,
+      variant = "wgcna",
+      save_pgx = save_pgx
     )
 
     return(NULL)

--- a/components/board.wgcna/R/wgcna_ui.R
+++ b/components/board.wgcna/R/wgcna_ui.R
@@ -205,7 +205,8 @@ WgcnaUI <- function(id) {
             info.text = "",
             caption = "Information about the Module.",
             height = c("100%", TABLE_HEIGHT_MODAL),
-            width = c("auto", "100%")
+            width = c("auto", "100%"),
+            show_save = TRUE
           ),
           bslib::layout_columns(
             col_widths = c(7, 5, 7, 5),

--- a/components/modules/AiCards.R
+++ b/components/modules/AiCards.R
@@ -53,7 +53,10 @@ AiTextCardServer <- function(id,
                              user_email = NULL,
                              telemetry_source = "card",
                              enabled_reactive = NULL,
-                             disabled_message = "AI features are disabled.") {
+                             disabled_message = "AI features are disabled.",
+                             prefetch_reactive = NULL,
+                             on_generated = NULL,
+                             on_save = NULL) {
   shiny::moduleServer(id, function(input, output, session) {
     # Prepare card-local state and cache for one on-demand text result.
     module_cache <- if (is.null(cache)) omicsai::omicsai_cache_init("mem") else cache
@@ -64,6 +67,39 @@ AiTextCardServer <- function(id,
       prompt = NULL,
       system_prompt = NULL
     )
+
+    # Durable-first display: when a precomputed summary exists for the current
+    # selection, render it instantly (no LLM call, no AI-enabled gate). Falling
+    # back to "idle" when none exists lets the user Generate on demand. Skipped
+    # while a live generation is running so a click is never overwritten.
+    if (!is.null(prefetch_reactive)) {
+      shiny::observeEvent(prefetch_reactive(), ignoreNULL = FALSE, {
+        if (identical(rv$status, "running")) return(NULL)
+        entry <- prefetch_reactive()
+        if (!is.null(entry) && !is.null(entry$summary)) {
+          rv$status <- "done"
+          rv$result <- list(text = entry$summary)
+          rv$error <- NULL
+        } else {
+          rv$status <- "idle"
+          rv$result <- NULL
+          rv$error <- NULL
+        }
+      })
+    }
+
+    # Persist the current summaries to disk (durable variants only). The board
+    # supplies on_save = function() save_pgx(pgx); we just report success/failure.
+    if (!is.null(on_save)) {
+      shiny::observeEvent(input$save, {
+        ok <- tryCatch(isTRUE(on_save()), error = function(e) FALSE)
+        shiny::showNotification(
+          if (ok) "Summary saved to dataset." else "Could not save summary.",
+          type = if (ok) "message" else "error",
+          session = session
+        )
+      })
+    }
 
     shiny::observeEvent(input$generate, {
       # Guard: block generation when AI is disabled (deployment licence or the
@@ -133,6 +169,12 @@ AiTextCardServer <- function(id,
           ),
           error = function(e) NULL
         )
+
+        # Durable variants persist the regenerated summary back into the pgx so
+        # it overrides the stored one (AI-Studio style); never break the card.
+        if (!is.null(on_generated)) {
+          tryCatch(on_generated(result), error = function(e) NULL)
+        }
       }
       info("[AiTextCardServer] text generation finished: id=", id,
            " status=", rv$status,

--- a/components/ui/ui-AiCards.R
+++ b/components/ui/ui-AiCards.R
@@ -20,7 +20,8 @@ AiTextCardUI <- function(id,
                          caption = "AI-generated summary.",
                          info.text = "",
                          height = c("100%", TABLE_HEIGHT_MODAL),
-                         width = c("auto", "100%")) {
+                         width = c("auto", "100%"),
+                         show_save = FALSE) {
   ns <- shiny::NS(id)
 
   opts <- shiny::tagList(
@@ -37,7 +38,16 @@ AiTextCardUI <- function(id,
       "Generate",
       icon = shiny::icon("refresh"),
       class = "btn-outline-primary"
-    )
+    ),
+    # Durable variants only: persist a regenerated summary back to the dataset.
+    if (isTRUE(show_save)) {
+      shiny::actionButton(
+        ns("save"),
+        "Save",
+        icon = shiny::icon("floppy-disk"),
+        class = "btn-outline-secondary"
+      )
+    }
   )
 
   PlotModuleUI(


### PR DESCRIPTION
## Summary
Durable per-module AI summaries for all four WGCNA boards. Precomputed at
pgx.compute time into `pgx$ai$wgcna|wgcna_mox$extras`, prefetched by the board
for instant render, with Regenerate + Save on the durable cards.

## Details
- precompute per-module summaries at pgx.compute time into pgx$ai$wgcna|wgcna_mox$extras; boards prefetch and render them instantly, Regenerate overrides the stored entry in memory
- add a Save control to the durable summary cards that persists a regenerated summary back to the dataset via the existing save_pgx path
- route consensus/preservation/multiomics through board_type-specific prompt builders and delete the duplicated board-side module-data helpers
