### PR TITLE
fix: clear the browser JS console errors

### DIFF
--- a/components/app/R/opg_server.R
+++ b/components/app/R/opg_server.R
@@ -447,17 +447,21 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
     bigdash.toggleTab(session, "mwgcna-tab", is.multiomics)
     bigdash.toggleTab(session, "wgcna-tab", !is.multiomics || show.beta)
 
-    ## hide beta subtabs..
-    toggleTab("drug-tabs", "Connectivity map (beta)", show.beta) ## too slow
-    toggleTab("pathway-tabs", "Enrichment Map (beta)", show.beta) ## too slow
-    toggleTab("wgcna-tabs", "AI Report✨", show.beta)
-    toggleTab("mwgcna-tabs", "AI Report✨", show.beta)
-    toggleTab("drug-tabs", "AI Summary✨", show.beta)     
+    ## hide beta subtabs.. only for boards already inserted in the DOM,
+    ## otherwise shiny throws "There is no tabsetPanel with id equal to ..."
+    if (loaded$systems == 1) {
+      toggleTab("drug-tabs", "Connectivity map (beta)", show.beta) ## too slow
+    }
+    if (loaded$enrichment == 1) {
+      toggleTab("pathway-tabs", "Enrichment Map (beta)", show.beta) ## too slow
+    }
 
     ## Control tab to only be displayed if there is custom fc + baseline fc
     has.customfc <- "custom" %in% colnames(PGX$gx.meta$meta[[1]]$fc) &&
       length(colnames(PGX$gx.meta$meta[[1]]$fc)) > 1
-    toggleTab("diffexpr-tabs1", "FC-FC comparison", has.customfc)
+    if (loaded$expression == 1) {
+      toggleTab("diffexpr-tabs1", "FC-FC comparison", has.customfc)
+    }
 
     ## Dynamically show upon availability in pgx object
     tabRequire(PGX, session, "drug-tab", "drugs", TRUE)

