### PR TITLE
Build on debian:trixie (R 4.5 / BioC 3.22)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,10 @@ on:
         description: 'Branch to build'
         required: true
         default: 'master'
+      base_image:
+        description: 'Base image to build FROM'
+        required: true
+        default: 'bigomics/omicsplayground:beta'
       update_playdata:
         description: 'Update playdata package'
         required: true
@@ -43,12 +47,20 @@ jobs:
     # runs-on: ubuntu-latest # free GH worker, not enough memory
     runs-on: self-hosted # run on dev-bigomics-frankfurt self-hosted runner
 
+    env:
+      # Branch to build: manual dispatch, else the PR source branch, else the
+      # pushed branch. Drives BOTH the checkout and the in-container git clone
+      # -- they must agree, or a branch build uses master's Dockerfile and
+      # master's dev/Rprofile while only the cloned app code follows the branch.
+      BUILD_BRANCH: ${{ github.event.inputs.branch || github.head_ref || github.ref_name }}
+      BASE_IMAGE: ${{ github.event.inputs.base_image || 'bigomics/omicsplayground:beta' }}
+
     steps:
       -
-        name: Checkout 
+        name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: master
+          ref: ${{ env.BUILD_BRANCH }}
       -
         name: Get version
         id: get_version
@@ -76,12 +88,12 @@ jobs:
           secrets: |
             GITHUB_PAT=${{ secrets.GH_PAT }}
           build-args: |
-            BRANCH=${{ github.event.inputs.branch || github.ref_name }}
+            BRANCH=${{ env.BUILD_BRANCH }}
+            BASE_IMAGE=${{ env.BASE_IMAGE }}
             CACHEBUST_CODE=${{ github.run_id }}
             update_playdata=${{ github.event.inputs.update_playdata || 'false' }}
             update_bigdash=${{ github.event.inputs.update_bigdash || 'true' }}
             update_playbase=${{ github.event.inputs.update_playbase || 'true' }}
-            GITHUB_PAT=${{ secrets.GH_PAT }}
           tags: |
-            ${{ (github.event.inputs.branch || github.ref_name) == 'master' && format('{0}/omicsplayground:{1}, {0}/omicsplayground:latest, {0}/omicsplayground:master', secrets.DOCKERHUB_USERNAME, steps.get_version.outputs.VERSION) || '' }}
-            ${{ (github.event.inputs.branch || github.ref_name) != 'master' && format('{0}/omicsplayground:{1}', secrets.DOCKERHUB_USERNAME, github.event.inputs.branch || github.ref_name) || '' }}
+            ${{ env.BUILD_BRANCH == 'master' && format('{0}/omicsplayground:{1}, {0}/omicsplayground:latest, {0}/omicsplayground:master', secrets.DOCKERHUB_USERNAME, steps.get_version.outputs.VERSION) || '' }}
+            ${{ env.BUILD_BRANCH != 'master' && format('{0}/omicsplayground:{1}', secrets.DOCKERHUB_USERNAME, env.BUILD_BRANCH) || '' }}

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,15 @@ docker.run2:
 		-v ~/Playground/omicsplayground/etc:/omicsplayground/etc \
 		bigomics/omicsplayground:$(TAG)
 
+## Base images to build FROM. Override to build on a trixie base, e.g.
+## make docker.update BRANCH=edgy BASE_IMAGE=bigomics/omicsplayground:trixie-base
+PLAYBASE_IMAGE=bigomics/playbase:latest
+BASE_IMAGE=bigomics/omicsplayground:beta
+
 docker: FORCE version
 	@echo building docker $(BRANCH)
 	docker build $(ARG) --no-cache --build-arg BRANCH=$(BRANCH) \
+		--build-arg BASE_IMAGE=$(PLAYBASE_IMAGE) \
 		--progress plain \
 		-f docker/Dockerfile \
 	  	-t bigomics/omicsplayground:$(BRANCH) . \
@@ -57,11 +63,24 @@ docker: FORCE version
 update_playdata=false
 update_bigdash=false
 update_playbase=true
+## CACHEBUST_CODE (not --no-cache) so the package layers stay cached and only
+## the code clone is re-pulled -- same as the GHA workflow does with run_id.
+## --secret is what feeds GITHUB_PAT to the private bigomics installs; without
+## it they are skipped by an `if [ -n "$$GITHUB_PAT" ]` guard and the build
+## still exits 0, leaving a silently broken image.
 docker.update: FORCE
