### PR TITLE
fix: gate AI report/infographic generation on dataset ownership

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -887,14 +887,15 @@ app_server <- function(input, output, session) {
 
   ## Resolve where the current pgx may be persisted, or NULL if the caller
   ## isn't allowed to persist it. Owner check = file lives in auth$user_dir.
-  ## Admins act as curators: they write back to the dataset's source dir.
+  ## When the admin feature is enabled (opt$ENABLE_ADMIN), admins act as
+  ## curators: they write back to the dataset's source dir.
   pgx_save_target <- function(pgx) {
     if (!isTRUE(auth$logged)) return(NULL)
     if (is.null(pgx$name)) return(NULL)
     file <- paste0(sub("[.]pgx$", "", pgx$name), ".pgx")
     owner_path <- file.path(auth$user_dir, file)
     if (file.exists(owner_path)) return(owner_path)
-    if (isTRUE(auth$ADMIN)) {
+    if (isTRUE(auth$ADMIN) && isTRUE(opt$ENABLE_ADMIN)) {
       src_path <- file.path(pgx_source_dir() %||% auth$user_dir, file)
       if (file.exists(src_path)) return(src_path)
     }

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -880,17 +880,36 @@ app_server <- function(input, output, session) {
   ## Standard modules
   ## -------------------------------------------------------------
 
-  ## Single audited save path for voluntary report regeneration.
-  ## Owner check = file must live in auth$user_dir. Public / shared
-  ## datasets become a silent no-op.
-  save_current_pgx <- function(pgx) {
-    if (!isTRUE(auth$logged)) return(invisible(FALSE))
-    if (is.null(pgx$name)) return(invisible(FALSE))
-    pgxdir <- auth$user_dir
-    if (!dir.exists(pgxdir)) return(invisible(FALSE))
+  ## Source directory of the currently loaded dataset, tracked by
+  ## LoadingBoard on each load (pgxdir %||% user_dir). Needed so admins
+  ## can persist AI content back to public/shared datasets they don't own.
+  pgx_source_dir <- reactiveVal(NULL)
+
+  ## Resolve where the current pgx may be persisted, or NULL if the caller
+  ## isn't allowed to persist it. Owner check = file lives in auth$user_dir.
+  ## Admins act as curators: they write back to the dataset's source dir.
+  pgx_save_target <- function(pgx) {
+    if (!isTRUE(auth$logged)) return(NULL)
+    if (is.null(pgx$name)) return(NULL)
     file <- paste0(sub("[.]pgx$", "", pgx$name), ".pgx")
-    full <- file.path(pgxdir, file)
-    if (!file.exists(full)) return(invisible(FALSE))
+    owner_path <- file.path(auth$user_dir, file)
+    if (file.exists(owner_path)) return(owner_path)
+    if (isTRUE(auth$ADMIN)) {
+      src_path <- file.path(pgx_source_dir() %||% auth$user_dir, file)
+      if (file.exists(src_path)) return(src_path)
+    }
+    NULL
+  }
+
+  ## Pre-flight predicate: TRUE iff the current user could persist this pgx.
+  ## Used to gate paid AI generation before it runs, not just the save.
+  can_save_current_pgx <- function(pgx) !is.null(pgx_save_target(pgx))
+
+  ## Single audited save path for voluntary report regeneration.
+  ## Public / shared datasets a non-owner can't persist become a silent no-op.
+  save_current_pgx <- function(pgx) {
+    full <- pgx_save_target(pgx)
+    if (is.null(full)) return(invisible(FALSE))
     pgx_obj <- if (methods::is(pgx, "reactivevalues")) {
       shiny::reactiveValuesToList(pgx)
     } else {
@@ -914,6 +933,7 @@ app_server <- function(input, output, session) {
     recompute_pgx = recompute_pgx,
     new_upload = new_upload,
     save_pgx = save_current_pgx,
+    pgx_source_dir = pgx_source_dir,
     parent = session
   )
 
@@ -965,7 +985,9 @@ app_server <- function(input, output, session) {
     })
   }
 
-  StudioServer("studio", pgx = PGX, save_pgx = save_current_pgx)
+  StudioServer("studio", pgx = PGX, save_pgx = save_current_pgx,
+    can_save_pgx = can_save_current_pgx,
+    user_email = function() shiny::isolate(auth$email))
 
   if (isTRUE(opt$ENABLE_ACROSS)) {
     AcrossBoard("across", pgx = PGX, pgx_dir = shiny::reactive(auth$user_dir),

--- a/components/app_studio/R/aireport_server.R
+++ b/components/app_studio/R/aireport_server.R
@@ -111,7 +111,8 @@ AiReportUI <- function(id) {
 }
 
 
-AiReportServer <- function(id, pgx, save_pgx = NULL) {
+AiReportServer <- function(id, pgx, save_pgx = NULL, can_save_pgx = NULL,
+                           user_email = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
     
@@ -568,7 +569,7 @@ AiReportServer <- function(id, pgx, save_pgx = NULL) {
           tryCatch(
             ai_telemetry_record_reports(
               shiny::isolate(shiny::reactiveValuesToList(pgx)),
-              user_email = NA_character_
+              user_email = studio_user_email(user_email)
             ),
             error = function(e) NULL
           )
@@ -682,6 +683,9 @@ AiReportServer <- function(id, pgx, save_pgx = NULL) {
 
     shiny::observeEvent(input$generate, {
       shiny::req(pgx$X, pgx$name)
+      if (!studio_can_generate(can_save_pgx, pgx, session, "AI reports")) {
+        return(NULL)
+      }
 
       llm_model <- getUserOption(session, "llm_model")
       if (is.null(llm_model) || llm_model == "") {
@@ -721,6 +725,10 @@ AiReportServer <- function(id, pgx, save_pgx = NULL) {
     }, ignoreInit = TRUE)
 
     shiny::observeEvent(input$confirm_generate, {
+      if (!studio_can_generate(can_save_pgx, pgx, session, "AI reports")) {
+        shiny::removeModal()
+        return(NULL)
+      }
       modules <- input$report_select
       if (!length(modules)) {
         shiny::showNotification("Select at least one report to regenerate.",

--- a/components/app_studio/R/infographic_server.R
+++ b/components/app_studio/R/infographic_server.R
@@ -221,7 +221,8 @@ infographic_job_result <- function(result, slot, token) {
 #' @param pgx ReactiveValues PGX object.
 #' @param save_pgx Optional callback used to persist modified PGX state.
 #' @return Shiny module server return value.
-InfographicServer <- function(id, pgx, save_pgx = NULL) {
+InfographicServer <- function(id, pgx, save_pgx = NULL, can_save_pgx = NULL,
+                              user_email = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     tmpdir <- file.path(tempdir(), paste0("ai-infographics-", id))
@@ -423,7 +424,7 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
       tryCatch(
         ai_telemetry_record_infographics(
           shiny::isolate(shiny::reactiveValuesToList(pgx)),
-          user_email = NA_character_
+          user_email = studio_user_email(user_email)
         ),
         error = function(e) NULL
       )
@@ -596,6 +597,9 @@ InfographicServer <- function(id, pgx, save_pgx = NULL) {
 
     shiny::observeEvent(input$generate, {
       shiny::req(pgx$X, pgx$name)
+      if (!studio_can_generate(can_save_pgx, pgx, session, "AI infographics")) {
+        return(NULL)
+      }
       if (isTRUE(image_jobs$running)) {
         shiny::showNotification("Infographic generation is already running.",
           type = "message", session = session)

--- a/components/app_studio/R/studio_server.R
+++ b/components/app_studio/R/studio_server.R
@@ -4,6 +4,45 @@
 ##
 
 
+## ---------------------------------------------------------------------
+## Shared helpers for the AI Studio generation modules (AiReportServer,
+## InfographicServer). Both gate paid generation on the same ownership
+## predicate and attribute cost telemetry to the same user; keeping that
+## logic here is the single source of truth so the two can't drift.
+## ---------------------------------------------------------------------
+
+#' Resolve the current user's email for cost telemetry attribution.
+#'
+#' @param user_email A reactive/closure over auth$email (read lazily so it
+#'   is populated post-login), or a plain value. Falls back to NA.
+#' @return Character scalar email, or NA_character_ when unavailable.
+studio_user_email <- function(user_email) {
+  em <- if (is.function(user_email)) user_email() else user_email
+  if (is.null(em) || !nzchar(em)) NA_character_ else em
+}
+
+#' Pre-flight authorization gate for paid AI generation.
+#'
+#' Returns TRUE when the user could persist the result (owner or admin);
+#' otherwise shows a styled notification and returns FALSE so callers can
+#' fail fast before spending on a generation doomed to no-op on save.
+#'
+#' @param can_save_pgx Predicate closure over auth/source dir, or NULL (no gate).
+#' @param pgx ReactiveValues PGX object.
+#' @param session Shiny session used for the notification.
+#' @param content Human label for the content type, e.g. "AI reports".
+#' @return TRUE if generation is allowed, FALSE otherwise.
+studio_can_generate <- function(can_save_pgx, pgx, session,
+                                content = "AI content") {
+  if (is.null(can_save_pgx)) return(TRUE)
+  if (isTRUE(can_save_pgx(pgx))) return(TRUE)
+  shiny::showNotification(
+    paste0("You can only generate ", content, " for datasets you own."),
+    type = "warning", session = session)
+  FALSE
+}
+
+
 #' The application server-side logic
 #'
 #' @param input,output,session Internal parameters for {shiny}.
@@ -12,7 +51,8 @@
 #' Note: pgx needs to be reactiveValues
 #'
 #'
-StudioServer <- function(id, pgx, save_pgx = NULL) {
+StudioServer <- function(id, pgx, save_pgx = NULL, can_save_pgx = NULL,
+                         user_email = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -53,8 +93,10 @@ StudioServer <- function(id, pgx, save_pgx = NULL) {
     ## ----------------- output -------------------------------
     VisReportServer("poster", pgx, output_format="poster")
     VisReportServer("slide", pgx, output_format="slide")
-    AiReportServer("aireport", pgx, save_pgx = save_pgx)
-    InfographicServer("infographic", pgx, save_pgx = save_pgx)
+    AiReportServer("aireport", pgx, save_pgx = save_pgx,
+        can_save_pgx = can_save_pgx, user_email = user_email)
+    InfographicServer("infographic", pgx, save_pgx = save_pgx,
+        can_save_pgx = can_save_pgx, user_email = user_email)
     
   }) ## end moduleServer
 }

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -19,6 +19,7 @@ LoadingBoard <- function(id,
                          recompute_pgx,
                          new_upload,
                          save_pgx = NULL,
+                         pgx_source_dir = NULL,
                          parent) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns ## NAMESPACE
@@ -286,6 +287,14 @@ LoadingBoard <- function(id,
 
     maybe_offer_ai_reports <- function(pgxfile, is_user_dir) {
       if (!isTRUE(opt$ENABLE_AI)) return(invisible(NULL))
+
+      ## Only offer generation to users who can persist the result: dataset
+      ## owners (loaded from their own dir) or admins (curators, who write
+      ## back to the source dir via save_current_pgx). Otherwise the paid
+      ## ai_report_generate() below runs only to no-op on save. Same gate as
+      ## AI Studio on-demand generation.
+      if (!isTRUE(is_user_dir) && !isTRUE(auth$ADMIN)) return(invisible(NULL))
+
       llm_model <- getUserOption(session, "llm_model")
       if (is.null(llm_model) || llm_model == "") return(invisible(NULL))
       cred_fn <- get_ai_credentials(session)
@@ -332,7 +341,10 @@ LoadingBoard <- function(id,
                 error = function(e) NULL
               )
             }
-            if (isTRUE(updated) && isTRUE(is_user_dir) && !is.null(save_pgx)) {
+            ## Persist through save_current_pgx, which resolves the correct
+            ## target (owner dir, or source dir for admins) and no-ops if not
+            ## permitted. Non-persisters were already turned away above.
+            if (isTRUE(updated) && !is.null(save_pgx)) {
               save_pgx(pgx)
             }
             if (isTRUE(updated)) {
@@ -364,6 +376,13 @@ LoadingBoard <- function(id,
         beepr::beep(10)
         shiny::removeModal()
         return(NULL)
+      }
+
+      ## Record the source directory of the dataset just loaded so downstream
+      ## save/authorization logic (e.g. admin write-back to public/shared
+      ## datasets) knows where it actually lives.
+      if (!is.null(pgx_source_dir)) {
+        pgx_source_dir(if (is.null(pgxdir)) auth$user_dir else pgxdir)
       }
 
       ## ----------------- update PGX object ---------------------------------

--- a/components/board.loading/R/loading_server.R
+++ b/components/board.loading/R/loading_server.R
@@ -289,11 +289,12 @@ LoadingBoard <- function(id,
       if (!isTRUE(opt$ENABLE_AI)) return(invisible(NULL))
 
       ## Only offer generation to users who can persist the result: dataset
-      ## owners (loaded from their own dir) or admins (curators, who write
-      ## back to the source dir via save_current_pgx). Otherwise the paid
-      ## ai_report_generate() below runs only to no-op on save. Same gate as
-      ## AI Studio on-demand generation.
-      if (!isTRUE(is_user_dir) && !isTRUE(auth$ADMIN)) return(invisible(NULL))
+      ## owners (loaded from their own dir) or, when the admin feature is
+      ## enabled, admins (curators, who write back to the source dir via
+      ## save_current_pgx). Otherwise the paid ai_report_generate() below runs
+      ## only to no-op on save. Same gate as AI Studio on-demand generation.
+      admin_ok <- isTRUE(auth$ADMIN) && isTRUE(opt$ENABLE_ADMIN)
+      if (!isTRUE(is_user_dir) && !admin_ok) return(invisible(NULL))
 
       llm_model <- getUserOption(session, "llm_model")
       if (is.null(llm_model) || llm_model == "") return(invisible(NULL))


### PR DESCRIPTION
## Summary 

This PR adds cost monitoring to the AI reports and infographics. It also allows only admins can regenerate AI reports. This second part will need to be carefully checked that it aligns with standard OPG practices.