### PR TITLE
fix: drop NPM batch correction for methylomics

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -249,7 +249,11 @@ upload_module_normalization_server <- function(
         ntop_features <- if (isTRUE(input$bec_full_features)) Inf else 1000
 
         methods <- c("ComBat", "limma", "RUV", "SVA", "NPM")
-        if (ncol(X0) > 100) methods <- methods[methods != "NPM"]
+        ## NPM does not scale: drop it for many samples or for the very large
+        ## feature space of methylation arrays.
+        if (ncol(X0) > 100 || upload_datatype() == "methylomics") {
+          methods <- methods[methods != "NPM"]
+        }
         shiny::updateSelectInput(
           session,
           "bec_method",


### PR DESCRIPTION
NPM gets very slow / mem hungry on big matrices: unusable on methylation arrays

Same guard that already excludes it above 100 samples