-	@echo building update docker 
-	docker build --no-cache \
+	@echo building update docker $(BRANCH) on $(BASE_IMAGE)
+	@test -n "$${GITHUB_PAT:-$$(gh auth token 2>/dev/null)}" || { \
+	  echo "ERROR: no GITHUB_PAT and 'gh auth token' failed."; \
+	  echo "The private bigomics packages would be silently skipped. Aborting."; \
+	  exit 1; }
+	DOCKER_BUILDKIT=1 GITHUB_PAT=$${GITHUB_PAT:-$$(gh auth token)} \
+	docker build \
 		--progress plain $(ARG) \
+		--secret id=GITHUB_PAT,env=GITHUB_PAT \
 		--build-arg BRANCH=$(BRANCH) \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--build-arg CACHEBUST_CODE=$$(date +%s) \
 		--build-arg update_playdata=$(update_playdata) \
 		--build-arg update_bigdash=$(update_bigdash) \
 		--build-arg update_playbase=$(update_playbase) \

--- a/dev/Rprofile
+++ b/dev/Rprofile
@@ -6,6 +6,16 @@ options(timeout = 99999)  ## download time.out
 options(BioC_mirror = "https://packagemanager.posit.co/bioconductor")
 options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor/config.yaml")
 
-# Configure a CRAN snapshot compatible with Bioconductor 3.18:
-options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest"))
+# Configure a CRAN snapshot compatible with Bioconductor 3.22.
+# NOTE: the __linux__/<distro> segment must match the base image. Leaving this
+# at noble on a trixie base serves Ubuntu binaries built against Ubuntu libs.
+options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/trixie/latest"))
+
+# PPM picks the binary build from the User-Agent. R does not send its own
+# identity unless HTTPUserAgent is set explicitly -- it sends "libcurl/x.y.z",
+# which PPM answers with source packages.
+options(HTTPUserAgent = sprintf(
+  "R/%s R (%s)", getRversion(),
+  paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])
+))
 

