### PR TITLE
fix: make the colour theme store per-session, not per-process

### DIFF
--- a/components/ui/ui-ColorDefaults.R
+++ b/components/ui/ui-ColorDefaults.R
@@ -35,28 +35,64 @@ COLOR_THEME_MAPPING <- list(
 )
 
 ## ---------------------------------------------------------------
-## Singleton reactive store (module-level environment)
+## Per-session reactive store
 ## ---------------------------------------------------------------
+##
+## The store must NOT be a process-level singleton. reactiveValues() registers
+## an onDestroy handler on whatever reactive domain is current when it is
+## created, and any later write raises "Can't access reactive ...; its module
+## session has been destroyed". A store built during the first browser session
+## and cached for the process is therefore already dead for the second one:
+## reload the page and the first write (appsettings_server.R, on auth$logged)
+## fails. It also leaked one user's theme into the next session.
+##
+## So: one store per browser session, kept on the session's userData.
 
 .color_theme_env <- new.env(parent = emptyenv())
-.color_theme_env$theme <- NULL
+.color_theme_env$theme <- NULL ## fallback for use outside any session
+
+.new_color_theme <- function() {
+  do.call(shiny::reactiveValues, COLOR_THEME_DEFAULTS)
+}
+
+#' The colour theme store for the current browser session.
+#'
+#' Anchored on the *root* session rather than the calling module session: the
+#' theme is app-wide, and a module session can be torn down (its UI removed)
+#' long before the browser session ends, which would kill the store early.
+#' Module sessions share the root session's `userData`, so every board sees
+#' the same object.
+#'
+#' @param session reactive domain to anchor on; defaults to the current one
+#' @return reactiveValues
+color_theme_store <- function(session = shiny::getDefaultReactiveDomain()) {
+  if (is.null(session)) {
+    ## No reactive domain: console, tests, or UI built outside a session. A
+    ## reactiveValues created with no domain registers no onDestroy handler,
+    ## so it is never marked destroyed and is safe to keep for the process.
+    if (is.null(.color_theme_env$theme)) {
+      .color_theme_env$theme <- .new_color_theme()
+    }
+    return(.color_theme_env$theme)
+  }
+
+  root <- if (is.function(session$rootScope)) session$rootScope() else session
+  if (is.null(root$userData$color_theme)) {
+    root$userData$color_theme <- shiny::withReactiveDomain(root, .new_color_theme())
+  }
+  root$userData$color_theme
+}
 
 #' Initialise the colour theme reactive store (call once in server).
 #' @return invisible reactiveValues
 init_color_theme <- function() {
-  if (is.null(.color_theme_env$theme)) {
-    .color_theme_env$theme <- do.call(shiny::reactiveValues, COLOR_THEME_DEFAULTS)
-  }
-  invisible(.color_theme_env$theme)
+  invisible(color_theme_store())
 }
 
 #' Return the colour theme reactive store.
 #' @return reactiveValues
 get_color_theme <- function() {
-  if (is.null(.color_theme_env$theme)) {
-    init_color_theme()
-  }
-  .color_theme_env$theme
+  color_theme_store()
 }
 
 #' Save the colour theme to a user directory as JSON.


### PR DESCRIPTION
## Symptom

Reload the app in the browser and the console fills with:

```
Warning: Error in : Can't access reactive `reactiveValues9982`; its module session has been destroyed
  88: [[<-
  87: observe
  86: <observer:observeEvent(auth$logged)>
```

First browser session is fine; every reload after it fails.

## Cause

`reactiveValues()` registers an `onDestroy` handler on whatever reactive domain is current **when it is created**, and any later write raises once that domain is gone (`shiny:::destroyedReactiveError`, raised from `ReactiveValues$set` when `.destroyed`).

`init_color_theme()` cached one store in a package-level environment:

```r
.color_theme_env <- new.env(parent = emptyenv())

init_color_theme <- function() {
  if (is.null(.color_theme_env$theme)) {                     # once per R process,
    .color_theme_env$theme <- do.call(shiny::reactiveValues, # not once per session
                                      COLOR_THEME_DEFAULTS)
  }
}
```

So the store is built inside the *first* browser session and then reused for the life of the R process. On reload that session is destroyed, the next one picks up the dead object, and the first write to it — `appsettings_server.R:330`, on `auth$logged` — fails.

Reproduced standalone:

```r
a <- MockShinySession$new()
withReactiveDomain(a, { t1 <- old_get(); isolate(t1$primary <- "#111111") })
a$close()                                     # browser reload
b <- MockShinySession$new()
withReactiveDomain(b, { t2 <- old_get(); isolate(t2$primary <- "#222222") })
#> Error: Can't access reactive `reactiveValues2398`; its module session has been destroyed
```

**Second bug, same cause:** while it worked, the singleton leaked one user's theme colours into the next session on the same process.

## Fix

One store per browser session, on the session's `userData`. Anchored on `rootScope()` rather than the calling module session — the theme is app-wide, and a module session can be torn down while the browser session lives on, which would kill the store early. Module sessions share the root `userData`, so all boards still see a single store.

With no reactive domain at all (console, tests, UI built outside a session) it falls back to a process-level store. That is safe for precisely the opposite reason to the original bug: no domain means no `onDestroy` handler, so it is never marked destroyed.

`get_color_theme()` / `init_color_theme()` keep their signatures, so **none of the ~10 call sites change**.

## Verification

| check | result |
|---|---|
| after reload, second session writes theme | ok *(was the error)* |
| second session sees its own value, not session 1's | `#222222` |
| all modules in a session share one store | `TRUE` |
| works with no reactive domain | ok |

I also scanned every `.R` under `components/` for the same anti-pattern (a `reactiveValues`/`reactiveVal` assigned into a `new.env()` global) — this was the only instance.

## Note

The follow-on `Error in grep: invalid 'pattern' argument` in the same console output is a separate issue: the app's unhandled-error handler fails while reporting, which masks the real message whenever anything errors. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)