### PR TITLE
Chores/update ai models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ LazyData: true
 Suggests:
     commonmark,
     omicsagentovi,
-    omicsai (>= 0.3.2),
+    omicsai (>= 0.3.8),
     omicspgx,
     omicspgxmcp,
     omicsplots,

--- a/components/app_copilot/R/copilot_restore_controller.R
+++ b/components/app_copilot/R/copilot_restore_controller.R
@@ -239,11 +239,11 @@ copilot_restore_controller <- function(
     previous_agent <- shiny::isolate(agent())
 
     # Capture the user's AI provider + credential closure on the Shiny thread
-    # (never inside the future). BigOmics -> provider "bigomics" + NULL
-    # credentials, which ovi_restore treats exactly as today (env-var path,
-    # openai tier fallback). A BYOK provider re-resolves the saved tier for
-    # that provider and applies the user key.
-    ai_sel   <- .copilot_ai_provider(session)
+    # (never inside the future). .copilot_restore_provider maps the managed
+    # "bigomics" sentinel to ovi's "openai" (env-var path, BigOmics tier
+    # model) and passes a real BYOK provider + key through — so restore
+    # resolves the same provider/model a fresh session for this user would.
+    ai_sel   <- .copilot_restore_provider(session)
     provider <- ai_sel$provider
     cred     <- ai_sel$credentials
 

--- a/components/app_copilot/R/copilot_run_controller.R
+++ b/components/app_copilot/R/copilot_run_controller.R
@@ -33,7 +33,7 @@
 #
 #   - BigOmics (or NULL provider): today's exact behaviour — the tier path only,
 #     no credentials, no model. The managed backend resolves the tier to
-#     gpt-5.4-nano / gpt-5.4-mini via omicsagentovi's own tier table.
+#     deepseek-v4-flash / gpt-5.6-terra via omicsagentovi's own tier table.
 #   - BYOK provider with a per-tier menu model selected: a provider-prefixed
 #     model id (the catalog stores bare ids for BYOK providers) plus the user's
 #     credential closure. Agent infers the provider from the model prefix.

--- a/components/app_copilot/R/copilot_run_controller.R
+++ b/components/app_copilot/R/copilot_run_controller.R
@@ -28,6 +28,29 @@
   )
 }
 
+# Resolve the provider/credentials pair to hand to omicsagentovi::ovi_restore().
+#
+# `ovi_restore()` takes only `provider` + `credentials` live (tier + model come
+# from the saved session row), and resolves the model via
+# ovi_resolve_copilot_model(tier, provider). It knows the managed backend as
+# provider "openai" — NOT "bigomics", which is an omicsplayground-only label;
+# passing "bigomics" hits ovi's BYOK catalog branch and errors. So map the
+# managed sentinel to "openai" (dropping any user key), and pass a real BYOK
+# provider through with its key. This mirrors the bigomics-vs-BYOK split in
+# .copilot_agent_build_args(): managed restore resolves the tier's BigOmics
+# model, BYOK restore re-resolves the saved tier against the user's own
+# provider/key — exactly what a fresh session for that user would build now.
+#
+#' @noRd
+.copilot_restore_provider <- function(session) {
+  sel <- .copilot_ai_provider(session)
+  if (identical(sel$provider, "bigomics")) {
+    list(provider = "openai", credentials = NULL)
+  } else {
+    list(provider = sel$provider, credentials = sel$credentials)
+  }
+}
+
 # Build the provider/credentials/model args to splice into omicsagentovi::Agent()
 # for a fresh build at `tier`.
 #

--- a/etc/ai_model_policy.json
+++ b/etc/ai_model_policy.json
@@ -21,7 +21,7 @@
       "menus": {
         "reports": {
           "models": [
-            "openai:gpt-5.4-nano"
+            "openrouter:deepseek/deepseek-v4-flash"
           ]
         },
         "images": {
@@ -30,10 +30,10 @@
           ]
         },
         "copilot_deep": {
-          "models": ["openai:gpt-5.4-mini"]
+          "models": ["openrouter:openai/gpt-5.6-terra"]
         },
         "copilot_balanced": {
-          "models": ["openai:gpt-5.4-nano"]
+          "models": ["openrouter:deepseek/deepseek-v4-flash"]
         }
       }
     },