--- a/dev/Rprofile
+++ b/dev/Rprofile
@@ -9,7 +9,14 @@ options(BIOCONDUCTOR_CONFIG_FILE = "https://packagemanager.posit.co/bioconductor
 # Configure a CRAN snapshot compatible with Bioconductor 3.22.
 # NOTE: the __linux__/<distro> segment must match the base image. Leaving this
 # at noble on a trixie base serves Ubuntu binaries built against Ubuntu libs.
-options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/trixie/latest"))
+#
+# Pinned to a date, NOT `latest`. On `latest` the binary channel served lattice
+# 0.23-1, which dropped the `parallel` export that methylumi still imports;
+# that breaks methylumi -> lumi -> wateRmelon, and wateRmelon is a playbase
+# Import. Symptom is nasty: the packages install fine and only fail on load.
+# Keep this date in step with playbase's dev/rspm.R -- if the two disagree, the
+# opg stages upgrade packages the base image was built against.
+options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/trixie/2026-07-15"))
 
 # PPM picks the binary build from the User-Agent. R does not send its own
 # identity unless HTTPUserAgent is set explicitly -- it sends "libcurl/x.y.z",

--- a/dev/sass.R
+++ b/dev/sass.R
@@ -11,5 +11,5 @@ output <- sass::sass(
   options = sass::sass_options(
     output_style = "compressed"
   ),
-  output = 'components/app/R/www/styles.min.css'
+  output = 'components/assets/styles.min.css'
 )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,16 +65,29 @@ COPY dev/*.R dev/description* dev/
 RUN Rscript dev/requirements.R
 
 #------------------------------------------------------------
-# Install fresh playbase (from same BRANCH)
+# Install fresh playbase.
+# If PLAYBASE_BRANCH is set, install exactly that branch and FAIL if it does
+# not exist (no silent fallback). Otherwise check playbase@{BRANCH} and fall
+# back to main when the sibling branch is missing.
 #------------------------------------------------------------
-# check if playbase@{$BRANCH} exists, if it does, install.. otherwise install main
-RUN echo "Checking playbase branch ${BRANCH}"
-RUN BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l) && \
+ARG PLAYBASE_BRANCH=
+RUN if [ -n "$PLAYBASE_BRANCH" ]; then \
+    echo "Installing playbase@${PLAYBASE_BRANCH} (explicit)"; \
+    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${PLAYBASE_BRANCH} | wc -l); \
+    if [ $BRANCH_EXISTS -ne 1 ]; then \
+        echo "ERROR: playbase branch '${PLAYBASE_BRANCH}' does not exist" >&2; exit 1; \
+    fi; \
+    R -e "remotes::install_github('bigomics/playbase@${PLAYBASE_BRANCH}',dependencies=FALSE)"; \
+else \
+    echo "Checking playbase branch ${BRANCH}"; \
+    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l) && \
     if [ $BRANCH_EXISTS -eq 1 ]; then \
         R -e "remotes::install_github('bigomics/playbase@${BRANCH}',dependencies=FALSE)"; \
     else \
+        echo "WARNING: no playbase@${BRANCH}, falling back to playbase@main"; \
         R -e "remotes::install_github('bigomics/playbase@main',dependencies=FALSE)"; \
-    fi
+    fi; \
+fi
 
 # after install non-detected missing packages
 #RUN R -e "remotes::install_version('Matrix', version = '1.6.1.1')"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,15 +27,17 @@ RUN apt update && apt install -y fonts-lato
 
 WORKDIR /tmp
 
+# Keep in sync with docker/Dockerfile.update -- see playbase dev/PINS.md.
+# tinytex is installed on top of this quarto, so this block must stay here.
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then \
-        wget -nv https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.56/quarto-1.5.56-linux-arm64.deb; \
+        wget -nv https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-arm64.deb; \
     elif [ "$ARCH" = "amd64" ]; then \
-        wget -nv https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.56/quarto-1.5.56-linux-amd64.deb; \
+        wget -nv https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-amd64.deb; \
     else \
         echo "Unsupported architecture: $ARCH"; exit 1; \
     fi && \
-    dpkg -i quarto-1.5.56-linux-*.deb; \
+    dpkg -i quarto-1.8.27-linux-*.deb; \
     quarto install tinytex
 
 #------------------------------------------------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,9 @@
 # Start from playbase image
 #------------------------------------------------------------
 
-FROM bigomics/playbase:latest
+# Overridable so a trixie playbase can be used without retagging :latest.
+ARG BASE_IMAGE=bigomics/playbase:latest
+FROM ${BASE_IMAGE}
 
 ARG BRANCH=master
 RUN echo Building Docker image from branch '$BRANCH'

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -128,21 +128,34 @@ RUN --mount=type=secret,id=GITHUB_PAT \
     fi
 
 #------------------------------------------------------------
-# Install fresh playbase (from same BRANCH)
+# Install fresh playbase.
+# If PLAYBASE_BRANCH is set, install exactly that branch and FAIL if it does
+# not exist (no silent fallback). Otherwise check playbase@{BRANCH} and fall
+# back to main when the sibling branch is missing.
 #------------------------------------------------------------
-# check if playbase@{$BRANCH} exists, if it does, install.. otherwise install main
 # TODO: temporary solution, this should go out once we rebuild base image
 RUN R -e "install.packages('ggiraph')"
 RUN R -e "BiocManager::install('TileDBArray')"
 
 ARG update_playbase=true
+ARG PLAYBASE_BRANCH=
 RUN if [ $update_playbase = true ]; then \
-    echo "Checking playbase branch ${BRANCH}"; \
-    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l); \
-    if [ $BRANCH_EXISTS -eq 1 ]; then \
-       R -e "remotes::install_github('bigomics/playbase@${BRANCH}',dependencies=FALSE)"; \
+    if [ -n "$PLAYBASE_BRANCH" ]; then \
+        echo "Installing playbase@${PLAYBASE_BRANCH} (explicit)"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${PLAYBASE_BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -ne 1 ]; then \
+            echo "ERROR: playbase branch '${PLAYBASE_BRANCH}' does not exist" >&2; exit 1; \
+        fi; \
+        R -e "remotes::install_github('bigomics/playbase@${PLAYBASE_BRANCH}',dependencies=FALSE)"; \
     else \
-       R -e "remotes::install_github('bigomics/playbase@main',dependencies=FALSE)"; \
+        echo "Checking playbase branch ${BRANCH}"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -eq 1 ]; then \
+           R -e "remotes::install_github('bigomics/playbase@${BRANCH}',dependencies=FALSE)"; \
+        else \
+           echo "WARNING: no playbase@${BRANCH}, falling back to playbase@main"; \
+           R -e "remotes::install_github('bigomics/playbase@main',dependencies=FALSE)"; \
+        fi \
     fi \
 fi
 
@@ -158,32 +171,52 @@ RUN R -e "if (!require('playbase')) { quit(status=1) }"
 #RUN R -e "remotes::install_github('the-y-company/bsutils',dependencies=FALSE)"
 
 #------------------------------------------------------------
-# Install fresh playdata (from same BRANCH)
+# Install fresh playdata (PLAYDATA_BRANCH, or same BRANCH with main fallback)
 #------------------------------------------------------------
-# check if playbase@{$BRANCH} exists, if it does, install.. otherwise install main
 ARG update_playdata=false
+ARG PLAYDATA_BRANCH=
 RUN if [ $update_playdata = true ]; then \
-    echo "Checking playdata branch ${BRANCH}"; \
-    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playdata.git ${BRANCH} | wc -l); \
-    if [ $BRANCH_EXISTS -eq 1 ]; then \
-        R -e "remotes::install_github('bigomics/playdata@${BRANCH}',dependencies=FALSE)"; \
+    if [ -n "$PLAYDATA_BRANCH" ]; then \
+        echo "Installing playdata@${PLAYDATA_BRANCH} (explicit)"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playdata.git ${PLAYDATA_BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -ne 1 ]; then \
+            echo "ERROR: playdata branch '${PLAYDATA_BRANCH}' does not exist" >&2; exit 1; \
+        fi; \
+        R -e "remotes::install_github('bigomics/playdata@${PLAYDATA_BRANCH}',dependencies=FALSE)"; \
     else \
-        R -e "remotes::install_github('bigomics/playdata@main',dependencies=FALSE)"; \
+        echo "Checking playdata branch ${BRANCH}"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playdata.git ${BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -eq 1 ]; then \
+            R -e "remotes::install_github('bigomics/playdata@${BRANCH}',dependencies=FALSE)"; \
+        else \
+            echo "WARNING: no playdata@${BRANCH}, falling back to playdata@main"; \
+            R -e "remotes::install_github('bigomics/playdata@main',dependencies=FALSE)"; \
+        fi \
     fi \
 fi
 
 #------------------------------------------------------------
-# Install fresh bigdash (from same BRANCH)
+# Install fresh bigdash (BIGDASH_BRANCH, or same BRANCH with master fallback)
 #------------------------------------------------------------
-# check if bigdash@{$BRANCH} exists, if it does, install.. otherwise install main
 ARG update_bigdash=false
+ARG BIGDASH_BRANCH=
 RUN if [ $update_bigdash = true ]; then \
-    echo "Checking bigdash branch ${BRANCH}"; \
-    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/bigdash.git ${BRANCH} | wc -l); \
-    if [ $BRANCH_EXISTS -eq 1 ]; then \
-       R -e "remotes::install_github('bigomics/bigdash@${BRANCH}',dependencies=FALSE)"; \
+    if [ -n "$BIGDASH_BRANCH" ]; then \
+        echo "Installing bigdash@${BIGDASH_BRANCH} (explicit)"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/bigdash.git ${BIGDASH_BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -ne 1 ]; then \
+            echo "ERROR: bigdash branch '${BIGDASH_BRANCH}' does not exist" >&2; exit 1; \
+        fi; \
+        R -e "remotes::install_github('bigomics/bigdash@${BIGDASH_BRANCH}',dependencies=FALSE)"; \
     else \
-       R -e "remotes::install_github('bigomics/bigdash@master',dependencies=FALSE)"; \
+        echo "Checking bigdash branch ${BRANCH}"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/bigdash.git ${BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -eq 1 ]; then \
+           R -e "remotes::install_github('bigomics/bigdash@${BRANCH}',dependencies=FALSE)"; \
+        else \
+           echo "WARNING: no bigdash@${BRANCH}, falling back to bigdash@master"; \
+           R -e "remotes::install_github('bigomics/bigdash@master',dependencies=FALSE)"; \
+        fi \
     fi \
 fi
 

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -10,7 +10,9 @@
 # Start from playbase image
 #------------------------------------------------------------
 
-FROM bigomics/omicsplayground:beta
+# Overridable so a trixie base can be used without retagging :beta.
+ARG BASE_IMAGE=bigomics/omicsplayground:beta
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Set the locale (uncomment UTF8)

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -24,7 +24,10 @@ ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 RUN apt update && apt install -y libpoppler-cpp-dev
 
 #------------------------------------------------------------
-# Update quarto (base image has 1.5.56 with typst 0.11; need >=1.8 for typst 0.12+)
+# Update quarto. A base built from docker/Dockerfile already ships this exact
+# version, so this is then a no-op reinstall; it stays because :beta is a
+# hand-blessed tag that may be an older image with typst 0.11. Once :beta is
+# always built from docker/Dockerfile this block can go. See playbase dev/PINS.md.
 #------------------------------------------------------------
 RUN ARCH=$(dpkg --print-architecture) && \
     wget -nv https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-${ARCH}.deb && \

--- a/docker/build-shibuya-trixie.sh
+++ b/docker/build-shibuya-trixie.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Build bigomics/omicsplayground:trixie-edgy on shibuya, from scratch.
+#
+# Not run by CI. This is the host-specific orchestration script used on the
+# shibuya VM (tokyo's Proxmox VM 101) to hand-build the trixie image locally,
+# because bigomics/omicsplayground:trixie-edgy is not published to Docker Hub.
+# See shiny-deploy/12-shinyproxy-docker-service-swarm/tokyo/AGENTS.md gotcha 6
+# on that deploy for the full context.
+#
+# Expects $HOME/trixie-build/{playbase,omicsplayground} to be checkouts of
+# those two repos (this script does not clone them) and $HOME/trixie-build/.pat
+# to contain a GITHUB_PAT.
+#
+# Built here, not on the Proxmox host: enabling docker there sets iptables
+# FORWARD DROP and makes every VM unreachable, which would take down this very
+# deploy. Building here also means the image lands directly in the daemon
+# ShinyProxy uses, with no transfer.
+#
+# REQUIREMENT: host CPU must expose AVX/AVX2. PPM ships tiledb as a binary built
+# for a modern ISA, and TileDBArray dyn.loads it during install -- without AVX
+# that is an instant SIGILL, which fails TileDBArray -> playbase (an Import) ->
+# the whole build.
+#   grep -w avx2 /proc/cpuinfo   # must print something
+set -euo pipefail
+
+ROOT=$HOME/trixie-build
+BRANCH=edgy                     # opg code branch cloned INSIDE the image
+PB_BRANCH=edgy                  # playbase branch. Explicit: Dockerfile.{,update}
+                                 # install exactly this (fail-fast if missing)
+                                 # instead of the same-name check with silent
+                                 # fallback to playbase@main. Decouples the two
+                                 # repos -- no same-named playbase alias needed.
+SQUASH=$HOME/.local/bin/docker-squash
+export DOCKER_BUILDKIT=1
+
+GITHUB_PAT=$(cat "$ROOT/.pat"); export GITHUB_PAT
+test -n "$GITHUB_PAT"
+
+step(){ echo; echo "=================== $* ($(date -Is)) ==================="; echo; }
+
+#---------------------------------------------------------------------
+# playbase base.
+# NOT `make docker`: its docker.squash guard is always-true and always exits 1,
+# and docker.pkg pipes to tee without pipefail so a failed build returns 0.
+#---------------------------------------------------------------------
+cd "$ROOT/playbase"
+cp dev/rspm.R dev/Rprofile          # gitignored; without it everything builds from source
+grep -q '2026-07-15' dev/Rprofile   # PPM pin must be present or lattice drifts to 0.23-1
+
+step "1/5  playbase OS layer"
+if docker image inspect playbase-os >/dev/null 2>&1; then echo "reusing playbase-os"; else
+  docker build --no-cache -f dev/Dockerfile.os -t playbase-os . 2>&1 | tee "$ROOT/os.log"
+fi
+
+step "2/5  playbase R base layer"
+if docker image inspect playbase-rbase >/dev/null 2>&1; then echo "reusing playbase-rbase"; else
+  docker build -f dev/Dockerfile.rbase -t playbase-rbase . 2>&1 | tee "$ROOT/rbase.log"
+fi
+
+step "3/5  playbase package layer + squash"
+if docker image inspect bigomics/playbase:trixie >/dev/null 2>&1; then
+  echo "reusing bigomics/playbase:trixie"
+else
+  umask 077; printf 'GITHUB_PAT=%s\n' "$GITHUB_PAT" > dev/Renviron
+  docker build -f dev/Dockerfile -t playbase-pkg . 2>&1 | tee "$ROOT/pkg.log"
+  rm -f dev/Renviron
+  docker image inspect playbase-pkg >/dev/null
+  # Squash for PAT hygiene, not size: the token is baked into an intermediate
+  # layer and this docker group has two members (xavier, kwee).
+  $SQUASH playbase-pkg -t bigomics/playbase:trixie
+  docker image inspect bigomics/playbase:trixie >/dev/null
+  docker rmi playbase-pkg
+fi
+
+#---------------------------------------------------------------------
+# Plain `docker build` for the opg stages. On an earlier build host (docker
+# 26.1.5) `quarto install tinytex` died under AppArmor with a deno SIGILL-style
+# panic, which forced a privileged buildx builder plus a local registry to feed
+# it the base image. Docker 29.7.1 does NOT reproduce that -- verified by
+# running the exact quarto+tinytex install under default confinement -- so the
+# registry and the container driver are both dropped. That also avoids pushing
+# the squashed 20.5GB single-layer image, whose one ~10GB blob timed out.
+#---------------------------------------------------------------------
+step "4/5  omicsplayground stage 1 (docker/Dockerfile)"
+cd "$ROOT/omicsplayground"
+docker build --no-cache --progress plain \
+  --build-arg BRANCH=$BRANCH \
+  --build-arg PLAYBASE_BRANCH=$PB_BRANCH \
+  --build-arg BASE_IMAGE=bigomics/playbase:trixie \
+  -f docker/Dockerfile \
+  -t bigomics/omicsplayground:trixie-edgy-base . 2>&1 | tee "$ROOT/stage1.log"
+docker image inspect bigomics/omicsplayground:trixie-edgy-base >/dev/null
+
+step "5/5  omicsplayground stage 2 (docker/Dockerfile.update)"
+docker build --progress plain \
+  --build-arg BRANCH=$BRANCH \
+  --build-arg PLAYBASE_BRANCH=$PB_BRANCH \
+  --build-arg BASE_IMAGE=bigomics/omicsplayground:trixie-edgy-base \
+  --build-arg CACHEBUST_CODE="$(date +%s)" \
+  --secret id=GITHUB_PAT,env=GITHUB_PAT \
+  -f docker/Dockerfile.update \
+  -t bigomics/omicsplayground:trixie-edgy . 2>&1 | tee "$ROOT/stage2.log"
+docker image inspect bigomics/omicsplayground:trixie-edgy >/dev/null
+
+#---------------------------------------------------------------------
+step "SMOKE TEST"
+#---------------------------------------------------------------------
+docker run --rm --entrypoint sh bigomics/omicsplayground:trixie-edgy \
+  -c '. /etc/os-release; echo "$PRETTY_NAME"; quarto --version'
+# Asserts the packages LOAD, not just that they are installed: an earlier run
+# passed an installed-only check while methylumi/lumi/wateRmelon were unloadable
+# because lattice had been upgraded out from under them. tiledb/TileDBArray are
+# the AVX canaries.
+docker run --rm --entrypoint Rscript bigomics/omicsplayground:trixie-edgy -e '
+  cat(R.version.string, "| BioC", as.character(BiocManager::version()), "\n")
+  cat("lattice", as.character(packageVersion("lattice")),
+      "| exports parallel:", "parallel" %in% getNamespaceExports("lattice"), "\n")
+  need <- c("collapse","isotree","WGCNAplus","omicsai","playbase","tiledb",
+            "TileDBArray","PCSF","visNetwork","wateRmelon","methylumi","lumi")
+  bad <- character(0)
+  for (x in need) {
+    r <- tryCatch({ suppressMessages(loadNamespace(x)); "LOADS" },
+                  error = function(e) paste("FAILS:", conditionMessage(e)))
+    cat(sprintf("%-12s %s\n", x, r)); if (r != "LOADS") bad <- c(bad, x)
+  }
+  cat("playbase", as.character(packageVersion("playbase")), "\n")
+  if (length(bad)) { cat("FAILED TO LOAD:", paste(bad, collapse=" "), "\n"); quit(status=1) }'
+
+rm -f "$ROOT/.pat"
+step "BUILD COMPLETE"


### PR DESCRIPTION
Companion to bigomics/playbase#511. **Both must land together** — see "The two pins" below.

## What this is

Builds Omics Playground on `debian:trixie` instead of `ubuntu:24.04`. The distro swap is not cosmetic: trixie ships R 4.5.0, and BiocManager hard-refuses BioC 3.18 on R 4.5, so R 4.3→4.5 and BioC 3.18→3.22 ride along unavoidably. That jump, not the `FROM` line, is the real risk.

The base image itself lives in playbase. This side is small: point at the trixie base, bump quarto, pin the package snapshot, and make CI able to build a branch at all.

## Status: validated end to end

Built from scratch on a Debian 13 box (`bigomics/playbase:trixie` → stage 1 → stage 2) and verified at runtime, not just built:

- Debian 13 · R 4.5.0 · BioC 3.22 · quarto 1.8.27 · typst · playbase 4.1.2 (edgy)
- app serves HTTP 200, titles as `Omics Playground 4`, no errors in log
- `example-data.pgx` loads: 18 samples, 7118 features, 5 real contrasts
- base graphics, a stored sample embedding, and a ggplot volcano over 7051 features all render (visually inspected)
- report export produces real PDFs through **both** engines — typst (posters) and LaTeX/tinytex (slides)

## ⚠️ Known issue this does NOT fix: report export breaks under AppArmor

On a Debian 13 host, `quarto render` inside a normally-confined container panics:

```
Deno has panicked ... failed to create UnixStream: Os { code: 13, kind: PermissionDenied }
```

No PDF is produced. **Both** report engines are affected. The only fix found is running the container with `apparmor=unconfined`; seccomp and the container runtime were both tested and ruled out. Note `quarto --version` still works, so a version-check smoke test reports healthy while render is broken.

This needs a deployment-side change (ShinyProxy container options) before trixie goes anywhere real. It was never seen in the earlier validation because that ran on WSL2, which has no AppArmor.

CI is unaffected — `setup-buildx-action` defaults to the `docker-container` driver, whose buildkitd is privileged and therefore unconfined. Local `make docker` on a Debian 13 machine **will** hit it, since all three Makefile targets use plain `docker build`.

## The two pins

`dev/Rprofile` here and `dev/rspm.R` in playbase must carry the **same** snapshot date. PPM's `latest` served lattice 0.23-1, which dropped the `parallel` export methylumi still imports; that cascades methylumi → lumi → wateRmelon, and wateRmelon is a playbase Import.

Pinning only one is **worse than pinning neither**: the base compiles correctly against lattice 0.22-9, then these stages upgrade lattice over it, and the build exits **0** with methylumi/lumi/wateRmelon installed but unloadable. `x %in% installed.packages()` returns TRUE for all three. Only `loadNamespace()` catches it.

Also worth knowing: PPM's source index advertised 0.22-9 while the binary channel shipped 0.23-1, so checking `src/contrib/PACKAGES` does not reveal this.

## CI changes

`docker-build.yml` hardcoded `ref: master` on checkout, so a `branch: <x>` dispatch built that branch's app code against **master's** Dockerfile and master's `dev/Rprofile` — on a trixie branch that silently reverts to the noble PPM URL, i.e. Ubuntu binaries on Debian. Checkout now follows the branch being built. Also:

- branch resolved once into `BUILD_BRANCH`, adding `github.head_ref` so PR builds stop passing `<PR#>/merge` to `git clone -b`
- `ARG BASE_IMAGE` before `FROM` in both Dockerfiles, so a trixie base can be used without retagging `:beta` out from under Docker Hub
- dropped `GITHUB_PAT` from `build-args` — unused (no matching `ARG`) and build-args land in image history; the BuildKit secret mount already delivers it
- `make docker.update` now passes `--secret`. Without it the private bigomics installs are skipped by their `if [ -n "$GITHUB_PAT" ]` guard **and the build still exits 0**

## Not done

- **The trixie playbase base is not on Docker Hub.** It exists only on the build host, so CI cannot do a full trixie build until someone publishes it.
- The AppArmor runtime issue above.
- `docker-base.yml` references `./docker/Dockerfile.base`, which does not exist in this repo — that workflow is dead. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
