### PR TITLE
feat: durable AI infographics with download and cost tracking

### DIFF
--- a/components/app_studio/R/infographic_server.R
+++ b/components/app_studio/R/infographic_server.R
@@ -43,53 +43,41 @@ InfographicUI <- function(id) {
   bslib::navset_tab(
     id = ns("navset"),
     bslib::nav_panel(title = "Summary",
-      bslib::card(
-        min_height = 600,
-        full_screen = TRUE,
-        div(shiny::imageOutput(ns("summary"), height = "100%", width = "100%"),
-          height = "100%", width = "100%", style = "text-align: center;")
-      )
-    ),
+      infographic_tab_card(ns, "combined")),
     bslib::nav_panel(title = "WGCNA",
-      bslib::card(
-        min_height = 600,
-        full_screen = TRUE,
-        div(shiny::imageOutput(ns("wgcna"), height = "100%", width = "100%"),
-          height = "100%", width = "100%", style = "text-align: center;")
-      )
-    ),
+      infographic_tab_card(ns, "wgcna")),
     bslib::nav_panel(title = "moxWGCNA",
-      bslib::card(
-        min_height = 600,
-        full_screen = TRUE,
-        div(shiny::imageOutput(ns("wgcna2"), height = "100%", width = "100%"),
-          height = "100%", width = "100%", style = "text-align: center;")
-      )
-    ),
+      infographic_tab_card(ns, "wgcna_mox")),
     bslib::nav_panel(title = "MOFA",
-      bslib::card(
-        min_height = 600,
-        full_screen = TRUE,
-        div(shiny::imageOutput(ns("mofa"), height = "100%", width = "100%"),
-          height = "100%", width = "100%", style = "text-align: center;")
-      )
-    ),
+      infographic_tab_card(ns, "mofa")),
     bslib::nav_panel(title = "DE",
-      bslib::card(
-        min_height = 600,
-        full_screen = TRUE,
-        div(shiny::imageOutput(ns("de"), height = "100%", width = "100%"),
-          height = "100%", width = "100%", style = "text-align: center;")
-      )
-    ),
+      infographic_tab_card(ns, "de")),
     bslib::nav_panel(title = "Enrichment",
-      bslib::card(
-        min_height = 600,
-        full_screen = TRUE,
-        div(shiny::imageOutput(ns("enrichment"), height = "100%", width = "100%"),
-          height = "100%", width = "100%", style = "text-align: center;")
-      )
-    )
+      infographic_tab_card(ns, "pathways"))
+  )
+}
+
+#' Build one infographic preview card with its PNG download button
+#'
+#' Shared by the static tabs in \code{InfographicUI()} and the dynamic drug
+#' tabs inserted by \code{InfographicServer()}, so both get an identical
+#' download control above the preview image.
+#'
+#' @param ns Namespace function for the infographic module.
+#' @param slot AI report slot name.
+#' @return A \code{bslib::card()} holding the download button and preview image.
+infographic_tab_card <- function(ns, slot) {
+  bslib::card(
+    min_height = 600,
+    full_screen = TRUE,
+    div(style = "text-align: right;",
+      shiny::downloadButton(ns(infographic_download_id(slot)),
+        "Download PNG", class = "btn btn-outline-primary btn-sm",
+        icon = shiny::icon("download"))
+    ),
+    div(shiny::imageOutput(ns(infographic_output_id(slot)),
+      height = "100%", width = "100%"),
+      height = "100%", width = "100%", style = "text-align: center;")
   )
 }
 
@@ -132,6 +120,14 @@ infographic_output_id <- function(slot) {
     pathways = "enrichment",
     paste0("preview_", slot)
   )
+}
+
+#' Resolve an AI report slot to its PNG download handler output ID
+#'
+#' @param slot AI report slot name.
+#' @return Shiny output ID for the infographic download button.
+infographic_download_id <- function(slot) {
+  paste0(infographic_output_id(slot), "_download")
 }
 
 #' Build an omicsai infographic prompt for one AI report