--- a/etc/ai_model_policy.json
+++ b/etc/ai_model_policy.json
@@ -21,18 +21,12 @@
       "menus": {
         "reports": {
           "models": [
-            "openai:gpt-5.4-nano",
-            "openai:gpt-5.4-mini",
-            "xai:grok-4.3",
-            "groq:openai/gpt-oss-120b",
-            "google:gemini-3-flash-preview",
-            "google:gemini-3.1-flash-lite-preview"
+            "openai:gpt-5.4-nano"
           ]
         },
         "images": {
           "models": [
-            "gemini-3.1-flash-image-preview",
-            "gemini-3-pro-image-preview"
+            "gemini-3.1-flash-image-preview"
           ]
         },
         "copilot_deep": {

--- a/tests/testthat/test-appsettings-ai.R
+++ b/tests/testthat/test-appsettings-ai.R
@@ -173,14 +173,15 @@ test_that("OPG policy can disable a provider and reorder menu defaults", {
   expect_null(make_opt(providers = "openai")$AI_MODELS$mistral)
 })
 
-test_that("BigOmics defaults stay unchanged and model menus remain hidden", {
-  expect_equal(opt$AI_MODELS$bigomics$reports[[1]], "openai:gpt-5.4-nano")
+test_that("BigOmics defaults point at the OpenRouter models and menus remain hidden", {
+  expect_equal(opt$AI_MODELS$bigomics$reports[[1]],
+               "openrouter:deepseek/deepseek-v4-flash")
   expect_equal(opt$AI_MODELS$bigomics$images[[1]],
                "gemini-3.1-flash-image-preview")
   expect_equal(opt$AI_MODELS$bigomics$copilot_deep,
-               "openai:gpt-5.4-mini")
+               "openrouter:openai/gpt-5.6-terra")
   expect_equal(opt$AI_MODELS$bigomics$copilot_balanced,
-               "openai:gpt-5.4-nano")
+               "openrouter:deepseek/deepseek-v4-flash")
 
   ui_source <- readLines(file.path(.repo_dir,
                                    "components/board.user/R/appsettings_ui.R"))

--- a/tests/testthat/test-appsettings-ai.R
+++ b/tests/testthat/test-appsettings-ai.R
@@ -18,6 +18,14 @@ if (!exists("%||%")) {
 setUserOption <- function(session, var, value) session$userData[[var]] <- value
 getUserOption <- function(session, var, value) session$userData[[var]]
 
+## BYOK entitlement gate (mirrors AuthenticationModule_functions.R, which the
+## standalone test env does not source). make_auth() leaves level unset -> ""
+## -> BYOK allowed, so the provider/menu observers run their real code paths.
+ai_byok_allowed <- function(level) {
+  lvl <- level %||% ""
+  identical(lvl, "enterprise") || !nzchar(lvl)
+}
+
 ## Init-time collaborators the module touches but that are irrelevant here.
 dbg                         <- function(...) invisible(NULL)
 user_table_resources_server <- function(...) invisible(NULL)

--- a/tests/testthat/test-appsettings-ai.R
+++ b/tests/testthat/test-appsettings-ai.R
@@ -213,7 +213,8 @@ test_that("changing provider repopulates the four menus from that provider's cat
     args = list(id = "s", auth = make_auth(), pgx = shiny::reactiveValues()), {
       session$setInputs(ai_provider = "openai")
       expect_equal(captured$llm_reports$choices,
-                   c("gpt-5.4-nano", "gpt-5.4-mini",
+                   c("gpt-5.4-nano", "gpt-5.6-sol", "gpt-5.6-terra",
+                     "gpt-5.6-luna", "gpt-5.4-mini",
                      "gpt-4o", "gpt-4o-mini"))
       expect_equal(captured$llm_reports$selected, "gpt-5.4-nano")
       expect_equal(captured$llm_images$choices, c("dall-e-3", "dall-e-2"))
@@ -295,7 +296,8 @@ test_that("Test & load falls back to static catalog choices on empty live result
       session$setInputs(ai_test_load = 1)
 
       expect_equal(captured$llm_reports,
-                   c("gpt-5.4-nano", "gpt-5.4-mini",
+                   c("gpt-5.4-nano", "gpt-5.6-sol", "gpt-5.6-terra",
+                     "gpt-5.6-luna", "gpt-5.4-mini",
                      "gpt-4o", "gpt-4o-mini"))
       expect_equal(captured$llm_images, c("dall-e-3", "dall-e-2"))
       expect_equal(alert$title, "Could not load provider models")

--- a/tests/testthat/test-copilot-restore-controller.R
+++ b/tests/testthat/test-copilot-restore-controller.R
@@ -29,6 +29,24 @@ if (packageVersion("omicsagentovi") < "0.4.0") {
   "../../components/board.copilot/R"
 }
 
+# %||% is normally provided by playbase / app utils but is not on the search
+# path when the copilot sources are loaded standalone here (see CLAUDE.md —
+# fix the test bootstrap, do not redefine the operator in R/).
+if (!exists("%||%")) `%||%` <- function(a, b) if (is.null(a)) b else a
+
+# App-global helpers used by the copilot provider resolver. The real
+# getUserOption/get_ai_credentials read session$userData (see
+# components/app/R/utils/utils.R and components/modules/AiCards.R); mirror
+# that here so the BYOK-provider tests below can steer the resolver by
+# writing session$userData.
+if (!exists("getUserOption")) {
+  getUserOption <- function(session, var, ...) session$userData[[var]]
+}
+if (!exists("get_ai_credentials")) {
+  get_ai_credentials <- function(session) session$userData[["ai_credentials"]]
+}
+if (!exists("copilot_system_prompt")) copilot_system_prompt <- function() ""
+
 source(file.path(.board_dir, "copilot_options.R"),  local = TRUE)
 source(file.path(.board_dir, "copilot_messages.R"), local = TRUE)
 source(file.path(.board_dir, "copilot_logger.R"),   local = TRUE)
@@ -39,6 +57,9 @@ source(file.path(.board_dir, "copilot_pgx_normalize.R"),       local = TRUE)
 # Context-block staging providers (current_dataset, future AI report, etc.)
 # are invoked by .complete_restore after agent reconstruction.
 source(file.path(.board_dir, "copilot_context_blocks.R"),      local = TRUE)
+# Owns .copilot_ai_provider / .copilot_restore_provider — the restore
+# controller reads the user's live provider through these.
+source(file.path(.board_dir, "copilot_run_controller.R"),      local = TRUE)
 source(file.path(.board_dir, "copilot_restore_controller.R"), local = TRUE)
 
 library(omicsagentovi)
@@ -353,7 +374,7 @@ test_that("start() happy path: chat clear + post events pushed, evidence cleared
   fake_evidence <- list(clear = function() { evidence_cleared <<- TRUE })
 
   local_mocked_bindings(
-    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) {
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx, ...) {
       ovi_restore_called <<- TRUE
       make_stub_agent()
     },
@@ -414,7 +435,7 @@ test_that("after task starts with NULL local_pgx: inflight set, status restoring
   agent_set_pgx_called <- FALSE
 
   local_mocked_bindings(
-    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) make_stub_agent(),
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx, ...) make_stub_agent(),
     agent_set_pgx = function(agent, pgx, ...) {
       agent_set_pgx_called <<- TRUE
       agent
@@ -472,7 +493,7 @@ test_that("non-NULL local_pgx triggers the sync fast path: restore completes ins
   agent_set_pgx_called <- FALSE
 
   local_mocked_bindings(
-    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) restored_agent,
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx, ...) restored_agent,
     agent_set_pgx = function(agent, pgx, ...) {
       agent_set_pgx_called <<- TRUE
       agent
@@ -511,6 +532,87 @@ test_that("non-NULL local_pgx triggers the sync fast path: restore completes ins
       expect_identical(shiny::isolate(agent_rv()), restored_agent)
     }
   )
+})
+
+# ===========================================================================
+# Provider resolution — the args handed to ovi_restore must mirror what a
+# fresh session for this user would build (omicsplayground-qkyp). Uses the
+# sync fast path (non-NULL local_pgx) so ovi_restore is actually invoked and
+# its provider/credentials can be captured.
+# ===========================================================================
+
+.run_restore_capturing_provider <- function(user_options) {
+  store          <- make_fake_store()
+  restored_agent <- make_stub_agent()
+  agent_rv       <- shiny::reactiveVal(make_stub_agent())
+  run_status_rv  <- shiny::reactiveVal("idle")
+  inflight_rv    <- shiny::reactiveVal(NULL)
+  chat_event_rv  <- shiny::reactiveVal(NULL)
+  fake_pgx       <- list(name = "ds", X = matrix(1, 2, 2))
+  captured       <- new.env(parent = emptyenv())
+
+  local_mocked_bindings(
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx,
+                           db_name, provider, credentials) {
+      captured$provider    <- provider
+      captured$credentials <- credentials
+      restored_agent
+    },
+    agent_set_pgx = function(agent, pgx, ...) agent,
+    session_transcript = function(agent_session, view = "user") list(),
+    .package = "omicsagentovi"
+  )
+
+  shiny::testServer(
+    function(input, output, session) {
+      for (nm in names(user_options)) session$userData[[nm]] <- user_options[[nm]]
+      ctrl <<- copilot_restore_controller(
+        store            = store,
+        agent            = agent_rv,
+        run_status       = run_status_rv,
+        restore_inflight = inflight_rv,
+        bindings_factory = function() build_run_bindings(
+                             session          = session,
+                             evidence_api     = NULL,
+                             pgx_loaded_event = NULL
+                           ),
+        local_pgx        = shiny::reactive(fake_pgx),
+        data_dir         = tempdir(),
+        evidence         = NULL,
+        chat_event       = chat_event_rv,
+        session          = session
+      )
+    },
+    expr = {
+      ctrl$start("sess-x")
+      session$flushReact()
+    }
+  )
+  captured
+}
+
+test_that("bigomics-managed restore passes provider 'openai' and no credentials", {
+  # A managed session has no ai_provider set -> resolver defaults to
+  # "bigomics", which must be translated to ovi's "openai" sentinel (NOT the
+  # literal "bigomics", which errors in ovi_resolve_copilot_model's catalog
+  # branch). Credentials must be dropped for the managed backend.
+  captured <- .run_restore_capturing_provider(list())
+  expect_equal(captured$provider, "openai")
+  expect_null(captured$credentials)
+})
+
+test_that("BYOK restore passes the user's real provider + credential closure", {
+  # A BYOK user configured anthropic must restore against anthropic (so ovi
+  # resolves the saved tier to an anthropic catalog model), carrying the
+  # user's key closure — never a bigomics/openai default.
+  key_fn <- function() "USER-KEY"
+  captured <- .run_restore_capturing_provider(list(
+    ai_provider    = "anthropic",
+    ai_credentials = key_fn
+  ))
+  expect_equal(captured$provider, "anthropic")
+  expect_identical(captured$credentials, key_fn)
+  expect_equal(captured$credentials(), "USER-KEY")
 })
 
 # ===========================================================================
@@ -570,7 +672,7 @@ test_that("agent_set_pgx throws during injection: restore still completes, agent
   set_pgx_attempted <- FALSE
 
   local_mocked_bindings(
-    ovi_restore = function(session_id, session_dir, bindings, restore_pgx) restored_agent,
+    ovi_restore = function(session_id, session_dir, bindings, restore_pgx, ...) restored_agent,
     agent_set_pgx = function(agent, pgx, ...) {
       set_pgx_attempted <<- TRUE
       stop("agent_set_pgx: simulated failure")


### PR DESCRIPTION
## Description

Swaps BigOmics-managed default AI models from native OpenAI to OpenRouter-hosted models, giving them a safe default reasoning effort, and fixes a real bug uncovered along the way.

**Model changes** (`etc/ai_model_policy.json`, bigomics provider block):
- `reports` / `copilot_balanced`: `openai:gpt-5.4-nano` → `openrouter:deepseek/deepseek-v4-flash`
- `copilot_deep`: `openai:gpt-5.4-mini` → `openrouter:openai/gpt-5.6-terra`
- `images`: unchanged
- Both new models now default to `reasoning_effort="medium"` on the wire — via a registry-level default added in omicsai (bigomics/omicsai#5), scoped away from the native `openai:gpt-5.4/5.5/5.6*` rows that broke in a past incident. No new UI exposure.
- The Copilot runtime doesn't read this JSON's `copilot_*` fields at all (confirmed) — the actual control point is omicsagentovi's own tier table, updated in bigomics/omicsagentovi#2.

**Bug fix**: `copilot_restore_controller.R` was passing the OPG-internal `"bigomics"` sentinel literally into `omicsagentovi::ovi_restore(provider=...)`, which has no such provider — restoring any managed Copilot session would crash. Added `.copilot_restore_provider()` to translate correctly (managed → ovi's `"openai"` sentinel, dropping credentials; BYOK → real provider + credentials passed through unchanged), so restore now resolves whatever provider/model the user currently has configured, matching fresh session construction.

**Dependencies:**
- bigomics/omicsai#5
- bigomics/omicsagentovi#2

This PR's renv already has `omicsai >= 0.3.8` and `omicsagentovi >= 0.5.87` installed and the `DESCRIPTION` floor bumped accordingly; once the sibling PRs are merged/released, no further app-side change is needed.