--- a/components/app/R/opg_ui.R
+++ b/components/app/R/opg_ui.R
@@ -156,6 +156,14 @@ opg_ui <- function() {
     
     bigdash::bigPage(
       shiny.i18n::usei18n(i18n),
+      ## shiny.i18n's subscribe() hands jQuery's Event object straight to Shiny's
+      ## callback, which expects a boolean, so every update_lang() logs
+      ## "Unexpected input value mode: '[object Object]'". Must come after
+      ## usei18n() so the binding is already registered.
+      shiny::tags$script(shiny::HTML(
+        "Shiny.inputBindings.bindingNames['shiny.shinyi18n'].binding.subscribe =
+           function (el, callback) { $(el).on('change.shinyi18n', function () { callback(false); }); };"
+      )),
       # header,
       title = "Omics Playground 4",
       theme = big_theme2,

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -58,7 +58,8 @@ app_ui <- function(x) {
       waiter::use_waiter(),
       sever::useSever(),
       bigLoaders::addBigLoaderDeps(),
-      firebase::useFirebase(firestore = TRUE, analytics = TRUE),
+      ## both args are deprecated no-ops in firebase >= 1.0 and only emit a warning
+      firebase::useFirebase(),
       shinybrowser::detect(),
       shinybusy::busy_start_up(
         text = tags$h2("\nPrepping your personal playground..."), mode = "auto",

--- a/components/ui/ui-EditorContent.R
+++ b/components/ui/ui-EditorContent.R
@@ -127,38 +127,6 @@ getEditorContent <- function(plot_type = "volcano", ns, ns_parent, title, cards 
               )
             ),
 
-            # Axis Options
-            bslib::accordion_panel(
-              "Text sizes",
-              bslib::layout_column_wrap(
-                width = 1 / 2,
-                numericInput(ns_parent("label_size"), "Labels", value = 4),
-                numericInput(ns_parent("marker_size"), "Points", value = 1),
-                numericInput(ns_parent("axis_text_size"), "Axis text", value = 14)
-              )
-            ),
-            bslib::accordion_panel(
-              "Margins",
-              checkboxInput(ns_parent("margin_checkbox"), "Custom margins", value = FALSE),
-              conditionalPanel(
-                condition = "input.margin_checkbox",
-                ns = ns_parent,
-                numericInput(ns_parent("margin_left"), "Left", value = 10),
-                numericInput(ns_parent("margin_right"), "Right", value = 10),
-                numericInput(ns_parent("margin_top"), "Top", value = 10),
-                numericInput(ns_parent("margin_bottom"), "Bottom", value = 10)
-              )
-            ),
-            bslib::accordion_panel(
-              "Aspect Ratio",
-              checkboxInput(ns_parent("aspect_ratio_checkbox"), "Custom aspect ratio", value = FALSE),
-              conditionalPanel(
-                condition = "input.aspect_ratio_checkbox",
-                numericInput(ns_parent("aspect_ratio"), NULL, value = 0.5, min = 0.1, max = 10),
-                ns = ns_parent
-              )
-            ),
-
             # Additional Settings
             bslib::accordion_panel(
               "Labels",

--- a/tests/testthat/test-editor-content-ids.R
+++ b/tests/testthat/test-editor-content-ids.R
@@ -1,0 +1,38 @@
+## test-editor-content-ids.R
+##
+## Regression guard: getEditorContent() must never emit the same input id
+## twice, otherwise the browser console fills with
+## "[shiny] Duplicate input IDs were found".
+
+.ui_dir <- if (dir.exists("components/ui")) "components/ui" else "../../components/ui"
+
+source(file.path(.ui_dir, "ui-ColorDefaults.R"), encoding = "UTF-8", local = TRUE)
+source(file.path(.ui_dir, "ui-EditorContent.R"), encoding = "UTF-8", local = TRUE)
+
+.plot_types <- c(
+  "volcano", "heatmap", "barplot", "expression_barplot", "expression_boxplot",
+  "correlation", "scatterplot", "featuremap", "enrichment", "clustering",
+  "clustering_prism", "grouped_barplot", "gradient", "significance",
+  "scatter_highlight", "rank_plot", "correlation_matrix", "scatter_updown",
+  "boxplot_methyl"
+)
+
+for (.ty in .plot_types) {
+  local({
+    ty <- .ty
+    test_that(paste0("editor content for '", ty, "' has no duplicate ids"), {
+      ui <- getEditorContent(
+        ty,
+        ns = shiny::NS(paste0("board-plot_", ty)),
+        ns_parent = shiny::NS("board"),
+        title = ty,
+        outputFunc = plotly::plotlyOutput
+      )
+      html <- as.character(ui)
+      ids <- regmatches(html, gregexpr('id="[^"]+"', html))[[1]]
+      ids <- sub('^id="', "", sub('"$', "", ids))
+      dups <- names(which(table(ids) > 1))
+      expect_equal(dups, character(0))
+    })
+  })
+}


### PR DESCRIPTION
Branched off `edgy`. Closes the console noise reported on `devel`.

## Reproduction

Launched the app headless (chromote/CDP), logged in, loaded `example-data.pgx`, walked 8 boards and opened a plot editor, capturing `console.error`/`console.warn`, uncaught exceptions and browser log entries. **The console is now clean — 0 errors, 0 warnings across that flow.**

## What was wrong

**1. Duplicate input IDs — the plot editor** (`components/ui/ui-EditorContent.R`)

The "Text sizes" / "Margins" / "Aspect Ratio" accordion panels were copy-pasted twice inside `volcano_content`, so every `*_volcano*` module emitted 11 duplicate input IDs: `label_size`, `marker_size`, `axis_text_size`, `margin_checkbox`, `margin_left/right/top/bottom`, `aspect_ratio_checkbox`, `aspect_ratio`. Matches the reported list 1:1. Dropped the second copy.

The other half of that report — `card_selector_modal: 6 inputs` — is a hardcoded, unnamespaced id in bigdash. Fixed separately in bigomics/bigdash#35; this PR does not depend on it.

**2. `There is no tabsetPanel with id equal to 'drug-tabs'`** (`components/app/R/opg_server.R`)

`tab_control()` runs on dataset change, before the lazily inserted boards exist in the DOM, so `hideTab`/`showTab` threw. Guarded the three live toggles on `loaded$systems` / `loaded$enrichment` / `loaded$expression`, and removed three calls targeting tabs that do not exist anywhere in the codebase (`"AI Report✨"` ×2, `"AI Summary✨"`).

**3. `[shiny] Error in inputBinding.receiveMessage()`** (`components/app/R/opg_ui.R`)

The `Object` in the console hides the real message. Expanded via CDP:

```
Error: Unexpected input value mode: '[object Object]'
binding: shiny.shinyi18n   message: {lang: "RNA-seq"}
```

Upstream bug in `shiny.i18n`: `subscribe: function(el, callback) { $(el).on('change', callback) }` hands jQuery's Event object to Shiny's callback, which expects a boolean. Every `update_lang()` throws. Re-wrapped after `usei18n()` — order matters, `custom/temp.js` loads *before* the i18n dependency so patching there is a silent no-op.

**4. firebase deprecation warnings** (`components/app/R/ui.R`)

`useFirebase(firestore = TRUE, analytics = TRUE)` — both args are no-ops in the installed firebase whose only effect is calling `.Deprecated()`. Dropped.

## Test

`tests/testthat/test-editor-content-ids.R` renders all 19 plot editor types and fails on any duplicate input id. Verified it fails on the pre-fix code and passes after.

## Not in this PR

- `bigdash/R/plot-module.R:632` calls `plotly::event_data("plotly_click")` with no `source`, so every plotly plot module logs *"source ID 'A' is not registered"* — 44× per dataset load in the R log, and the click-to-label handler it feeds never receives events. The fix (`event_register`) would switch on click handling for every plotly plot at once, so it wants its own PR.
- `renderpopup` / `renderfigure_2` (the zoom and editor modal plots) are initialised at 0×0 while their modal is closed. Latent — not currently throwing on the real click path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