@@ -243,7 +239,7 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
     # Render one stored infographic slot into its preview image output.
     render_infographic <- function(slot) {
       renderImage({
-        img <- ai_infographic_get(pgx_snapshot(), slot)
+        img <- playbase::ai_infographic_get(pgx_snapshot(), slot)
         shiny::validate(shiny::need(!is.null(img),
           paste("missing",
             # Use a stable display label for static and dynamic report slots.
@@ -251,6 +247,34 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
             "infographic")))
         ai_infographic_render_value(img, tmpdir, paste0("infographic-", slot))
       }, deleteFile = FALSE)
+    }
+
+    # Build a PNG download handler for one stored infographic slot. Reads the
+    # durable bytes via playbase (source-agnostic: precompute or regenerate),
+    # then applies the same watermark regular plot downloads get.
+    download_infographic <- function(slot) {
+      shiny::downloadHandler(
+        filename = function() {
+          dataset <- sub("[.]pgx$", "", pgx$name %||% "dataset")
+          paste0(dataset, "-infographic-", slot, ".png")
+        },
+        content = function(file) {
+          img <- playbase::ai_infographic_get(pgx_snapshot(), slot)
+          shiny::validate(shiny::need(
+            !is.null(img) && is.raw(img$bytes) && length(img$bytes) > 0L,
+            paste("no",
+              infographic_module_labels(pgx_snapshot(), slot),
+              "infographic available")))
+          writeBin(img$bytes, file)
+          # Gate on the global WATERMARK exactly like PlotModuleServer; a
+          # no-op if ImageMagick is missing or watermarking is disabled.
+          if (!WATERMARK %in% c("none", FALSE)) {
+            addWatermark.PNG2(file,
+              mark = file.path(FILES, "watermark-logo.png"),
+              position = WATERMARK)
+          }
+        }
+      )
     }
 
     # Rebuild dynamic drug-connectivity tabs from the current AI report slots.
@@ -269,20 +293,14 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
           nav = bslib::nav_panel(
             title = label,
             value = slot,
-            bslib::card(
-              min_height = 600,
-              full_screen = TRUE,
-              div(shiny::imageOutput(ns(infographic_output_id(slot)),
-                height = "100%",
-                width = "100%"), height = "100%", width = "100%",
-                style = "text-align: center;")
-            )
+            infographic_tab_card(ns, slot)
           )
         )
         local({
           slot_i <- slot
           # Bind each dynamic tab to the matching stored infographic slot.
           output[[infographic_output_id(slot_i)]] <- render_infographic(slot_i)
+          output[[infographic_download_id(slot_i)]] <- download_infographic(slot_i)
         })
         dynamic_drug_tabs <<- c(dynamic_drug_tabs, slot)
         target <- slot
