### PR TITLE
Fix/chatbot UI

### DIFF
--- a/components/app_copilot/R/CopilotBoardUI.R
+++ b/components/app_copilot/R/CopilotBoardUI.R
@@ -18,10 +18,27 @@ CopilotBoardUI <- function(id) {
     col_widths = c(3, 5, 4),
     style = "height: calc(100vh - 80px);",
 
-    # ---- Left column: datasets / history / docs ----
+    # ---- Left column: docs / reports ----
+    bslib::card(
+      height = "100%",
+      bslib::navset_underline(
+        bslib::nav_panel(
+          "Context",
+          bslib::navset_underline(
+            bslib::nav_panel("Documents", CopilotDocsUI(ns("docs"))),
+            bslib::nav_panel("Reports", CopilotReportsUI(ns("reports")))
+          )
+        )
+      )
+    ),
+
+    # ---- Centre column: chat ----
+    CopilotChatUI(ns("chat")),
+
+    # ---- Right column: datasets / history, on top of evidence ----
     bslib::layout_columns(
       col_widths = 12,
-      row_heights = c(5,4),
+      row_heights = c(4, 7),
       bslib::card(
         height = "calc(100% - 40px)",
         shiny::actionButton(
@@ -44,25 +61,8 @@ CopilotBoardUI <- function(id) {
           )
         )
       ),
-      bslib::card(
-        height = "100%",
-        bslib::navset_underline(
-          bslib::nav_panel(
-            "Context",
-            bslib::navset_underline(
-              bslib::nav_panel("Documents", CopilotDocsUI(ns("docs"))),
-              bslib::nav_panel("Reports", CopilotReportsUI(ns("reports")))
-            )
-          )
-        )
-      )
-    ),
-
-    # ---- Centre column: chat ----
-    CopilotChatUI(ns("chat")),
-
-    # ---- Right column: evidence ----
-    CopilotEvidenceUI(ns("evidence"))
+      CopilotEvidenceUI(ns("evidence"))
+    )
   )
 
 

