### PR TITLE
PCA: select components PC1-PC5, biplot arrows, phenotype directions and variance plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Suggests:
     omicspgx,
     omicspgxmcp,
     omicsplots,
+    plotly.repel,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2
@@ -35,6 +36,7 @@ Imports:
     forcats,
     future,
     ggforce,
+    ggrepel,
     ggVennDiagram,
     heatmaply,
     htmltools,

--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -261,7 +261,7 @@ clustering_plot_clustpca_server <- function(id,
           plt <- plt %>% plotly::add_text(
             x = pos[, 1], y = pos[, 2], text = rownames(df),
             textposition = "top center",
-            textfont = list(size = 12 * cex, color = "grey30"),
+            textfont = list(size = 12 * cex, color = "#4D4D4D"),
             showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
           )
         }
@@ -283,14 +283,14 @@ clustering_plot_clustpca_server <- function(id,
               x = as.vector(rbind(0, aa$x, NA)),
               y = as.vector(rbind(0, aa$y, NA)),
               type = "scatter", mode = "lines",
-              line = list(color = "grey30", width = 1.8),
+              line = list(color = "#4D4D4D", width = 1.8),
               showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
             ) %>%
             plotly::add_trace(
               x = aa$x, y = aa$y,
               type = "scatter", mode = "markers",
               marker = list(
-                symbol = "arrow", size = 12, color = "grey30",
+                symbol = "arrow", size = 12, color = "#4D4D4D",
                 angle = atan2(aa$x, aa$y) * 180 / pi
               ),
               text = aa$text, hoverinfo = "text",
@@ -306,7 +306,7 @@ clustering_plot_clustpca_server <- function(id,
           plt <- plt %>% plotly::add_annotations(
             x = aa$lx, y = aa$ly, text = aa$text,
             showarrow = FALSE,
-            font = list(color = "grey20", size = 13 * cex),
+            font = list(color = "#333333", size = 13 * cex),
             bgcolor = "rgba(255,255,255,0.65)", borderpad = 2
           )
           if (isTRUE(input$pca_repel) && requireNamespace("plotly.repel", quietly = TRUE)) {
@@ -315,8 +315,8 @@ clustering_plot_clustpca_server <- function(id,
               data = data.frame(x = aa$x, y = aa$y, text = aa$text),
               x = ~x, y = ~y, text = ~text,
               box_padding = 0.4, point_padding = 0.3, max_overlaps = 20,
-              font = list(color = "grey20", size = 13 * cex),
-              segment = list(color = "grey60", width = 1)
+              font = list(color = "#333333", size = 13 * cex),
+              segment = list(color = "#999999", width = 1)
             )
           }
         }
@@ -444,7 +444,7 @@ clustering_plot_clustpca_server <- function(id,
         plotly::add_trace(
           x = ~pc, y = ~cumulative, name = "cumulative",
           type = "scatter", mode = "lines+markers",
-          line = list(color = "grey40"), marker = list(color = "grey40"),
+          line = list(color = "#666666"), marker = list(color = "#666666"),
           hovertemplate = "up to %{x}: %{y}%<extra></extra>"
         ) %>%
         plotly::layout(

--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -73,6 +73,8 @@ clustering_plot_clustpca_server <- function(id,
                                             pgx,
                                             selected_samples,
                                             clustmethod,
+                                            pca_components,
+                                            pca_dims,
                                             watermark = FALSE,
                                             parent) {
   moduleServer(id, function(input, output, session) {
@@ -90,7 +92,12 @@ clustering_plot_clustpca_server <- function(id,
 
     plot_data <- shiny::reactive({
       samples <- selected_samples()
-      cluster.pos <- pgx$cluster$pos
+      ## drop pca2d.varexp and friends: only the position matrices are tabular
+      cluster.pos <- Filter(is.matrix, pgx$cluster$pos)
+      ## the board recomputes PCA on the fly, so export those instead of the
+      ## stored PC1/PC2 only
+      cluster.pos <- cluster.pos[grep("^pca", names(cluster.pos), invert = TRUE)]
+      cluster.pos$pca <- pca_components()$pos
       for (m in names(cluster.pos)) {
         colnames(cluster.pos[[m]]) <- paste0(m, ".", colnames(cluster.pos[[m]]))
       }
@@ -101,7 +108,7 @@ clustering_plot_clustpca_server <- function(id,
     })
 
 
-    create_plot <- function(pgx, pos, pca2d.varexp, method, colvar, shapevar, label, cex, palette = "muted_light", custom_colors = NULL) {
+    create_plot <- function(pgx, pos, xlab, ylab, method, colvar, shapevar, label, cex, palette = "muted_light", custom_colors = NULL) {
       do3d <- (ncol(pos) == 3)
       sel <- rownames(pos)
       df <- cbind(pos, pgx$samples[sel, , drop = FALSE])
@@ -206,17 +213,10 @@ clustering_plot_clustpca_server <- function(id,
             showarrow = FALSE
           )
 
-        if (method == "pca") {
-          plt <- plt %>% plotly::layout(
-            xaxis = list(title = paste0(toupper(method), "1 (", pca2d.varexp[1], "%)")),
-            yaxis = list(title = paste0(toupper(method), "2 (", pca2d.varexp[2], "%)"))
-          )
-        } else {
-          plt <- plt %>% plotly::layout(
-            xaxis = list(title = paste0(toupper(method), "1")),
-            yaxis = list(title = paste0(toupper(method), "2"))
-          )
-        }
+        plt <- plt %>% plotly::layout(
+          xaxis = list(title = xlab),
+          yaxis = list(title = ylab)
+        )
 
         ## add group/cluster annotation labels
         if (label == "inside") {
@@ -252,7 +252,7 @@ clustering_plot_clustpca_server <- function(id,
       return(plt)
     }
 
-    create_ggplot <- function(pgx, pos, pca2d.varexp, method, colvar, label, cex, palette = "muted_light", custom_colors = NULL) {
+    create_ggplot <- function(pgx, pos, xlab, ylab, method, colvar, label, cex, palette = "muted_light", custom_colors = NULL) {
       sel <- rownames(pos)
       df <- cbind(pos, pgx$samples[sel, , drop = FALSE])
 
@@ -271,21 +271,13 @@ clustering_plot_clustpca_server <- function(id,
 
       showlabels <- (label %in% c("group", "inside"))
 
-      if (method == "pca") {
-        xl <- paste0(toupper(method), "1 (", pca2d.varexp[1], "%)")
-        yl <- paste0(toupper(method), "2 (", pca2d.varexp[2], "%)")
-      } else {
-        xl <- paste0(toupper(method), "1")
-        yl <- paste0(toupper(method), "2")
-      }
-
       p <- playbase::pgx.scatterPlotXY.GGPLOT(
         pos,
         var = colvar_fct,
         col = clrs,
         cex = cex,
-        xlab = xl,
-        ylab = yl,
+        xlab = xlab,
+        ylab = ylab,
         title = toupper(method),
         cex.title = 1.2,
         cex.clust = 1.1,
@@ -293,6 +285,22 @@ clustering_plot_clustpca_server <- function(id,
         legend = !(label %in% c("<none>", "group", "sample"))
       )
       p
+    }
+
+    ## Positions and axis labels for one layout method. PCA is recomputed on
+    ## the fly (pgx only stores PC1-PC3) so any pair of PC1-PC5 can be plotted.
+    method_pos <- function(m, samples, do3d = FALSE) {
+      if (m == "pca") {
+        pc <- pca_components()
+        k <- if (do3d) seq_len(min(3, ncol(pc$pos))) else pca_dims()
+        pos <- pc$pos[samples, k, drop = FALSE]
+        labs <- paste0("PC", k, " (", pc$varexp[k], "%)")
+      } else {
+        m1 <- paste0(m, ifelse(do3d, "3d", "2d"))
+        pos <- pgx$cluster$pos[[m1]][samples, , drop = FALSE]
+        labs <- paste0(toupper(m), seq_len(ncol(pos)))
+      }
+      list(pos = pos, xlab = labs[1], ylab = labs[2])
     }
 
     create_plotlist <- function() {
@@ -327,15 +335,12 @@ clustering_plot_clustpca_server <- function(id,
       plist <- list()
       for (i in 1:length(methods)) {
         m <- methods[i]
-        m1 <- paste0(m, "2d")
-        if (do3d) m1 <- paste0(m, "3d")
-        pos <- pgx$cluster$pos[[m1]]
-        pos <- pos[samples, ]
-        pca2d.varexp <- pgx$cluster$pos$pca2d.varexp
+        mp <- method_pos(m, samples, do3d = do3d)
         plist[[i]] <- create_plot(
           pgx = pgx,
-          pos = pos,
-          pca2d.varexp = pca2d.varexp,
+          pos = mp$pos,
+          xlab = mp$xlab,
+          ylab = mp$ylab,
           method = m,
           colvar = colvar,
           shapevar = shapevar,
@@ -377,15 +382,13 @@ clustering_plot_clustpca_server <- function(id,
       plts <- list()
       for (i in seq_along(methods)) {
         m <- methods[i]
-        m1 <- paste0(m, "2d")
-        pos <- pgx$cluster$pos[[m1]]
-        pos <- pos[samples, ]
-        pca2d.varexp <- pgx$cluster$pos$pca2d.varexp
+        mp <- method_pos(m, samples)
 
         p <- create_ggplot(
           pgx = pgx,
-          pos = pos,
-          pca2d.varexp = pca2d.varexp,
+          pos = mp$pos,
+          xlab = mp$xlab,
+          ylab = mp$ylab,
           method = m,
           colvar = colvar,
           label = label,

--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -35,6 +35,36 @@ clustering_plot_clustpca_ui <- function(
       ),
       "Place group labels as legend at the bottom or in plot as group or sample labels."
     ),
+    ## arrows only make sense for PCA: loadings and phenotype correlations are
+    ## defined against ordered components, which t-SNE/UMAP do not have
+    shiny::conditionalPanel(
+      "input.hm_clustmethod == 'pca'",
+      ns = parent,
+      withTooltip(
+        shiny::selectInput(ns("pca_arrows"), "Arrows:",
+          choices = c("<none>", "features", "phenotypes"), width = "100%"
+        ),
+        "Overlay a biplot: arrows for the top feature loadings, or for the direction in which each phenotype increases."
+      ),
+      shiny::conditionalPanel(
+        "input.pca_arrows != '<none>'",
+        ns = ns,
+        withTooltip(
+          shiny::numericInput(ns("pca_numarrows"), "Number of arrows:",
+            value = 3, min = 1, max = 50, step = 1, width = "100%"
+          ),
+          "How many arrows to label and draw, ranked by length. Lower numbers keep the plot readable."
+        ),
+        withTooltip(
+          shiny::checkboxInput(ns("pca_repel"), "repel labels", value = TRUE),
+          "Move overlapping arrow labels apart. Switch off to pin each label to its own arrow tip."
+        )
+      ),
+      withTooltip(
+        shiny::checkboxInput(ns("pca_varplot"), "variance explained"),
+        "Show how much variance each component explains, instead of the samples."
+      )
+    ),
     withTooltip(
       shiny::checkboxInput(ns("all_clustmethods"), "show all methods"),
       "Show an overview of all dimensionality reduction methods."
@@ -75,6 +105,7 @@ clustering_plot_clustpca_server <- function(id,
                                             clustmethod,
                                             pca_components,
                                             pca_dims,
+                                            labeltype = shiny::reactive("feature"),
                                             watermark = FALSE,
                                             parent) {
   moduleServer(id, function(input, output, session) {
@@ -108,7 +139,23 @@ clustering_plot_clustpca_server <- function(id,
     })
 
 
-    create_plot <- function(pgx, pos, xlab, ylab, method, colvar, shapevar, label, cex, palette = "muted_light", custom_colors = NULL) {
+    ## arrows scaled to fill the score cloud (loadings and correlations live on
+    ## a much smaller scale than the scores), with the label just past the tip
+    scale_arrows <- function(arrows, pos) {
+      s <- 0.65 * max(abs(pos)) / max(abs(arrows))
+      ax <- arrows[, 1] * s
+      ay <- arrows[, 2] * s
+      r <- sqrt(ax^2 + ay^2)
+      r[r == 0] <- 1
+      nudge <- 0.05 * max(abs(pos))
+      list(
+        x = ax, y = ay,
+        lx = ax + nudge * ax / r, ly = ay + nudge * ay / r,
+        text = rownames(arrows)
+      )
+    }
+
+    create_plot <- function(pgx, pos, xlab, ylab, method, colvar, shapevar, label, cex, palette = "muted_light", custom_colors = NULL, arrows = NULL) {
       do3d <- (ncol(pos) == 3)
       sel <- rownames(pos)
       df <- cbind(pos, pgx$samples[sel, , drop = FALSE])
@@ -218,6 +265,54 @@ clustering_plot_clustpca_server <- function(id,
           yaxis = list(title = ylab)
         )
 
+        if (!is.null(arrows) && nrow(arrows) && max(abs(arrows)) > 0) {
+          aa <- scale_arrows(arrows, pos)
+          ## Arrows are drawn as traces, NOT as annotations: plotly.repel takes
+          ## ownership of layout.annotations at render time (plotly-repel.js
+          ## relayouts the whole array), which wipes anything annotation-drawn.
+          ## Shafts are one NA-separated line trace, heads are markers rotated
+          ## along each arrow (angle is the bearing, clockwise from up).
+          plt <- plt %>%
+            plotly::add_trace(
+              x = as.vector(rbind(0, aa$x, NA)),
+              y = as.vector(rbind(0, aa$y, NA)),
+              type = "scatter", mode = "lines",
+              line = list(color = "grey30", width = 1.8),
+              showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
+            ) %>%
+            plotly::add_trace(
+              x = aa$x, y = aa$y,
+              type = "scatter", mode = "markers",
+              marker = list(
+                symbol = "arrow", size = 12, color = "grey30",
+                angle = atan2(aa$x, aa$y) * 180 / pi
+              ),
+              text = aa$text, hoverinfo = "text",
+              showlegend = FALSE, inherit = FALSE
+            )
+          ## Arrow tips bunch up, so fixed-offset labels collide. plotly.repel
+          ## places them in the browser and re-solves on zoom/pan. Off by
+          ## request, or when the optional package is not installed: labels then
+          ## sit nudged just past their own tip.
+          if (isTRUE(input$pca_repel) && requireNamespace("plotly.repel", quietly = TRUE)) {
+            plt <- plotly.repel::add_text_repel(
+              plt,
+              data = data.frame(x = aa$x, y = aa$y, text = aa$text),
+              x = ~x, y = ~y, text = ~text,
+              box_padding = 0.4, point_padding = 0.3, max_overlaps = 20,
+              font = list(color = "grey20", size = 13 * cex),
+              segment = list(color = "grey60", width = 1)
+            )
+          } else {
+            plt <- plt %>% plotly::add_annotations(
+              x = aa$lx, y = aa$ly, text = aa$text,
+              showarrow = FALSE,
+              font = list(color = "grey20", size = 13 * cex),
+              bgcolor = "rgba(255,255,255,0.65)", borderpad = 2
+            )
+          }
+        }
+
         ## add group/cluster annotation labels
         if (label == "inside") {
           plt <- plt %>%
@@ -252,7 +347,7 @@ clustering_plot_clustpca_server <- function(id,
       return(plt)
     }
 
-    create_ggplot <- function(pgx, pos, xlab, ylab, method, colvar, label, cex, palette = "muted_light", custom_colors = NULL) {
+    create_ggplot <- function(pgx, pos, xlab, ylab, method, colvar, label, cex, palette = "muted_light", custom_colors = NULL, arrows = NULL) {
       sel <- rownames(pos)
       df <- cbind(pos, pgx$samples[sel, , drop = FALSE])
 
@@ -284,23 +379,133 @@ clustering_plot_clustpca_server <- function(id,
         label.clusters = showlabels,
         legend = !(label %in% c("<none>", "group", "sample"))
       )
+
+      if (!is.null(arrows) && nrow(arrows) && max(abs(arrows)) > 0) {
+        aa <- scale_arrows(arrows, pos)
+        df.a <- data.frame(x = aa$x, y = aa$y, lx = aa$lx, ly = aa$ly, text = aa$text)
+        p <- p +
+          ggplot2::geom_segment(
+            data = df.a,
+            ggplot2::aes(x = 0, y = 0, xend = x, yend = y),
+            arrow = ggplot2::arrow(length = ggplot2::unit(0.18, "cm"), type = "closed"),
+            colour = "grey30", linewidth = 0.5, inherit.aes = FALSE
+          ) +
+          if (isTRUE(input$pca_repel)) {
+            ggrepel::geom_text_repel(
+              data = df.a,
+              ggplot2::aes(x = x, y = y, label = text),
+              colour = "grey20", size = 3 * cex, inherit.aes = FALSE,
+              box.padding = 0.4, point.padding = 0.3,
+              segment.colour = "grey60", max.overlaps = 20
+            )
+          } else {
+            ggplot2::geom_text(
+              data = df.a,
+              ggplot2::aes(x = lx, y = ly, label = text),
+              colour = "grey20", size = 3 * cex, inherit.aes = FALSE
+            )
+          }
+      }
       p
+    }
+
+    ## Scree data: percentage of variance per component plus its running total.
+    ## Both series are percentages, so they share one axis. The percentages come
+    ## from pca_components() and are relative to the total variance, so they do
+    ## not sum to 100 over the five components we compute -- that is correct.
+    varexp_data <- function() {
+      v <- pca_components()$varexp
+      data.frame(
+        pc = factor(paste0("PC", seq_along(v)), levels = paste0("PC", seq_along(v))),
+        varexp = as.numeric(v),
+        cumulative = cumsum(as.numeric(v))
+      )
+    }
+
+    create_varplot <- function(palette = "muted_light") {
+      df <- varexp_data()
+      clr <- omics_pal_d(palette = palette)(8)[1]
+      plotly::plot_ly(df) %>%
+        plotly::add_bars(
+          x = ~pc, y = ~varexp, name = "per component",
+          marker = list(color = clr),
+          text = ~ paste0(varexp, "%"), textposition = "outside",
+          hovertemplate = "%{x}: %{y}%<extra></extra>"
+        ) %>%
+        plotly::add_trace(
+          x = ~pc, y = ~cumulative, name = "cumulative",
+          type = "scatter", mode = "lines+markers",
+          line = list(color = "grey40"), marker = list(color = "grey40"),
+          hovertemplate = "up to %{x}: %{y}%<extra></extra>"
+        ) %>%
+        plotly::layout(
+          xaxis = list(title = ""),
+          yaxis = list(title = "variance explained (%)", rangemode = "tozero"),
+          showlegend = FALSE
+        )
+    }
+
+    create_gg_varplot <- function(palette = "muted_light") {
+      df <- varexp_data()
+      clr <- omics_pal_d(palette = palette)(8)[1]
+      ggplot2::ggplot(df, ggplot2::aes(x = pc)) +
+        ggplot2::geom_col(ggplot2::aes(y = varexp), fill = clr) +
+        ggplot2::geom_text(
+          ggplot2::aes(y = varexp, label = paste0(varexp, "%")),
+          vjust = -0.5, size = 3
+        ) +
+        ggplot2::geom_line(ggplot2::aes(y = cumulative, group = 1), colour = "grey40") +
+        ggplot2::geom_point(ggplot2::aes(y = cumulative), colour = "grey40") +
+        ggplot2::labs(x = NULL, y = "variance explained (%)") +
+        ggplot2::expand_limits(y = 0)
+    }
+
+    ## Biplot arrow endpoints on the two selected components, in loading or
+    ## correlation units. Ranked by length and cut to the top N; the caller
+    ## scales them to the score cloud.
+    arrow_ends <- function(pc, k) {
+      mode <- input$pca_arrows
+      if (is.null(mode) || mode == "<none>") {
+        return(NULL)
+      }
+      A <- if (mode == "features") pc$loadings else pc$pheno.cor
+      if (is.null(A) || max(k) > ncol(A)) {
+        return(NULL)
+      }
+      A <- A[stats::complete.cases(A[, k, drop = FALSE]), k, drop = FALSE]
+      if (!nrow(A)) {
+        return(NULL)
+      }
+      ## free-text numeric: empty or nonsense while typing must not blank the plot
+      n <- suppressWarnings(as.integer(input$pca_numarrows))
+      if (length(n) != 1 || is.na(n)) n <- 3
+      n <- max(1, n)
+      A <- A[head(order(-(A[, 1]^2 + A[, 2]^2)), n), , drop = FALSE]
+      if (mode == "features") {
+        rownames(A) <- playbase::probe2symbol(
+          rownames(A), pgx$genes, labeltype(),
+          fill_na = TRUE
+        )
+      }
+      A
     }
 
     ## Positions and axis labels for one layout method. PCA is recomputed on
     ## the fly (pgx only stores PC1-PC3) so any pair of PC1-PC5 can be plotted.
     method_pos <- function(m, samples, do3d = FALSE) {
+      arrows <- NULL
       if (m == "pca") {
         pc <- pca_components()
         k <- if (do3d) seq_len(min(3, ncol(pc$pos))) else pca_dims()
         pos <- pc$pos[samples, k, drop = FALSE]
         labs <- paste0("PC", k, " (", pc$varexp[k], "%)")
+        if (!do3d) arrows <- arrow_ends(pc, k)
       } else {
         m1 <- paste0(m, ifelse(do3d, "3d", "2d"))
         pos <- pgx$cluster$pos[[m1]][samples, , drop = FALSE]
         labs <- paste0(toupper(m), seq_len(ncol(pos)))
       }
-      list(pos = pos, xlab = labs[1], ylab = labs[2])
+      list(pos = pos, xlab = labs[1], ylab = labs[2], arrows = arrows)
     }
 
     create_plotlist <- function() {
@@ -347,7 +552,8 @@ clustering_plot_clustpca_server <- function(id,
           label = label,
           cex = ifelse(length(methods) > 1, 0.6, 1),
           palette = palette,
-          custom_colors = custom_colors
+          custom_colors = custom_colors,
+          arrows = mp$arrows
         )
       }
       plist
@@ -394,7 +600,8 @@ clustering_plot_clustpca_server <- function(id,
           label = label,
           cex = ifelse(length(methods) > 1, 0.6, 1),
           palette = palette,
-          custom_colors = custom_colors
+          custom_colors = custom_colors,
+          arrows = mp$arrows
         )
         p <- apply_ggprism_theme(p, gp)
         p <- apply_editor_theme(p, input)
@@ -406,6 +613,19 @@ clustering_plot_clustpca_server <- function(id,
     plot.RENDER <- reactive({
       gp <- extract_ggprism_params(input)
       do3d <- isTRUE(input$plot3d)
+
+      ## the variance toggle replaces the scatter in this same panel. Check the
+      ## layout too: the checkbox keeps its value while hidden, so switching to
+      ## tsne/umap must not leave a PCA scree plot on screen.
+      if (isTRUE(input$pca_varplot) && clustmethod() == "pca") {
+        palette <- if (!is.null(input$palette)) input$palette else "muted_light"
+        if (palette %in% c("original", "default", "custom", "")) palette <- "muted_light"
+        if (gp$use_ggprism) {
+          p <- apply_editor_theme(apply_ggprism_theme(create_gg_varplot(palette), gp), input)
+          return(ggplot_as_plotly_image(p, width = 6, height = 6))
+        }
+        return(apply_plotly_editor_theme(create_varplot(palette), input))
+      }
 
       if (gp$use_ggprism && !do3d) {
         plts <- create_gg_plotlist()

--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -19,6 +19,19 @@ clustering_plot_clustpca_ui <- function(
   ns <- shiny::NS(id)
 
   plot_opts <- shiny::tagList(
+    ## only PCA has variance to show, so the view selector lives behind the same
+    ## layout gate as the arrows. Its own panel: the three selectors below apply
+    ## to every layout and must stay outside it.
+    shiny::conditionalPanel(
+      "input.hm_clustmethod == 'pca'",
+      ns = parent,
+      withTooltip(
+        shiny::selectInput(ns("plot_type"), "Plot type:",
+          choices = c("samples", "variance explained"), width = "100%"
+        ),
+        "Show the samples in PCA space, or how much variance each component explains."
+      )
+    ),
     withTooltip(
       shiny::selectInput(ns("hmpca.colvar"), "Color/label:", choices = NULL, width = "100%"),
       "Set colors/labels according to a given phenotype."
@@ -40,29 +53,32 @@ clustering_plot_clustpca_ui <- function(
     shiny::conditionalPanel(
       "input.hm_clustmethod == 'pca'",
       ns = parent,
-      withTooltip(
-        shiny::selectInput(ns("pca_arrows"), "Arrows:",
-          choices = c("<none>", "features", "phenotypes"), width = "100%"
-        ),
-        "Overlay a biplot: arrows for the top feature loadings, or for the direction in which each phenotype increases."
-      ),
+      ## nested rather than folded into the condition above: that panel is keyed
+      ## on the parent namespace, plot_type on this one, and a single condition
+      ## string only resolves one of them
       shiny::conditionalPanel(
-        "input.pca_arrows != '<none>'",
+        "input.plot_type == 'samples'",
         ns = ns,
         withTooltip(
-          shiny::numericInput(ns("pca_numarrows"), "Number of arrows:",
-            value = 3, min = 1, max = 50, step = 1, width = "100%"
+          shiny::selectInput(ns("pca_arrows"), "Arrows:",
+            choices = c("<none>", "features", "phenotypes"), width = "100%"
           ),
-          "How many arrows to label and draw, ranked by length. Lower numbers keep the plot readable."
+          "Overlay a biplot: arrows for the top feature loadings, or for the direction in which each phenotype increases."
         ),
-        withTooltip(
-          shiny::checkboxInput(ns("pca_repel"), "repel labels", value = TRUE),
-          "Move overlapping arrow labels apart. Switch off to pin each label to its own arrow tip."
+        shiny::conditionalPanel(
+          "input.pca_arrows != '<none>'",
+          ns = ns,
+          withTooltip(
+            shiny::numericInput(ns("pca_numarrows"), "Number of arrows:",
+              value = 3, min = 1, max = 50, step = 1, width = "100%"
+            ),
+            "How many arrows to label and draw, ranked by length. Lower numbers keep the plot readable."
+          ),
+          withTooltip(
+            shiny::checkboxInput(ns("pca_repel"), "repel labels", value = TRUE),
+            "Move overlapping arrow labels apart. Switch off to pin each label to its own arrow tip."
+          )
         )
-      ),
-      withTooltip(
-        shiny::checkboxInput(ns("pca_varplot"), "variance explained"),
-        "Show how much variance each component explains, instead of the samples."
       )
     ),
     withTooltip(
@@ -261,7 +277,7 @@ clustering_plot_clustpca_server <- function(id,
           plt <- plt %>% plotly::add_text(
             x = pos[, 1], y = pos[, 2], text = rownames(df),
             textposition = "top center",
-            textfont = list(size = 12 * cex, color = "#4D4D4D"),
+            textfont = list(size = 12 * cex, color = unname(omics_colors("super_dark_grey"))),
             showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
           )
         }
@@ -273,6 +289,15 @@ clustering_plot_clustpca_server <- function(id,
 
         if (!is.null(arrows) && nrow(arrows) && max(abs(arrows)) > 0) {
           aa <- scale_arrows(arrows, pos)
+          ## saturated accent: the points run on muted_light (desaturated and
+          ## lightened), so the biplot overlay reads as an overlay and not as
+          ## another group, and its labels stay apart from the grey sample ones
+          arrow.clr <- unname(omics_colors("terra_cotta"))
+          ## derived, not written out: a literal rgba() would go stale the day
+          ## terra_cotta changes
+          arrow.seg <- sprintf(
+            "rgba(%s,0.6)", paste(grDevices::col2rgb(arrow.clr), collapse = ",")
+          )
           ## Arrows are drawn as traces, NOT as annotations: plotly.repel takes
           ## ownership of layout.annotations at render time (plotly-repel.js
           ## relayouts the whole array), which wipes anything annotation-drawn.
@@ -283,14 +308,14 @@ clustering_plot_clustpca_server <- function(id,
               x = as.vector(rbind(0, aa$x, NA)),
               y = as.vector(rbind(0, aa$y, NA)),
               type = "scatter", mode = "lines",
-              line = list(color = "#4D4D4D", width = 1.8),
+              line = list(color = arrow.clr, width = 1.8),
               showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
             ) %>%
             plotly::add_trace(
               x = aa$x, y = aa$y,
               type = "scatter", mode = "markers",
               marker = list(
-                symbol = "arrow", size = 12, color = "#4D4D4D",
+                symbol = "arrow", size = 12, color = arrow.clr,
                 angle = atan2(aa$x, aa$y) * 180 / pi
               ),
               text = aa$text, hoverinfo = "text",
@@ -306,7 +331,7 @@ clustering_plot_clustpca_server <- function(id,
           plt <- plt %>% plotly::add_annotations(
             x = aa$lx, y = aa$ly, text = aa$text,
             showarrow = FALSE,
-            font = list(color = "#333333", size = 13 * cex),
+            font = list(color = arrow.clr, size = 13 * cex),
             bgcolor = "rgba(255,255,255,0.65)", borderpad = 2
           )
           if (isTRUE(input$pca_repel) && requireNamespace("plotly.repel", quietly = TRUE)) {
@@ -315,8 +340,9 @@ clustering_plot_clustpca_server <- function(id,
               data = data.frame(x = aa$x, y = aa$y, text = aa$text),
               x = ~x, y = ~y, text = ~text,
               box_padding = 0.4, point_padding = 0.3, max_overlaps = 20,
-              font = list(color = "#333333", size = 13 * cex),
-              segment = list(color = "#999999", width = 1)
+              font = list(color = arrow.clr, size = 13 * cex),
+              ## leader lines are connective tissue, not data: same hue, faded
+              segment = list(color = arrow.seg, width = 1)
             )
           }
         }
@@ -392,26 +418,28 @@ clustering_plot_clustpca_server <- function(id,
       if (!is.null(arrows) && nrow(arrows) && max(abs(arrows)) > 0) {
         aa <- scale_arrows(arrows, pos)
         df.a <- data.frame(x = aa$x, y = aa$y, lx = aa$lx, ly = aa$ly, text = aa$text)
+        ## same accent as the plotly path, see the note there
+        arrow.clr <- unname(omics_colors("terra_cotta"))
         p <- p +
           ggplot2::geom_segment(
             data = df.a,
             ggplot2::aes(x = 0, y = 0, xend = x, yend = y),
             arrow = ggplot2::arrow(length = ggplot2::unit(0.18, "cm"), type = "closed"),
-            colour = "grey30", linewidth = 0.5, inherit.aes = FALSE
+            colour = arrow.clr, linewidth = 0.5, inherit.aes = FALSE
           ) +
           if (isTRUE(input$pca_repel)) {
             ggrepel::geom_text_repel(
               data = df.a,
               ggplot2::aes(x = x, y = y, label = text),
-              colour = "grey20", size = 3 * cex, inherit.aes = FALSE,
+              colour = arrow.clr, size = 3 * cex, inherit.aes = FALSE,
               box.padding = 0.4, point.padding = 0.3,
-              segment.colour = "grey60", max.overlaps = 20
+              segment.colour = arrow.clr, segment.alpha = 0.6, max.overlaps = 20
             )
           } else {
             ggplot2::geom_text(
               data = df.a,
               ggplot2::aes(x = lx, y = ly, label = text),
-              colour = "grey20", size = 3 * cex, inherit.aes = FALSE
+              colour = arrow.clr, size = 3 * cex, inherit.aes = FALSE
             )
           }
       }
@@ -628,10 +656,10 @@ clustering_plot_clustpca_server <- function(id,
       gp <- extract_ggprism_params(input)
       do3d <- isTRUE(input$plot3d)
 
-      ## the variance toggle replaces the scatter in this same panel. Check the
-      ## layout too: the checkbox keeps its value while hidden, so switching to
+      ## the variance view replaces the scatter in this same panel. Check the
+      ## layout too: the selector keeps its value while hidden, so switching to
       ## tsne/umap must not leave a PCA scree plot on screen.
-      if (isTRUE(input$pca_varplot) && clustmethod() == "pca") {
+      if (identical(input$plot_type, "variance explained") && clustmethod() == "pca") {
         palette <- if (!is.null(input$palette)) input$palette else "muted_light"
         if (palette %in% c("original", "default", "custom", "")) palette <- "muted_light"
         if (gp$use_ggprism) {

--- a/components/board.clustering/R/clustering_plot_clusterpca.R
+++ b/components/board.clustering/R/clustering_plot_clusterpca.R
@@ -252,13 +252,19 @@ clustering_plot_clustpca_server <- function(id,
             symbol = shapevar,
             symbols = symbols,
             text = tt.info
-          ) %>%
-          plotly::add_annotations(
-            x = pos[, 1],
-            y = pos[, 2],
-            text = ann.text,
-            showarrow = FALSE
           )
+
+        ## Sample labels go in a text TRACE, not annotations: plotly.repel
+        ## replaces the whole annotation array in the browser, which would
+        ## silently erase them whenever arrow labels are being repelled.
+        if (label.samples) {
+          plt <- plt %>% plotly::add_text(
+            x = pos[, 1], y = pos[, 2], text = rownames(df),
+            textposition = "top center",
+            textfont = list(size = 12 * cex, color = "grey30"),
+            showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
+          )
+        }
 
         plt <- plt %>% plotly::layout(
           xaxis = list(title = xlab),
@@ -290,10 +296,19 @@ clustering_plot_clustpca_server <- function(id,
               text = aa$text, hoverinfo = "text",
               showlegend = FALSE, inherit = FALSE
             )
-          ## Arrow tips bunch up, so fixed-offset labels collide. plotly.repel
-          ## places them in the browser and re-solves on zoom/pan. Off by
-          ## request, or when the optional package is not installed: labels then
-          ## sit nudged just past their own tip.
+          ## Labels are ALWAYS drawn as annotations, nudged just past their own
+          ## tip. plotly.repel is then layered on top when asked for: its JS
+          ## relayouts the whole annotation array in the browser, so on screen
+          ## the repelled labels REPLACE these rather than doubling up.
+          ## Wherever that JS does not run -- kaleido image export, or
+          ## plotly::subplot() stripping the render hook in "show all methods"
+          ## -- the annotations survive, so labels are never silently lost.
+          plt <- plt %>% plotly::add_annotations(
+            x = aa$lx, y = aa$ly, text = aa$text,
+            showarrow = FALSE,
+            font = list(color = "grey20", size = 13 * cex),
+            bgcolor = "rgba(255,255,255,0.65)", borderpad = 2
+          )
           if (isTRUE(input$pca_repel) && requireNamespace("plotly.repel", quietly = TRUE)) {
             plt <- plotly.repel::add_text_repel(
               plt,
@@ -302,13 +317,6 @@ clustering_plot_clustpca_server <- function(id,
               box_padding = 0.4, point_padding = 0.3, max_overlaps = 20,
               font = list(color = "grey20", size = 13 * cex),
               segment = list(color = "grey60", width = 1)
-            )
-          } else {
-            plt <- plt %>% plotly::add_annotations(
-              x = aa$lx, y = aa$ly, text = aa$text,
-              showarrow = FALSE,
-              font = list(color = "grey20", size = 13 * cex),
-              bgcolor = "rgba(255,255,255,0.65)", borderpad = 2
             )
           }
         }
@@ -326,12 +334,13 @@ clustering_plot_clustpca_server <- function(id,
             cex2 <- 1
             if (length(grp.pos) > 20) cex2 <- 0.8
             if (length(grp.pos) > 50) cex2 <- 0.6
-            plt <- plt %>% plotly::add_annotations(
+            ## text trace, not annotations: see the sample-label note above
+            plt <- plt %>% plotly::add_text(
               x = grp.pos[, 1],
               y = grp.pos[, 2],
               text = paste0("<b>", rownames(grp.pos), "</b>"),
-              font = list(size = 24 * cex2 * cex, color = "#555"),
-              showarrow = FALSE
+              textfont = list(size = 24 * cex2 * cex, color = "#555"),
+              showlegend = FALSE, hoverinfo = "skip", inherit = FALSE
             )
           }
           plt <- plt %>%
@@ -479,13 +488,14 @@ clustering_plot_clustpca_server <- function(id,
       ## free-text numeric: empty or nonsense while typing must not blank the plot
       n <- suppressWarnings(as.integer(input$pca_numarrows))
       if (length(n) != 1 || is.na(n)) n <- 3
-      n <- max(1, n)
+      n <- min(max(1, n), 50) ## the UI max is advisory: typed values bypass it
       A <- A[head(order(-(A[, 1]^2 + A[, 2]^2)), n), , drop = FALSE]
       if (mode == "features") {
-        rownames(A) <- playbase::probe2symbol(
-          rownames(A), pgx$genes, labeltype(),
-          fill_na = TRUE
-        )
+        ## probe2symbol returns NULL when the requested label column is absent
+        ## (reachable while labeltype still holds the previous dataset's
+        ## choice). Blanking the rownames would blank the labels downstream.
+        sym <- playbase::probe2symbol(rownames(A), pgx$genes, labeltype(), fill_na = TRUE)
+        if (length(sym) == nrow(A)) rownames(A) <- sym
       }
       A
     }
@@ -525,7 +535,9 @@ clustering_plot_clustpca_server <- function(id,
       methods <- clustmethod()
       if (input$all_clustmethods) {
         cluster.names <- names(pgx$cluster$pos)
-        methods <- sub("2d", "", grep("2d", cluster.names, value = TRUE))
+        ## anchored: pgx$cluster$pos also holds pca2d.varexp, which an
+        ## unanchored match turns into a bogus "pca.varexp" method
+        methods <- sub("2d$", "", grep("2d$", cluster.names, value = TRUE))
       }
       do3d <- (input$plot3d)
       multiplot <- length(methods) > 1
@@ -574,7 +586,9 @@ clustering_plot_clustpca_server <- function(id,
       methods <- clustmethod()
       if (input$all_clustmethods) {
         cluster.names <- names(pgx$cluster$pos)
-        methods <- sub("2d", "", grep("2d", cluster.names, value = TRUE))
+        ## anchored: pgx$cluster$pos also holds pca2d.varexp, which an
+        ## unanchored match turns into a bogus "pca.varexp" method
+        methods <- sub("2d$", "", grep("2d$", cluster.names, value = TRUE))
       }
 
       groups <- sort(unique(as.character(pgx$samples[samples, colvar])))

--- a/components/board.clustering/R/clustering_plot_phenoplot.R
+++ b/components/board.clustering/R/clustering_plot_phenoplot.R
@@ -45,6 +45,8 @@ clustering_plot_phenoplot_server <- function(id,
                                              selected_phenotypes,
                                              clustmethod,
                                              selected_samples,
+                                             pca_components,
+                                             pca_dims,
                                              watermark = FALSE) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
@@ -86,9 +88,13 @@ clustering_plot_phenoplot_server <- function(id,
       shiny::req(pgx$Y)
       Y <- pgx$Y
 
-      ## get t-SNE positions
-      clustmethod1 <- paste0(clustmethod(), "2d")
-      pos <- pgx$cluster$pos[[clustmethod1]]
+      ## get layout positions. PCA is recomputed on the fly so that the
+      ## selected components match the dimensionality reduction plot.
+      if (clustmethod() == "pca") {
+        pos <- pca_components()$pos[, pca_dims(), drop = FALSE]
+      } else {
+        pos <- pgx$cluster$pos[[paste0(clustmethod(), "2d")]]
+      }
       colnames(pos) <- c("x", "y")
       jj <- selected_samples()
       kk <- selected_phenotypes()

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -17,6 +17,21 @@
 ##' too. Upgrade path: export pgx.pcaComponents() from playbase, have
 ##' pgx.clusterMatrix() delegate to it, and delete this copy.
 ##'
+##' How many components pgx.pcaComponents() can return for a matrix.
+##'
+##' Derived from the dimensions alone, so the axis selectors can be populated
+##' without running the decomposition. Keep in step with the npc capping in
+##' pgx.pcaComponents(), or the selectors will offer components that do not
+##' exist.
+##'
+##' @param X expression matrix (features x samples)
+##' @param npc maximum number of components wanted
+##' @return integer number of components actually available
+pgx.pcaMaxComponents <- function(X, npc = 5) {
+  max(1, min(npc, ncol(X) - 1, nrow(X) - 1))
+}
+
+
 ##' @param X expression matrix (features x samples)
 ##' @param Y sample annotation; when given, phenotype levels are one-hot
 ##'   encoded and correlated with each component for the direction arrows
@@ -25,6 +40,14 @@
 ##' @return list(pos = samples x npc scores, varexp = percentage per component,
 ##'   loadings = features x npc, pheno.cor = phenotype levels x npc or NULL)
 pgx.pcaComponents <- function(X, Y = NULL, npc = 5, reduce.sd = 1000) {
+  ## Inf/-Inf survive an is.na() check but turn the row into NaN once centered,
+  ## which leaves an all-NaN component and breaks the sign pinning below.
+  X[!is.finite(X)] <- NA
+  ## Reduce BEFORE imputing: imputing the full matrix to then discard all but
+  ## the top reduce.sd rows costs seconds on a large NA-heavy dataset.
+  if (nrow(X) > reduce.sd) {
+    X <- X[head(order(-matrixStats::rowSds(X, na.rm = TRUE)), reduce.sd), , drop = FALSE]
+  }
   if (any(is.na(X))) {
     if (playbase::is.multiomics(rownames(X))) {
       X <- playbase::imputeMissing.mox(X, method = "SVD2")
@@ -32,15 +55,19 @@ pgx.pcaComponents <- function(X, Y = NULL, npc = 5, reduce.sd = 1000) {
       X <- playbase::imputeMissing(X, method = "SVD2")
     }
   }
-  if (nrow(X) > reduce.sd) {
-    X <- X[head(order(-matrixStats::rowSds(X, na.rm = TRUE)), reduce.sd), , drop = FALSE]
-  }
   X <- X - rowMeans(X, na.rm = TRUE)
-  npc <- max(1, min(npc, ncol(X) - 1, nrow(X) - 1))
+  npc <- pgx.pcaMaxComponents(X, npc)
 
   ## ponytail: irlba is unstable when npc approaches min(dim), and base svd is
-  ## exact and cheap at that size anyway
-  sv <- if (min(dim(X)) <= npc + 2) svd(X) else irlba::irlba(X, nv = npc)
+  ## exact and cheap at that size anyway. irlba also throws outright on a
+  ## degenerate (near null space) matrix, where svd still returns -- playbase
+  ## dodges that with random jitter, which we cannot use without losing
+  ## reproducibility, so fall back to the exact decomposition instead.
+  sv <- if (min(dim(X)) <= npc + 2) {
+    svd(X)
+  } else {
+    tryCatch(irlba::irlba(X, nv = npc), error = function(e) svd(X))
+  }
 
   pos <- sv$v[, seq_len(npc), drop = FALSE]
   loadings <- sv$u[, seq_len(npc), drop = FALSE]
@@ -181,8 +208,12 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
           choices = clustmethods, sel = selmethod
         )
 
-        ## principal components available for the axis selectors
-        npc <- ncol(pca_components()$pos)
+        ## Principal components available for the axis selectors. Derived from
+        ## the matrix dimensions rather than by calling pca_components(): an
+        ## error thrown inside an observer ends the whole Shiny session, and
+        ## forcing it here would also pay for the decomposition on every dataset
+        ## load even for users who never open this tab.
+        npc <- pgx.pcaMaxComponents(pgx$X, npc = 5)
         pcs <- stats::setNames(seq_len(npc), paste0("PC", seq_len(npc)))
         shiny::updateSelectInput(session, "pca_dimx", choices = pcs, selected = 1)
         shiny::updateSelectInput(session, "pca_dimy", choices = pcs, selected = min(2, npc))

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -4,6 +4,57 @@
 ##
 
 
+##' Recompute the PCA of the samples on the fly.
+##'
+##' pgx$cluster$pos only stores PC1-PC2 (pca2d) and PC1-PC3 (pca3d), so any
+##' higher component has to be recomputed here.
+##'
+##' ponytail: this duplicates the preprocessing recipe of the "pca" branch of
+##' playbase::pgx.clusterMatrix() (playbase/R/pgx-cluster.R) -- top-SD rows,
+##' row-centered, irlba. It deliberately drops the jitter and column
+##' augmentation that function adds for t-SNE/UMAP stability, so PC1/PC2 match
+##' the stored pca2d only up to sign. If that recipe changes, change it here
+##' too. Upgrade path: export pgx.pcaComponents() from playbase, have
+##' pgx.clusterMatrix() delegate to it, and delete this copy.
+##'
+##' @param X expression matrix (features x samples)
+##' @param npc maximum number of components to return
+##' @param reduce.sd reduce to this many top-SD features before the SVD
+##' @return list(pos = samples x npc matrix, varexp = percentage per component)
+pgx.pcaComponents <- function(X, npc = 5, reduce.sd = 1000) {
+  if (any(is.na(X))) {
+    if (playbase::is.multiomics(rownames(X))) {
+      X <- playbase::imputeMissing.mox(X, method = "SVD2")
+    } else {
+      X <- playbase::imputeMissing(X, method = "SVD2")
+    }
+  }
+  if (nrow(X) > reduce.sd) {
+    X <- X[head(order(-matrixStats::rowSds(X, na.rm = TRUE)), reduce.sd), , drop = FALSE]
+  }
+  X <- X - rowMeans(X, na.rm = TRUE)
+  npc <- max(1, min(npc, ncol(X) - 1, nrow(X) - 1))
+
+  ## ponytail: irlba is unstable when npc approaches min(dim), and base svd is
+  ## exact and cheap at that size anyway
+  sv <- if (min(dim(X)) <= npc + 2) svd(X) else irlba::irlba(X, nv = npc)
+
+  pos <- sv$v[, seq_len(npc), drop = FALSE]
+  ## the sign of an SVD is arbitrary: pin the largest-magnitude loading positive
+  ## so the plot does not mirror between sessions
+  for (i in seq_len(npc)) {
+    if (sv$u[which.max(abs(sv$u[, i])), i] < 0) pos[, i] <- -pos[, i]
+  }
+  rownames(pos) <- colnames(X)
+  colnames(pos) <- paste0("PC", seq_len(npc))
+
+  list(
+    pos = pos,
+    varexp = round(sv$d[seq_len(npc)]^2 / sum(X^2, na.rm = TRUE) * 100, 1)
+  )
+}
+
+
 ##' Clustering board server module
 ##'
 ##' .. content for \details{} ..
@@ -29,7 +80,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     tab_elements <- list(
       "Heatmap" = list(
         enable = NULL,
-        disable = c("hm_clustmethod")
+        disable = c("hm_clustmethod", "pca_dimx", "pca_dimy")
       ),
       "PCA/tSNE" = list(
         enable = NULL,
@@ -37,7 +88,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       ),
       "Parallel" = list(
         enable = NULL,
-        disable = c("selected_phenotypes", "hm_clustmethod")
+        disable = c("selected_phenotypes", "hm_clustmethod", "pca_dimx", "pca_dimy")
       )
     )
 
@@ -105,6 +156,12 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
         shiny::updateSelectInput(session, "hm_clustmethod",
           choices = clustmethods, sel = selmethod
         )
+
+        ## principal components available for the axis selectors
+        npc <- ncol(pca_components()$pos)
+        pcs <- stats::setNames(seq_len(npc), paste0("PC", seq_len(npc)))
+        shiny::updateSelectInput(session, "pca_dimx", choices = pcs, selected = 1)
+        shiny::updateSelectInput(session, "pca_dimy", choices = pcs, selected = min(2, npc))
       }
     )
 
@@ -692,6 +749,22 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       playbase::selectSamplesFromSelectedLevels(pgx$Y, input$hm_samplefilter)
     })
 
+    ## PC1-PC5 on the fly. Only depends on pgx$X, so this runs once per dataset
+    ## and is cached for every later change of the axis selectors.
+    pca_components <- shiny::reactive({
+      shiny::req(pgx$X)
+      pgx.pcaComponents(pgx$X, npc = 5)
+    })
+
+    pca_dims <- shiny::reactive({
+      npc <- ncol(pca_components()$pos)
+      dims <- suppressWarnings(c(as.integer(input$pca_dimx), as.integer(input$pca_dimy)))
+      ## empty before the selectors are populated, stale right after a dataset
+      ## switch shrinks the number of available components
+      shiny::req(length(dims) == 2, !any(is.na(dims)), all(dims <= npc))
+      dims
+    })
+
     # plots ##########
     clustering_plot_splitmap_server(
       id = "splitmap",
@@ -712,6 +785,8 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       pgx = pgx,
       selected_samples = selected_samples,
       clustmethod = shiny::reactive(input$hm_clustmethod),
+      pca_components = pca_components,
+      pca_dims = pca_dims,
       watermark = WATERMARK,
       parent = ns
     )
@@ -722,6 +797,8 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       selected_phenotypes = shiny::reactive(input$selected_phenotypes),
       clustmethod = shiny::reactive(input$hm_clustmethod),
       selected_samples = selected_samples,
+      pca_components = pca_components,
+      pca_dims = pca_dims,
       watermark = WATERMARK
     )
 

--- a/components/board.clustering/R/clustering_server.R
+++ b/components/board.clustering/R/clustering_server.R
@@ -18,10 +18,13 @@
 ##' pgx.clusterMatrix() delegate to it, and delete this copy.
 ##'
 ##' @param X expression matrix (features x samples)
+##' @param Y sample annotation; when given, phenotype levels are one-hot
+##'   encoded and correlated with each component for the direction arrows
 ##' @param npc maximum number of components to return
 ##' @param reduce.sd reduce to this many top-SD features before the SVD
-##' @return list(pos = samples x npc matrix, varexp = percentage per component)
-pgx.pcaComponents <- function(X, npc = 5, reduce.sd = 1000) {
+##' @return list(pos = samples x npc scores, varexp = percentage per component,
+##'   loadings = features x npc, pheno.cor = phenotype levels x npc or NULL)
+pgx.pcaComponents <- function(X, Y = NULL, npc = 5, reduce.sd = 1000) {
   if (any(is.na(X))) {
     if (playbase::is.multiomics(rownames(X))) {
       X <- playbase::imputeMissing.mox(X, method = "SVD2")
@@ -40,17 +43,38 @@ pgx.pcaComponents <- function(X, npc = 5, reduce.sd = 1000) {
   sv <- if (min(dim(X)) <= npc + 2) svd(X) else irlba::irlba(X, nv = npc)
 
   pos <- sv$v[, seq_len(npc), drop = FALSE]
+  loadings <- sv$u[, seq_len(npc), drop = FALSE]
   ## the sign of an SVD is arbitrary: pin the largest-magnitude loading positive
-  ## so the plot does not mirror between sessions
+  ## so the plot does not mirror between sessions. Scores and loadings must flip
+  ## together, otherwise the biplot arrows point the wrong way.
   for (i in seq_len(npc)) {
-    if (sv$u[which.max(abs(sv$u[, i])), i] < 0) pos[, i] <- -pos[, i]
+    if (loadings[which.max(abs(loadings[, i])), i] < 0) {
+      loadings[, i] <- -loadings[, i]
+      pos[, i] <- -pos[, i]
+    }
   }
-  rownames(pos) <- colnames(X)
-  colnames(pos) <- paste0("PC", seq_len(npc))
+  dimnames(pos) <- list(colnames(X), paste0("PC", seq_len(npc)))
+  dimnames(loadings) <- list(rownames(X), paste0("PC", seq_len(npc)))
+
+  ## correlation of each one-hot encoded phenotype level with each component,
+  ## for the phenotype-direction arrows
+  pheno.cor <- NULL
+  if (!is.null(Y)) {
+    pheno.cor <- tryCatch(
+      {
+        H <- playbase::expandPhenoMatrix(Y[rownames(pos), , drop = FALSE], drop.ref = FALSE)
+        rho <- suppressWarnings(stats::cor(H, pos, use = "pairwise.complete.obs"))
+        rho[stats::complete.cases(rho), , drop = FALSE]
+      },
+      error = function(e) NULL
+    )
+  }
 
   list(
     pos = pos,
-    varexp = round(sv$d[seq_len(npc)]^2 / sum(X^2, na.rm = TRUE) * 100, 1)
+    varexp = round(sv$d[seq_len(npc)]^2 / sum(X^2, na.rm = TRUE) * 100, 1),
+    loadings = loadings,
+    pheno.cor = pheno.cor
   )
 }
 
@@ -752,8 +776,8 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     ## PC1-PC5 on the fly. Only depends on pgx$X, so this runs once per dataset
     ## and is cached for every later change of the axis selectors.
     pca_components <- shiny::reactive({
-      shiny::req(pgx$X)
-      pgx.pcaComponents(pgx$X, npc = 5)
+      shiny::req(pgx$X, pgx$Y)
+      pgx.pcaComponents(pgx$X, Y = pgx$Y, npc = 5)
     })
 
     pca_dims <- shiny::reactive({
@@ -787,6 +811,7 @@ ClusteringBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
       clustmethod = shiny::reactive(input$hm_clustmethod),
       pca_components = pca_components,
       pca_dims = pca_dims,
+      labeltype = labeltype,
       watermark = WATERMARK,
       parent = ns
     )

--- a/components/board.clustering/R/clustering_ui.R
+++ b/components/board.clustering/R/clustering_ui.R
@@ -127,6 +127,20 @@ ClusteringInputs <- function(id) {
             choices = c("tsne", "pca", "umap", "pacmap")
           ),
           "Choose the layout method for clustering plots."
+        ),
+        shiny::conditionalPanel(
+          "input.hm_clustmethod == 'pca'",
+          ns = ns,
+          withTooltip(
+            shiny::selectInput(ns("pca_dimx"), "X axis:", choices = NULL),
+            "Principal component shown on the horizontal axis.",
+            placement = "right", options = list(container = "body")
+          ),
+          withTooltip(
+            shiny::selectInput(ns("pca_dimy"), "Y axis:", choices = NULL),
+            "Principal component shown on the vertical axis.",
+            placement = "right", options = list(container = "body")
+          )
         )
       )
     )
@@ -246,8 +260,8 @@ ClusteringUI <- function(id) {
         clustering_plot_clustpca_ui(
           ns("PCAplot"),
           title = "Dimensionality reduction",
-          info.text = "Using the {Color/label}, {Shape} and {Label} options it is possible to control how the points are colored and shaped (acording to which available phenotypes) and it is possible to control where are the labels located respectively. There is also the option to visualize the three dimensionality reduction techniques at the same time, and the option to visualize the plot in three dimensions. For 2-dimensional principal component analysis, the percentage of variance explained by the first two principal components is reported in the x- and y-axis.",
-          info.methods = "Relationship (or similarity) between the samples for visual analytics, where similarity is visualized as proximity of the points. Three clustering methods are available, t-SNE (using the Rtsne R package [1]), UMAP (using the uwot R package [2]) and PCA (using the irlba R package [3]). Samples that are ‘similar’ will be placed close to each other.",
+          info.text = "Using the {Color/label}, {Shape} and {Label} options it is possible to control how the points are colored and shaped (acording to which available phenotypes) and it is possible to control where are the labels located respectively. There is also the option to visualize the three dimensionality reduction techniques at the same time, and the option to visualize the plot in three dimensions. For 2-dimensional principal component analysis, the {X axis} and {Y axis} options in the settings panel select which of the first five principal components are plotted against each other, and the percentage of variance explained by each of them is reported on the corresponding axis.",
+          info.methods = "Relationship (or similarity) between the samples for visual analytics, where similarity is visualized as proximity of the points. Three clustering methods are available, t-SNE (using the Rtsne R package [1]), UMAP (using the uwot R package [2]) and PCA (using the irlba R package [3]). Samples that are ‘similar’ will be placed close to each other. For PCA, the first five principal components are computed on the 1000 most variable features after row centering, and the reported percentage is the share of the total variance of that matrix explained by the component.",
           info.references = list(
             list(
               "Krijthe J (2023) Rtsne: T-Distributed Stochastic Neighbor Embedding using a Barnes-Hut Implementation.",

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -82,6 +82,7 @@ RUN R -e "BiocManager::install('wateRmelon')"
 RUN R -e "devtools::install_github('bigomics/metaLINCS')"
 RUN R -e "BiocManager::install('karyoploteR')"
 RUN R -e "BiocManager::install('regioneR')"
+RUN R -e "remotes::install_github('bigomics/plotly.repel')" # repelled arrow labels on the PCA biplot
 
 #------------------------------------------------------------
 # Add supporting R libraries

--- a/tests/testthat/test-clustering-pca-components.R
+++ b/tests/testthat/test-clustering-pca-components.R
@@ -137,6 +137,42 @@ test_that("a phenotype table that cannot be encoded does not kill the PCA", {
   expect_equal(dim(pc$pos), c(ncol(X), 5L))
 })
 
+test_that("the cheap component cap agrees with what is actually computed", {
+  ## the axis selectors are populated from pgx.pcaMaxComponents() without
+  ## running the SVD; if the two drift, the UI offers components that do not exist
+  for (ns in c(2, 3, 6, 8, 13)) {
+    X <- make_X(nsamples = ns)$X
+    expect_equal(
+      pgx.pcaMaxComponents(X, npc = 5),
+      ncol(pgx.pcaComponents(X, npc = 5)$pos),
+      info = paste("nsamples =", ns)
+    )
+  }
+})
+
+test_that("non-finite values do not break the decomposition", {
+  ## Inf passes an is.na() check but becomes NaN once the row is centered,
+  ## leaving an all-NaN component that the sign pinning cannot index
+  X <- make_X()$X
+  X[5, 3] <- Inf
+  X[100, 7] <- -Inf
+  pc <- pgx.pcaComponents(X, npc = 5)
+  expect_equal(dim(pc$pos), c(ncol(X), 5L))
+  expect_true(all(is.finite(pc$pos)))
+  expect_true(all(is.finite(pc$loadings)))
+})
+
+test_that("a degenerate matrix falls back to the exact svd instead of throwing", {
+  ## irlba errors with "starting vector near the null space" here; playbase
+  ## avoids it with random jitter, which we cannot use without losing sign
+  ## reproducibility
+  X <- matrix(1, 1200, 12)
+  dimnames(X) <- list(paste0("gene", 1:1200), paste0("s", 1:12))
+  pc <- pgx.pcaComponents(X, npc = 5)
+  expect_equal(dim(pc$pos), c(12L, 5L))
+  expect_true(all(is.finite(pc$pos)))
+})
+
 test_that("reduce.sd keeps the most variable features", {
   X <- make_X(nfeatures = 300)$X
   ## the 20 planted rows carry the signal and survive the SD cut

--- a/tests/testthat/test-clustering-pca-components.R
+++ b/tests/testthat/test-clustering-pca-components.R
@@ -84,6 +84,59 @@ test_that("missing values are imputed rather than propagated", {
   expect_false(any(is.na(pc$varexp)))
 })
 
+test_that("loadings come back aligned with the features and the scores", {
+  X <- make_X()$X
+  pc <- pgx.pcaComponents(X, npc = 5)
+
+  expect_equal(dim(pc$loadings), c(nrow(X), 5L))
+  expect_equal(rownames(pc$loadings), rownames(X))
+  expect_equal(colnames(pc$loadings), paste0("PC", 1:5))
+
+  ## the planted rows dominate PC1, which is what the biplot arrows point at
+  top <- rownames(pc$loadings)[order(-abs(pc$loadings[, "PC1"]))][1:20]
+  expect_true(all(top %in% paste0("gene", 1:20)))
+})
+
+test_that("scores and loadings are flipped together", {
+  ## X %*% loadings must stay proportional to the scores after sign pinning;
+  ## flipping one without the other points the arrows the wrong way
+  X <- make_X()$X
+  pc <- pgx.pcaComponents(X, npc = 5)
+  Xc <- X - rowMeans(X)
+  for (i in 1:5) {
+    expect_gt(cor(as.vector(t(Xc) %*% pc$loadings[, i]), pc$pos[, i]), 0.999)
+  }
+})
+
+test_that("phenotype correlations are returned only when Y is given", {
+  d <- make_X()
+  X <- d$X
+  Y <- data.frame(
+    grp = ifelse(d$grp == 1, "treated", "control"),
+    batch = rep(c("b1", "b2"), each = ncol(X) / 2),
+    row.names = colnames(X)
+  )
+
+  expect_null(pgx.pcaComponents(X, npc = 5)$pheno.cor)
+
+  pc <- pgx.pcaComponents(X, Y = Y, npc = 5)
+  expect_equal(ncol(pc$pheno.cor), 5L)
+  expect_true(all(abs(pc$pheno.cor) <= 1))
+  ## the planted group is what PC1 separates, so it must dominate PC1
+  expect_gt(
+    max(abs(pc$pheno.cor[grep("^grp=", rownames(pc$pheno.cor)), "PC1"])),
+    max(abs(pc$pheno.cor[grep("^batch=", rownames(pc$pheno.cor)), "PC1"]))
+  )
+})
+
+test_that("a phenotype table that cannot be encoded does not kill the PCA", {
+  X <- make_X()$X
+  ## every sample its own level: nothing to correlate against
+  Y <- data.frame(id = colnames(X), row.names = colnames(X))
+  pc <- pgx.pcaComponents(X, Y = Y, npc = 5)
+  expect_equal(dim(pc$pos), c(ncol(X), 5L))
+})
+
 test_that("reduce.sd keeps the most variable features", {
   X <- make_X(nfeatures = 300)$X
   ## the 20 planted rows carry the signal and survive the SD cut

--- a/tests/testthat/test-clustering-pca-components.R
+++ b/tests/testthat/test-clustering-pca-components.R
@@ -1,0 +1,93 @@
+## test-clustering-pca-components.R
+##
+## Unit tests for pgx.pcaComponents(), the on-the-fly PCA behind the X axis /
+## Y axis selectors on the Clustering board. pgx$cluster$pos only stores
+## PC1-PC3, so PC4/PC5 come from here.
+##
+## Sources the board server standalone; only function definitions live at the
+## top level of that file, so no Shiny session is needed.
+
+.board_dir <- if (dir.exists("components/board.clustering/R")) {
+  "components/board.clustering/R"
+} else {
+  "../../components/board.clustering/R"
+}
+
+source(file.path(.board_dir, "clustering_server.R"), local = TRUE)
+
+## features x samples, two planted groups separated along a strong axis
+make_X <- function(nsamples = 12, nfeatures = 200, seed = 1) {
+  set.seed(seed)
+  X <- matrix(rnorm(nfeatures * nsamples), nfeatures, nsamples)
+  grp <- rep(c(0, 1), length.out = nsamples)
+  X[1:20, ] <- X[1:20, ] + rep(grp * 8, each = 20)
+  dimnames(X) <- list(paste0("gene", 1:nfeatures), paste0("s", 1:nsamples))
+  list(X = X, grp = grp)
+}
+
+test_that("returns five components with sane variance percentages", {
+  X <- make_X()$X
+  pc <- pgx.pcaComponents(X, npc = 5)
+
+  expect_equal(dim(pc$pos), c(ncol(X), 5L))
+  expect_equal(colnames(pc$pos), paste0("PC", 1:5))
+  expect_equal(rownames(pc$pos), colnames(X))
+
+  expect_length(pc$varexp, 5)
+  expect_true(all(diff(pc$varexp) <= 0)) ## non-increasing
+  expect_true(all(pc$varexp > 0))
+  expect_lte(sum(pc$varexp), 100)
+})
+
+test_that("PC1 separates the planted groups", {
+  d <- make_X()
+  pc <- pgx.pcaComponents(d$X, npc = 5)
+  expect_gt(abs(cor(pc$pos[, "PC1"], d$grp)), 0.95)
+})
+
+test_that("components match prcomp up to sign", {
+  X <- make_X()$X
+  pc <- pgx.pcaComponents(X, npc = 5)
+  ## replicate the same preprocessing: row-centered, no SD reduction at 200 rows
+  ref <- prcomp(t(X - rowMeans(X)), center = FALSE)
+  for (i in 1:3) {
+    expect_gt(abs(cor(pc$pos[, i], ref$x[, i])), 0.999)
+  }
+})
+
+test_that("sign is pinned so the plot does not mirror between runs", {
+  X <- make_X()$X
+  expect_equal(
+    pgx.pcaComponents(X, npc = 5)$pos,
+    pgx.pcaComponents(X, npc = 5)$pos,
+    tolerance = 1e-4
+  )
+})
+
+test_that("number of components is capped by the sample count", {
+  X <- make_X(nsamples = 4)$X
+  pc <- pgx.pcaComponents(X, npc = 5)
+  expect_equal(ncol(pc$pos), 3L) ## ncol(X) - 1
+  expect_length(pc$varexp, 3)
+
+  ## small datasets take the exact svd path rather than irlba
+  X6 <- make_X(nsamples = 6)$X
+  expect_equal(ncol(pgx.pcaComponents(X6, npc = 5)$pos), 5L)
+})
+
+test_that("missing values are imputed rather than propagated", {
+  X <- make_X()$X
+  X[5, 3] <- NA
+  X[100, 7] <- NA
+  pc <- pgx.pcaComponents(X, npc = 5)
+  expect_false(any(is.na(pc$pos)))
+  expect_false(any(is.na(pc$varexp)))
+})
+
+test_that("reduce.sd keeps the most variable features", {
+  X <- make_X(nfeatures = 300)$X
+  ## the 20 planted rows carry the signal and survive the SD cut
+  pc <- pgx.pcaComponents(X, npc = 5, reduce.sd = 50)
+  expect_equal(dim(pc$pos), c(ncol(X), 5L))
+  expect_gt(pc$varexp[1], pc$varexp[2])
+})


### PR DESCRIPTION
Client asked to see up to PC5 and choose which component is plotted against which, plus a biplot, phenotype directions and a variance plot.

`pgx$cluster$pos` only stores PC1-PC3, so the board now recomputes PC1-PC5 on demand. Everything is gated to the `pca` layout — t-SNE/UMAP axes are unordered, so "PC3 vs PC5" means nothing there.

### Pick the components — sidebar, under `Layout`
![component selectors](https://raw.githubusercontent.com/bigomics/omicsplayground/assets/pca-screenshots/01-component-selectors.png)

Both panels follow the choice:
![PC2 vs PC3](https://raw.githubusercontent.com/bigomics/omicsplayground/assets/pca-screenshots/02-pc2-vs-pc3.png)

### Biplot controls — plot options
![biplot controls](https://raw.githubusercontent.com/bigomics/omicsplayground/assets/pca-screenshots/03-biplot-controls.png)

### Arrows: `features` = gene loadings, `phenotypes` = direction each phenotype increases
![biplot](https://raw.githubusercontent.com/bigomics/omicsplayground/assets/pca-screenshots/04-biplot-features.png)
![phenotype directions](https://raw.githubusercontent.com/bigomics/omicsplayground/assets/pca-screenshots/05-phenotype-directions.png)

### `variance explained` swaps the panel for a scree plot
![variance explained](https://raw.githubusercontent.com/bigomics/omicsplayground/assets/pca-screenshots/06-variance-explained.png)

## Notes

- **Variance % are lower than before** — now divided by total variance instead of the 50 components irlba retains. The old numbers were inflated.
- **The image needs rebuilding**: `plotly.repel` added to `docker/Dockerfile.update`. Without it the repel toggle silently does nothing (degrades to fixed labels, does not break).
- No playbase change needed.

## Testing

43 unit tests on the new helper (prcomp agreement, sign stability, non-finite input, degenerate matrices, 2/3/6/8/13 samples). Full suite: no regressions. Driven end to end in a browser — the screenshots above are from that run.

An independent review found 6 defects in rendering and error handling, all fixed in `5327d95dc`. The browser captures found a 7th: `grey30` is a valid R colour but not valid CSS, so plotly silently drew the arrows pink (`885a0c8cc`).

## Known gaps

Image export renders labels unrepelled; X and Y can be set to the same component; CSV export ignores the variance view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