@@ -293,7 +311,7 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
     # Sync visible tabs, checkbox choices, and style choices from PGX state.
     update_nav <- function(pgx_list = pgx_snapshot()) {
       sync_drug_tabs(pgx_list)
-      slots <- unique(c(ai_report_slots(pgx_list), ai_infographic_slots(pgx_list)))
+      slots <- unique(c(ai_report_slots(pgx_list), playbase::ai_infographic_slots(pgx_list)))
       targets <- c(
         combined = "Summary",
         wgcna = "WGCNA",
@@ -386,7 +404,7 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
     # Store one job result in pgx$ai and advance batch counters.
     store_image_job_result <- function(slot, result = NULL, error = NULL,
                                        style = NULL) {
-      updated_pgx <- ai_infographic_set(
+      updated_pgx <- playbase::ai_infographic_set(
         pgx_snapshot(),
         slot,
         result,
@@ -398,6 +416,18 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
       image_jobs$changed <- TRUE
       image_jobs$done <- image_jobs$done + 1L
       if (!is.null(error)) image_jobs$failed <- image_jobs$failed + 1L
+
+      # Telemetry: record one event per infographic from the persisted
+      # pgx$ai slot. Dataset-keyed event_id makes this idempotent across
+      # sessions/reloads; no-ops for error entries (no usage to record).
+      tryCatch(
+        ai_telemetry_record_infographics(
+          shiny::isolate(shiny::reactiveValuesToList(pgx)),
+          user_email = NA_character_
+        ),
+        error = function(e) NULL
+      )
+
       invisible(NULL)
     }
 
@@ -551,6 +581,13 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
     output$mofa <- render_infographic("mofa")
     output$de <- render_infographic("de")
     output$enrichment <- render_infographic("pathways")
+
+    for (slot in c("combined", "wgcna", "wgcna_mox", "mofa", "de", "pathways")) {
+      local({
+        slot_i <- slot
+        output[[infographic_download_id(slot_i)]] <- download_infographic(slot_i)
+      })
+    }
 
     shiny::observeEvent(list(pgx$X, pgx$name, pgx$ai), {
       shiny::req(pgx$X, pgx$name)

--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -571,6 +571,21 @@ upload_module_computepgx_server <- function(
                     ),
                     value = TRUE
                   )
+                ),
+                conditionalPanel(
+                  "input.create_ai_reports == true",
+                  ns = ns,
+                  div(
+                    style = "margin-top:-20px;margin-left:12px;margin-bottom:-20px;",
+                    shiny::checkboxInput(
+                      ns("create_ai_infographics"),
+                      label = withTooltip(
+                        shiny::span("Create AI infographics"),
+                        "Infographics can also be generated later from AI Studio. Image generation adds extra compute time and cost."
+                      ),
+                      value = FALSE
+                    )
+                  )
                 )
               ),
               bslib::card(
@@ -1171,6 +1186,7 @@ upload_module_computepgx_server <- function(
         }
 
         create_ai_reports <- is.null(input$create_ai_reports) || isTRUE(input$create_ai_reports)
+        create_ai_infographics <- isTRUE(input$create_ai_infographics)
         llm_model <- getUserOption(session, "llm_model")
         cred_fn <- get_ai_credentials(session)
         ai_features <- NULL
@@ -1190,6 +1206,16 @@ upload_module_computepgx_server <- function(
           # is a no-op when WGCNA was not among the selected extra methods, so
           # this is safe to set unconditionally whenever AI reports are on.
           ai_features$wgcna_summaries <- ai_features$reports
+
+          # Precompute durable AI infographics for the static report slots,
+          # opt-in via the nested checkbox (defaults FALSE — image generation
+          # has real per-slot provider cost/time, unlike text reports).
+          if (isTRUE(create_ai_infographics)) {
+            ai_features$infographics <- list(
+              select = c("combined", "wgcna", "wgcna_mox", "mofa", "de", "pathways"),
+              style = "bigomics"
+            )
+          }
         }
 
         ## Define create_pgx function arguments
@@ -1492,6 +1518,10 @@ upload_module_computepgx_server <- function(
           computedPGX(pgx)
           tryCatch(
             ai_telemetry_record_reports(pgx, user_email = auth$email),
+            error = function(e) NULL
+          )
+          tryCatch(
+            ai_telemetry_record_infographics(pgx, user_email = auth$email),
             error = function(e) NULL
           )
         } else {

--- a/components/modules/AiReports.R
+++ b/components/modules/AiReports.R
@@ -7,13 +7,6 @@
 # PGX AI report access helpers
 # =============================================================================
 
-.ai_report_ai_slot <- function(pgx) {
-  if (is.null(pgx) || !is.list(pgx)) return(NULL)
-  ai <- pgx$ai
-  if (is.null(ai) || !is.list(ai)) return(NULL)
-  ai
-}
-
 .ai_report_valid_entry <- function(x) {
   is.list(x) &&
     is.character(x$report) &&
@@ -23,7 +16,7 @@
 }
 
 ai_report_slots <- function(pgx) {
-  ai <- .ai_report_ai_slot(pgx)
+  ai <- playbase::ai_report_ai_slot(pgx)
   if (is.null(ai)) return(character(0))
 
   slots <- setdiff(names(ai), "meta")
@@ -39,7 +32,7 @@ ai_report_get <- function(pgx, slot) {
     return(NULL)
   }
 
-  ai <- .ai_report_ai_slot(pgx)
+  ai <- playbase::ai_report_ai_slot(pgx)
   if (is.null(ai)) return(NULL)
 
   entry <- ai[[slot]]
@@ -167,7 +160,7 @@ ai_report_generate <- function(pgx,
 
 ai_report_update_text <- function(pgx, reports) {
   if (is.null(pgx) || !is.list(pgx)) return(pgx)
-  ai <- .ai_report_ai_slot(pgx)
+  ai <- playbase::ai_report_ai_slot(pgx)
   if (is.null(ai)) return(pgx)
 
   reports <- reports[!is.na(names(reports)) & nzchar(names(reports))]
@@ -220,181 +213,9 @@ ai_report_copy_into_reactive <- function(pgx_rv, ai) {
   invisible(TRUE)
 }
 
-#' Get one stored AI infographic from pgx$ai
-#'
-#' Returns an infographic entry only when it contains stored bytes, an existing
-#' file path, or a stored error status.
-#'
-#' @param pgx PGX object as a list.
-#' @param slot AI report slot name.
-#' @return Infographic entry list, or \code{NULL} when unavailable.
-ai_infographic_get <- function(pgx, slot) {
-  if (is.null(slot) || length(slot) != 1L) return(NULL)
-  slot <- tryCatch(as.character(slot)[[1L]], error = function(e) NA_character_)
-  if (is.na(slot) || !nzchar(slot)) return(NULL)
-
-  ai <- .ai_report_ai_slot(pgx)
-  if (is.null(ai) || !is.list(ai[[slot]])) return(NULL)
-
-  img <- ai[[slot]]$infographic
-  if (!is.list(img)) return(NULL)
-  has_bytes <- is.raw(img$bytes) && length(img$bytes) > 0L
-  has_path <- is.character(img$path) && length(img$path) > 0L &&
-    nzchar(img$path[[1L]]) && file.exists(img$path[[1L]])
-  if (!has_bytes && !has_path && !identical(img$status, "error")) return(NULL)
-  img
-}
-
-#' List AI report slots with stored infographic state
-#'
-#' @param pgx PGX object as a list.
-#' @return Character vector of AI report slot names with infographic entries.
-ai_infographic_slots <- function(pgx) {
-  ai <- .ai_report_ai_slot(pgx)
-  if (is.null(ai)) return(character(0))
-
-  slots <- setdiff(names(ai), "meta")
-  slots[vapply(slots, function(slot) {
-    !is.null(ai_infographic_get(pgx, slot))
-  }, logical(1))]
-}
-
-#' Convert provider errors into user-facing infographic messages
-#'
-#' @param error Error condition or character error message.
-#' @return Sanitized message suitable for storage and UI display.
-ai_infographic_friendly_error <- function(error) {
-  msg <- if (inherits(error, "condition")) {
-    conditionMessage(error)
-  } else if (is.null(error)) {
-    ""
-  } else {
-    paste(as.character(error), collapse = " ")
-  }
-  msg <- trimws(msg)
-
-  if (!nzchar(msg)) {
-    return("Infographic generation failed. Please try again.")
-  }
-  if (grepl("503|Service Unavailable|high demand|overload|saturat",
-      msg, ignore.case = TRUE)) {
-    return(paste0(
-      "Image generation server is temporarily overloaded. ",
-      "Please try again in a few minutes."
-    ))
-  }
-  if (grepl("429|Too Many Requests|rate.?limit", msg, ignore.case = TRUE)) {
-    return("Image generation rate limit reached. Please wait a moment and try again.")
-  }
-  if (grepl("timeout|timed.?out", msg, ignore.case = TRUE)) {
-    return(paste0(
-      "Image generation timed out. The service may be busy; ",
-      "please try again."
-    ))
-  }
-  if (grepl("No image data|Empty response|no response", msg, ignore.case = TRUE)) {
-    return(paste0(
-      "Image generation server seems saturated and returned no image. ",
-      "Please try again."
-    ))
-  }
-  if (grepl("_API_KEY|API.?key|401|Unauthorized", msg, ignore.case = TRUE)) {
-    return(paste0(
-      "Image generation is not configured correctly. ",
-      "Please contact your administrator."
-    ))
-  }
-
-  "Image generation failed. Please try again."
-}
-
-#' Extract persisted image payload fields from an omicsai image result
-#'
-#' @param result \code{omicsai_image_result} list, or \code{NULL} for errors.
-#' @return List containing bytes, content type, path, prompt, model, and metadata.
-ai_infographic_payload <- function(result) {
-  path <- NULL
-  prompt <- NULL
-  metadata <- NULL
-  if (is.list(result)) {
-    path <- if (is.character(result$path) && length(result$path) > 0L) {
-      result$path[[1L]]
-    } else {
-      NULL
-    }
-    prompt <- result$prompt
-    metadata <- result$metadata
-  }
-
-  bytes <- raw(0)
-  if (!is.null(path) && file.exists(path)) {
-    bytes <- readBin(path, what = raw(), n = file.info(path)$size)
-  }
-
-  ext <- tolower(tools::file_ext(if (is.null(path)) "image.png" else path))
-  list(
-    bytes = bytes,
-    content_type = switch(ext,
-      jpg = "image/jpeg",
-      jpeg = "image/jpeg",
-      "image/png"),
-    path = path,
-    prompt = prompt,
-    model = if (is.null(metadata$model)) NULL else metadata$model,
-    metadata = metadata
-  )
-}
-
-#' Store one AI infographic under pgx$ai
-#'
-#' Writes generated image bytes and metadata, or a sanitized error entry, into
-#' \code{pgx$ai[[slot]]$infographic}.
-#'
-#' @param pgx PGX object as a list.
-#' @param slot AI report slot name.
-#' @param result \code{omicsai_image_result} list, or \code{NULL} for errors.
-#' @param status Infographic status, usually \code{"done"} or \code{"error"}.
-#' @param error Optional provider error for failed generation.
-#' @param style omicsai image style ID.
-#' @param n_blocks Deprecated layout metadata retained for compatibility.
-#' @return Updated PGX object.
-ai_infographic_set <- function(pgx, slot, result,
-                               status = "done", error = NULL,
-                               style = NULL, n_blocks = NULL) {
-  if (is.null(pgx) || !is.list(pgx)) return(pgx)
-  slot <- tryCatch(as.character(slot)[[1L]], error = function(e) NA_character_)
-  if (is.na(slot) || !nzchar(slot)) return(pgx)
-
-  if (is.null(pgx$ai) || !is.list(pgx$ai)) pgx$ai <- list()
-  if (is.null(pgx$ai[[slot]]) || !is.list(pgx$ai[[slot]])) {
-    pgx$ai[[slot]] <- list()
-  }
-  # Normalize generated image data before writing the PGX AI schema entry.
-  payload <- ai_infographic_payload(result)
-
-  pgx$ai[[slot]]$infographic <- list(
-    status = status,
-    error = if (identical(status, "error")) {
-      ai_infographic_friendly_error(error)
-    } else {
-      error
-    },
-    bytes = payload$bytes,
-    content_type = payload$content_type,
-    path = payload$path,
-    prompt = payload$prompt,
-    model = payload$model,
-    style = style,
-    n_blocks = n_blocks,
-    date = as.character(Sys.time()),
-    metadata = payload$metadata
-  )
-  pgx
-}
-
 #' Convert a stored AI infographic entry into a Shiny renderImage value
 #'
-#' @param img Infographic entry returned by \code{ai_infographic_get()}.
+#' @param img Infographic entry returned by \code{playbase::ai_infographic_get()}.
 #' @param tmpdir Directory used to materialize stored raw bytes.
 #' @param name Base filename for materialized image bytes.
 #' @return List suitable for \code{shiny::renderImage()}, or \code{NULL}.
@@ -402,7 +223,7 @@ ai_infographic_render_value <- function(img, tmpdir, name = "infographic") {
   if (is.null(img) || !is.list(img)) return(NULL)
   if (identical(img$status, "error")) {
     # Keep legacy/raw stored errors friendly before they reach the UI.
-    msg <- ai_infographic_friendly_error(img$error)
+    msg <- playbase::ai_infographic_friendly_error(img$error)
     shiny::validate(shiny::need(FALSE, msg))
   }
 

--- a/components/modules/AiTelemetry.R
+++ b/components/modules/AiTelemetry.R
@@ -551,3 +551,78 @@ ai_telemetry_record_reports <- function(pgx, user_email,
 
   invisible(recorded)
 }
+
+## ---------------------------------------------------------------------------
+## .9 — record_infographics(): reconcile helper for AI infographic slots
+
+#' Record telemetry for all AI infographic slots that carry usage data
+#'
+#' Scans \code{pgx$ai} and calls \code{ai_telemetry_record()} once per slot
+#' whose \code{infographic$metadata$usage} is non-NULL. Unlike report slots,
+#' infographic usage is nested under \code{infographic$metadata$usage} (not a
+#' top-level \code{usage} field) and its model lives in the sibling
+#' \code{infographic$model}, not inside the usage list itself. The stored
+#' timestamp is \code{infographic$date}, a character string, parsed back to
+#' POSIXct with a \code{Sys.time()} fallback.
+#'
+#' Uses a dataset-keyed \code{session_id} so the resulting
+#' \code{event_id = "infographic:<dataset_id>:<module>:<created_at>"} is
+#' stable across sessions and reloads — INSERT OR IGNORE deduplicates replays.
+#'
+#' Safe to call multiple times on the same pgx; tolerate \code{user_email = NA}.
+#' Errors are logged but never propagate (fire-and-forget).
+#'
+#' @param pgx       PGX object as a plain list (not reactive).
+#' @param user_email User email from auth\$email; may be NA.
+#' @param db_path   Telemetry db path.
+#' @return Invisible character vector of event ids recorded (may be empty).
+ai_telemetry_record_infographics <- function(pgx, user_email,
+                                             db_path = .ai_tel_default_db()) {
+  if (is.null(pgx) || !is.list(pgx)) return(invisible(character(0)))
+  ai <- if (is.list(pgx$ai)) pgx$ai else NULL
+  if (is.null(ai)) return(invisible(character(0)))
+
+  dataset_id <- if (!is.null(pgx$name) && nzchar(pgx$name %||% "")) pgx$name else ""
+  slots      <- names(ai)
+  recorded   <- character(0)
+
+  for (module in slots) {
+    slot <- ai[[module]]
+    if (!is.list(slot)) next
+    infographic <- slot$infographic
+    if (!is.list(infographic)) next
+    usage <- infographic$metadata$usage
+    if (is.null(usage)) next
+
+    model <- infographic$model %||% NA_character_
+    created_at <- tryCatch(
+      as.POSIXct(infographic$date),
+      error = function(e) NA
+    )
+    if (is.null(created_at) || is.na(created_at)) created_at <- Sys.time()
+
+    # Build a stable, dataset-keyed session_id so the sink's formula produces:
+    #   event_id = "infographic:<dataset_id>:<module>:<created_at_us>"
+    session_id <- paste0(dataset_id, ":", module)
+
+    ev_id <- tryCatch(
+      ai_telemetry_record(
+        source     = "infographic",
+        session_id = session_id,
+        user_email = user_email,
+        model      = model,
+        usage      = usage,
+        created_at = created_at,
+        db_path    = db_path
+      ),
+      error = function(e) {
+        warning("[ai_telemetry_record_infographics] failed for module '", module,
+                "': ", conditionMessage(e), call. = FALSE)
+        NULL
+      }
+    )
+    if (!is.null(ev_id)) recorded <- c(recorded, ev_id)
+  }
+
+  invisible(recorded)
+}

--- a/tests/testthat/test-ai-reports.R
+++ b/tests/testthat/test-ai-reports.R
@@ -271,7 +271,7 @@ test_that("ai_infographic_set stores image bytes and metadata under pgx$ai", {
   ), class = "omicsai_image_result")
 
   pgx <- list(ai = list(combined = list(report = "Combined report")))
-  updated <- ai_infographic_set(pgx, "combined", result,
+  updated <- playbase::ai_infographic_set(pgx, "combined", result,
     style = "bigomics", n_blocks = 2)
 
   stored <- updated$ai$combined$infographic
@@ -283,7 +283,7 @@ test_that("ai_infographic_set stores image bytes and metadata under pgx$ai", {
   expect_equal(stored$model, "gemini-test")
   expect_equal(stored$style, "bigomics")
   expect_equal(stored$n_blocks, 2)
-  expect_equal(ai_infographic_slots(updated), "combined")
+  expect_equal(playbase::ai_infographic_slots(updated), "combined")
 })
 
 test_that("ai_infographic_get and render tolerate missing and error states", {
@@ -295,9 +295,9 @@ test_that("ai_infographic_get and render tolerate missing and error states", {
     )
   ))
 
-  expect_null(ai_infographic_get(pgx, "combined"))
-  expect_equal(ai_infographic_get(pgx, "wgcna")$error, "provider failed")
-  expect_equal(ai_infographic_slots(pgx), "wgcna")
+  expect_null(playbase::ai_infographic_get(pgx, "combined"))
+  expect_equal(playbase::ai_infographic_get(pgx, "wgcna")$error, "provider failed")
+  expect_equal(playbase::ai_infographic_slots(pgx), "wgcna")
 })
 
 test_that("ai_infographic_friendly_error hides provider internals", {
@@ -306,21 +306,21 @@ test_that("ai_infographic_friendly_error hides provider internals", {
     "No image data in Gemini response"
   )
 
-  expect_match(ai_infographic_friendly_error(raw_error),
+  expect_match(playbase::ai_infographic_friendly_error(raw_error),
     "server seems saturated", fixed = TRUE)
   expect_false(grepl(
     "\\.image_api_call|Gemini",
-    ai_infographic_friendly_error(raw_error)
+    playbase::ai_infographic_friendly_error(raw_error)
   ))
-  expect_match(ai_infographic_friendly_error("HTTP 429 rate limit"),
+  expect_match(playbase::ai_infographic_friendly_error("HTTP 429 rate limit"),
     "rate limit", fixed = TRUE)
-  expect_match(ai_infographic_friendly_error(""),
+  expect_match(playbase::ai_infographic_friendly_error(""),
     "Please try again", fixed = TRUE)
 })
 
 test_that("ai_infographic_set stores friendly errors", {
   pgx <- list(ai = list(pathways = list(report = "Enrichment report")))
-  updated <- ai_infographic_set(
+  updated <- playbase::ai_infographic_set(
     pgx,
     "pathways",
     NULL,


### PR DESCRIPTION
- add an opt-in "Create AI infographics" checkbox to the upload wizard, nested under "Create AI reports", so infographics precompute once at upload time via playbase::pgx.update_infographics() instead of only ever being generated on-demand and lost to whoever clicks first
- migrate infographic_server.R's schema calls to playbase:: (the schema functions moved there), add a per-slot watermarked PNG download button to AI Studio, and add ai_telemetry_record_infographics() so infographic generation cost is tracked the same way AI report generation already is
- wire telemetry at both the upload-precompute and on-demand-regenerate paths, deduplicated via a dataset-keyed event id so re-loading or re-viewing a dataset never double-counts cost

Depends on:
- https://github.com/bigomics/omicsai/pull/4
- https://github.com/bigomics/playbase/pull/503