--- a/components/app_copilot/R/CopilotBoardUI.R
+++ b/components/app_copilot/R/CopilotBoardUI.R
@@ -18,15 +18,48 @@ CopilotBoardUI <- function(id) {
     col_widths = c(3, 5, 4),
     style = "height: calc(100vh - 80px);",
 
-    # ---- Left column: docs / reports ----
-    bslib::card(
-      height = "100%",
-      bslib::navset_underline(
-        bslib::nav_panel(
-          "Context",
+    # ---- Left column: new-chat button, on top of docs / reports ----
+    # "New chat" lives here (own row) rather than inside the
+    # Dataset/Settings/History card on the right, which already has little
+    # vertical room to spare. Plain flexbox instead of layout_columns
+    # row_heights, so the button keeps its intrinsic size instead of being
+    # stretched to fill a grid row.
+    shiny::div(
+      style = "height: 100%; display: flex; flex-direction: column; gap: 8px;",
+      shiny::actionButton(
+        ns("new_chat"),
+        label = "New chat",
+        icon  = shiny::icon("plus"),
+        class = "btn-sm btn-outline-secondary w-100",
+        style = "flex: 0 0 auto;"
+      ),
+      shiny::div(
+        style = "flex: 1 1 auto; min-height: 0;",
+        # Header mirrors the "Plot output" card header exactly (same
+        # `as.card_item(fillRow(height = "33px", class = "plotmodule-header"))`
+        # shape, NOT card_header) rather than a navset_underline nav_panel —
+        # a single-tab nav_panel rendered as a clickable-looking tab next to
+        # "Documents" / "Reports", which read as a visual button and
+        # confused reviewers. as.card_item is required for the header to
+        # span the card edge-to-edge — a plain child gets wrapped in a
+        # padded card_body, which insets the header and its border-bottom.
+        bslib::card(
+          height = "100%",
+          bslib::as.card_item(shiny::fillRow(
+            flex = 1,
+            class = "plotmodule-header",
+            height = "33px",
+            shiny::div(
+              class = "plotmodule-title",
+              style = "white-space: nowrap; overflow: hidden; text-overflow: clip;",
+              "Workspace"
+            )
+          )),
           bslib::navset_underline(
             bslib::nav_panel("Documents", CopilotDocsUI(ns("docs"))),
-            bslib::nav_panel("Reports", CopilotReportsUI(ns("reports")))
+            bslib::nav_panel("Reports", CopilotReportsUI(ns("reports"))),
+            bslib::nav_panel("Settings", CopilotChatSettings(ns("chat"))),
+            bslib::nav_panel("History", CopilotHistoryUI(ns("history")))
           )
         )
       )
@@ -35,31 +68,27 @@ CopilotBoardUI <- function(id) {
     # ---- Centre column: chat ----
     CopilotChatUI(ns("chat")),
 
-    # ---- Right column: datasets / history, on top of evidence ----
+    # ---- Right column: dataset info, on top of evidence ----
+    # "Dataset" is the only remaining item here now that Settings/History
+    # moved left, so it gets the same plain "Plot output"-style header as
+    # Context instead of a navset_underline — a lone tab would reintroduce
+    # the clickable-looking-button problem we just fixed on the left.
     bslib::layout_columns(
       col_widths = 12,
       row_heights = c(4, 7),
       bslib::card(
-        height = "calc(100% - 40px)",
-        shiny::actionButton(
-          ns("new_chat"),
-          label = "New chat",
-          icon  = shiny::icon("plus"),
-          class = "btn-sm btn-outline-secondary w-100",
-          style = "margin-bottom: 8px;"
-        ),
-        bslib::navset_underline(
-          #bslib::nav_panel("Datasets", CopilotDatasetsUI(ns("datasets"))),
-          bslib::nav_panel("Dataset",
-            shiny::uiOutput(ns("dataset_info"))
-          ),
-          bslib::nav_panel("Settings",
-            CopilotChatSettings(ns("chat"))
-          ),
-          bslib::nav_panel("History",
-            CopilotHistoryUI(ns("history"))
+        height = "100%",
+        bslib::as.card_item(shiny::fillRow(
+          flex = 1,
+          class = "plotmodule-header",
+          height = "33px",
+          shiny::div(
+            class = "plotmodule-title",
+            style = "white-space: nowrap; overflow: hidden; text-overflow: clip;",
+            "Dataset"
           )
-        )
+        )),
+        shiny::uiOutput(ns("dataset_info"))
       ),
       CopilotEvidenceUI(ns("evidence"))
     )

--- a/components/app_copilot/R/CopilotReportsServer.R
+++ b/components/app_copilot/R/CopilotReportsServer.R
@@ -185,26 +185,46 @@ CopilotReportsServer <- function(id, pgx) {
             } else {
               isTRUE(current)
             }
-            shiny::tags$li(
-              style = if (already_used) {
-                "opacity: 0.55;"
-              } else {
-                NULL
-              },
-              shiny::tags$label(
-                class = "checkbox-inline",
-                style = "display: block; font-weight: normal;",
-                shiny::tags$input(
-                  id = session$ns(id),
-                  type = "checkbox",
-                  checked = if (checked) "checked" else NULL,
-                  disabled = if (already_used) "disabled" else NULL
-                ),
+            label_tag <- shiny::tags$label(
+              class = "checkbox-inline",
+              style = paste(
+                "display: block; font-weight: normal;",
+                # No `disabled` attribute when locked — that native state is
+                # what drove the greyed-out look. Interaction is blocked via
+                # pointer-events instead, so the checkbox stays full-colour.
+                if (already_used) "pointer-events: none;" else ""
+              ),
+              shiny::tags$input(
+                id = session$ns(id),
+                type = "checkbox",
+                checked = if (checked) "checked" else NULL,
+                `aria-disabled` = if (already_used) "true" else NULL
+              ),
+              shiny::tags$span(
+                style = "margin-left: 6px;",
+                copilot_report_label(value, slot)
+              ),
+              if (already_used) {
                 shiny::tags$span(
-                  style = "margin-left: 6px;",
-                  copilot_report_label(value, slot)
+                  class = "text-muted",
+                  style = "margin-left: 4px;",
+                  shiny::icon("lock")
                 )
-              )
+              }
+            )
+            shiny::tags$li(
+              if (already_used) {
+                bslib::tooltip(
+                  shiny::tags$span(
+                    style = "display: block; cursor: not-allowed;",
+                    label_tag
+                  ),
+                  copilot_msg("report_locked"),
+                  placement = "right"
+                )
+              } else {
+                label_tag
+              }
             )
           })
         )

--- a/components/app_copilot/R/copilot_messages.R
+++ b/components/app_copilot/R/copilot_messages.R
@@ -37,6 +37,7 @@ COPILOT_MSG <- list(
   switch_failed    = "Copilot: failed to switch dataset — {{msg}}",
   error_prefix     = "Copilot error: {{msg}}",
   restore_busy     = "Restore is unavailable while the agent is responding.",
+  report_locked    = "Reports can only be passed once per session.",
   model_gone       = "ovi_restore: cannot restore session — model is not resolvable. Pick a different model.",
   no_session       = "ovi_restore: no saved session with that id.",
   # Provider-specific error categories (shown to users instead of raw API text)


### PR DESCRIPTION
## Summary

Reshuffle of the Chatbot UI:

- Right column now stacks Dataset/Settings/History above the plot-rendering Evidence card (left column keeps just Docs/Reports context).
- Consumed reports stay full-colour instead of greying out — locked via `pointer-events`, with a lock icon + tooltip ("reports can only be passed once per session").

```
components/app_copilot/R/
├─ CopilotBoardUI.R         # column relayout
├─ CopilotReportsServer.R   # lock-not-grey checkbox + tooltip
└─ copilot_messages.R       # +report_locked message
```