### PR TITLE
feat: show normalized data in Sample QC, not raw counts

### DIFF
--- a/components/board.dataview/R/dataview_plot_boxplot.R
+++ b/components/board.dataview/R/dataview_plot_boxplot.R
@@ -40,7 +40,8 @@ dataview_plot_boxplot_server <- function(id,
                                          getCountsTable,
                                          r.samples = reactive(""),
                                          r.annot = reactive(""),
-                                         r.data_type,
+                                         r.datasource = reactive("X"),
+                                         r.data_type = reactive("log2"),
                                          watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     shiny::observe({
@@ -67,7 +68,9 @@ dataview_plot_boxplot_server <- function(id,
       samples <- r.samples()
       annot <- r.annot()
       shiny::req(res)
-      list(counts = res$log2counts, sample = colnames(res$log2counts), annot = annot)
+      ## {Scale} picks linear or log2, {Sample QC data} picked the matrix upstream
+      counts <- if (identical(r.data_type(), "counts")) res$counts else res$log2counts
+      list(counts = counts, sample = colnames(counts), annot = annot)
     })
 
     output$rank_list <- shiny::renderUI({
@@ -98,15 +101,8 @@ dataview_plot_boxplot_server <- function(id,
     plotly.RENDER <- function() {
       res <- plot_data()
       shiny::req(res)
-      data_type <- r.data_type()
-
-      if (data_type == "counts") {
-        ylab <- "Counts (log2CPM)"
-      } else if (data_type == "abundance") {
-        ylab <- "Abundance"
-      } else {
-        ylab <- "Abundance (log2)"
-      }
+      ylab <- if (identical(r.datasource(), "counts")) "Counts" else "Normalized abundance"
+      if (!identical(r.data_type(), "counts")) ylab <- paste0(ylab, " (log2)")
 
       df <- res$counts[, , drop = FALSE]
       if (nrow(df) > 1000) {

--- a/components/board.dataview/R/dataview_plot_coefficientOfvariation.R
+++ b/components/board.dataview/R/dataview_plot_coefficientOfvariation.R
@@ -40,16 +40,26 @@ dataview_plot_variationcoefficient_server <- function(id,
                                                       pgx,
                                                       r.samples,
                                                       r.groupby,
+                                                      r.datasource = reactive("X"),
                                                       watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     plot_data <- shiny::reactive({
       shiny::req(pgx$X, pgx$samples)
-      counts <- pgx$counts
       Y <- pgx$samples
       samples <- r.samples()
       groupby <- r.groupby()
       if (!all(samples %in% rownames(Y))) {
         return(NULL)
+      }
+
+      ## same rule as getCountStatistics(): X is log2 (beta for methylomics) and
+      ## CV needs a linear scale.
+      is.meth <- !is.null(pgx$datatype) && pgx$datatype == "methylomics"
+      if (identical(r.datasource(), "counts")) {
+        counts <- pgx$counts[, samples, drop = FALSE]
+      } else {
+        counts <- pgx$X[, samples, drop = FALSE]
+        if (!is.meth) counts <- 2**counts
       }
 
       if (groupby == "<ungrouped>") {

--- a/components/board.dataview/R/dataview_plot_totalcounts.R
+++ b/components/board.dataview/R/dataview_plot_totalcounts.R
@@ -41,32 +41,33 @@ dataview_plot_totalcounts_ui <- function(
 
 dataview_plot_totalcounts_server <- function(id,
                                              getCountStatistics,
-                                             r.data_type,
+                                             r.datasource = reactive("X"),
+                                             r.data_type = reactive("log2"),
                                              r.samples = reactive(""),
                                              r.data_groupby = reactive(""),
                                              watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     plot_data <- shiny::reactive({
       data_groupby <- r.data_groupby()
-      data_type <- r.data_type()
       samples <- r.samples()
       tbl <- getCountStatistics()
       req(tbl)
 
-      type <- tspan("counts", js = FALSE)
-
-      logtype <- if (data_type == "log2") {
-        " (log2)"
-      } else if (data_type == "logCPM") {
-        " (logCPM)"
+      type <- if (identical(r.datasource(), "counts")) {
+        tspan("counts", js = FALSE)
       } else {
-        ("")
+        tspan("normalized abundance", js = FALSE)
       }
 
       sampleqc_plottype <- input$sampleqc_plottype
 
+      ## {Scale} applies to the totals only: a feature count stays a count.
+      logscale <- !identical(r.data_type(), "counts")
+      total.counts <- tbl$total.counts
+      if (logscale) total.counts <- log2(1 + total.counts)
+
       if (sampleqc_plottype == "Total abundance") {
-        ylab <- paste0("Total ", type)
+        ylab <- paste0("Total ", type, if (logscale) " (log2)" else "")
       } else if (sampleqc_plottype == "Number of detected features") {
         ylab <- "N. of detected features"
       }
@@ -74,10 +75,11 @@ dataview_plot_totalcounts_server <- function(id,
       res <- list(
         df = data.frame(
           sample = names(tbl$total.counts),
-          counts = tbl$total.counts,
+          counts = total.counts,
           ndetectedfeat = tbl$n.detected.features
         ),
         ylab = ylab,
+        fmt = if (logscale) "%.2f" else "%8.0f",
         sampleqc_plottype = sampleqc_plottype
       )
 
@@ -136,7 +138,7 @@ dataview_plot_totalcounts_server <- function(id,
               marker = list(color = bar_color),
               hovertemplate = ~ paste0(
                 "Sample: <b>", sample, "</b><br>",
-                res$ylab, ": <b>", sprintf("%8.0f", counts), "</b>",
+                res$ylab, ": <b>", sprintf(res$fmt, counts), "</b>",
                 "<extra></extra>"
               )
             ) %>%

--- a/components/board.dataview/R/dataview_server.R
+++ b/components/board.dataview/R/dataview_server.R
@@ -197,6 +197,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       "counts_total",
       getCountStatistics,
       r.samples = selected_samples,
+      r.datasource = reactive(input$qc_datasource),
       r.data_type = reactive(input$data_type),
       watermark = WATERMARK
     )
@@ -207,6 +208,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       getCountStatistics,
       r.samples = selected_samples,
       r.annot = annot,
+      r.datasource = reactive(input$qc_datasource),
       r.data_type = reactive(input$data_type),
       watermark = WATERMARK
     )
@@ -230,6 +232,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       pgx,
       r.samples = selected_samples,
       r.groupby = reactive(input$data_groupby),
+      r.datasource = reactive(input$qc_datasource),
       watermark = WATERMARK
     )
 
@@ -285,7 +288,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
 
     getCountStatistics <- eventReactive(
       {
-        list(pgx$X, input$data_groupby, input$data_samplefilter)
+        list(pgx$X, input$data_groupby, input$data_samplefilter, input$qc_datasource)
       },
       {
         shiny::req(pgx$X, pgx$Y, pgx$samples)
@@ -299,7 +302,20 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         if (nsamples == 0) {
           return(NULL)
         }
-        counts <- pgx$counts[, samples, drop = FALSE]
+        ## QC plots show either the normalized/batch-corrected matrix used for the
+        ## analysis (pgx$X, default) or the raw counts. X is log2 (beta for
+        ## methylomics), so linearize it: totals and class proportions only make
+        ## sense on a linear scale. raw.counts is kept for feature detection, which
+        ## is a property of the uploaded data (X may be normalized and imputed).
+        is.meth <- !is.null(pgx$datatype) && pgx$datatype == "methylomics"
+        use.X <- !identical(input$qc_datasource, "counts")
+        raw.counts <- pgx$counts[, samples, drop = FALSE]
+        if (use.X) {
+          counts <- pgx$X[, samples, drop = FALSE]
+          if (!is.meth) counts <- 2**counts
+        } else {
+          counts <- raw.counts
+        }
 
         grpvar <- input$data_groupby
         if (grpvar != "<ungrouped>") {
@@ -307,10 +323,13 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
           grps <- sort(unique(gr))
           ## check if there are any samples remaining in the group after filtering
           if (length(grps) > 1) {
-            mx <- tapply(samples, gr, function(ii) {
-              rowMeans(counts[, ii, drop = FALSE], na.rm = TRUE)
-            })
-            counts <- do.call(cbind, mx)
+            grpmean <- function(mx) {
+              do.call(cbind, tapply(samples, gr, function(ii) {
+                rowMeans(mx[, ii, drop = FALSE], na.rm = TRUE)
+              }))
+            }
+            counts <- grpmean(counts)
+            raw.counts <- grpmean(raw.counts)
           }
         }
 
@@ -318,9 +337,11 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         if (ncol(counts) > 500) {
           kk <- sample(ncol(counts), 400, replace = TRUE)
           counts <- counts[, kk, drop = FALSE]
+          raw.counts <- raw.counts[, kk, drop = FALSE]
           subtt <- c(subtt, "random subset")
         }
         colnames(counts) <- substring(colnames(counts), 1, 24)
+        colnames(raw.counts) <- colnames(counts)
 
         gset <- list()
         gg <- pgx$genes[rownames(counts), ]$symbol
@@ -351,14 +372,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         prop.counts <- 100 * t(t(summed.counts) / total.counts)
 
         ## N. of detected features per sample or group AZ
-        n.detected.features <- apply(counts, 2, function(x) length(which(x > 0)))
-
-        ## get variation per group
-        # log2counts <- log2(1 + counts)
-        is.meth <- !is.null(pgx$datatype) && pgx$datatype == "methylomics"
-        log2counts <- if (is.meth) playbase::mToBeta(counts) else log2(1 + counts)
-        varx <- apply(log2counts, 1, var)
-        gset.var <- sapply(gset, function(s) mean(varx[s], na.rm = TRUE))
+        n.detected.features <- apply(raw.counts, 2, function(x) length(which(x > 0)))
 
         ## sort get top 20 gene families
         jj <- head(order(-rowSums(prop.counts, na.rm = TRUE)), 20)
@@ -375,7 +389,10 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         ss2 <- match(ss, colnames(prop.counts))
         prop.counts <- prop.counts[, ss2, drop = FALSE]
         counts <- counts[, ss2, drop = FALSE]
-        if (is.meth) {
+        if (use.X) {
+          ## counts is 2**X (beta values for methylomics): back to the analysis scale
+          log2counts <- if (is.meth) counts else log2(counts)
+        } else if (is.meth) {
           log2counts <- playbase::mToBeta(counts)
         } else {
           if (any(pgx$X[, samples, drop = FALSE] < 0, na.rm = TRUE)) {
@@ -393,6 +410,7 @@ DataViewBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         res <- list(
           total.counts = total.counts,
           subtt = subtt,
+          counts = counts, ## linear scale, for {Scale} = linear
           log2counts = log2counts,
           prop.counts = prop.counts,
           n.detected.features = n.detected.features, ## AZ

--- a/components/board.dataview/R/dataview_ui.R
+++ b/components/board.dataview/R/dataview_ui.R
@@ -56,6 +56,17 @@ DataViewInputs <- function(id) {
           ),
           "Choose an input data type for the analysis.",
           placement = "bottom"
+        ),
+        withTooltip(
+          shiny::radioButtons(
+            ns("qc_datasource"), "Sample QC data:",
+            choiceNames = c("normalized", "raw"),
+            choiceValues = c("X", "counts"),
+            selected = "X",
+            inline = TRUE
+          ),
+          "Sample QC plots: show the normalized (and batch-corrected) data used for the analysis, or the raw uploaded counts.",
+          placement = "bottom"
         )
       )
     )


### PR DESCRIPTION
Sample QC read `pgx$counts` in all five plots, so it always showed the raw
upload — normalization and batch correction were invisible on the one tab
where you go to check them.

New **Sample QC data: normalized | raw** toggle in the settings panel,
defaulting to normalized (`pgx$X`, linearized so totals and proportions
still mean something).