### PR TITLE
feat(dev): DEV_AUTOLOAD and an on-demand R profiler

### DIFF
--- a/components/app/R/global.R
+++ b/components/app/R/global.R
@@ -205,6 +205,7 @@ opt.default <- list(
   ENABLE_INACTIVITY = TRUE,
   INACTIVITY_TIMEOUT = 1800,
   ENABLE_ANNOT = FALSE,
+  DEV_AUTOLOAD = FALSE, ## dev/testing: skip sign-in, load example, open Dashboard
   ENABLE_METADATA = FALSE,
   ENABLE_UPGRADE = FALSE,
   ENCRYPTED_EMAIL = FALSE,

--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -120,7 +120,9 @@ app_server <- function(input, output, session) {
   } else if (authentication == "none") {
     auth <- NoAuthenticationModule(
       id = "auth",
-      show_modal = TRUE
+      ## DEV_AUTOLOAD skips the splash: show_modal = FALSE makes the module
+      ## log the user in straight away instead of waiting for "Sure I am!".
+      show_modal = !isTRUE(opt$DEV_AUTOLOAD)
     )
   } else if (authentication == "none2") {
     ## no authentication but also not showing main modal (enter)
@@ -173,6 +175,63 @@ app_server <- function(input, output, session) {
   ## TRUE while a background TileDB build is running, so re-opening the Across
   ## tab does not prompt for (or launch) a second build.
   tiledb_building <- reactiveVal(FALSE)
+
+  ## ---------------------------------------------------------------
+  ## DEV_AUTOLOAD: come up straight on the Dashboard
+  ## ---------------------------------------------------------------
+  ##
+  ## For local development and automated testing. Skips the sign-in splash
+  ## (see NoAuthenticationModule above), loads the example dataset and opens
+  ## the Dashboard, so the app reaches a usable state with no clicking.
+  ##
+  ## Requires AUTHENTICATION = none; with any real authentication method the
+  ## splash is not ours to skip and this only does the dataset half.
+  ## Never enable it on a deployed instance.
+  if (isTRUE(opt$DEV_AUTOLOAD)) {
+    ## NoAuthenticationModule only flips `logged` inside resetUSER(), which it
+    ## calls from the showLogin output's renderUI -- so with the splash
+    ## suppressed nothing logs the user in. Call the module's own resetUSER()
+    ## rather than setting $logged by hand: it also clears MODULES_LOADED,
+    ## which is a cross-session global. Without that reset the previous
+    ## session's value survives, MODULES_TO_LOAD comes out empty, and no board
+    ## UI is ever inserted -- the Dashboard opens blank.
+    shiny::isolate({
+      if (is.function(auth$resetUSER)) {
+        auth$resetUSER()
+      } else {
+        auth$logged <- TRUE
+      }
+    })
+
+    dev_autoload_started <- FALSE
+
+    shiny::observe({
+      shiny::req(isTRUE(auth$logged))
+      if (dev_autoload_started) {
+        return()
+      }
+      dev_autoload_started <<- TRUE
+      ## board.loading answers load_example() by looking for the
+      ## "example-data" row in its dataset table; bumping before that table
+      ## is populated just raises "No example data". Give it a moment.
+      shinyjs::delay(3000, {
+        info("[DEV_AUTOLOAD] loading example dataset")
+        load_example(1)
+      })
+    })
+
+    ## ignoreNULL so this only fires once a dataset is actually active; no
+    ## req() here, because observeEvent(once = TRUE) destroys itself via
+    ## on.exit() even when the handler aborts.
+    shiny::observeEvent(PGX$name,
+      {
+        info("[DEV_AUTOLOAD] dataset ready, opening Dashboard")
+        bslib::nav_select("app-sidebar", "Dashboard", session = session)
+      },
+      once = TRUE,
+      ignoreNULL = TRUE
+    )
+  }
 
   ## Default boards ------------------------------------------
   ## WelcomeBoard("welcome",

--- a/dev/run_app_profile.R
+++ b/dev/run_app_profile.R
@@ -1,0 +1,54 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
+##
+## Run the app under R's sampling profiler (Rprof), started and stopped on
+## demand, so a slow interaction can be attributed to actual R functions.
+##
+## Profiling is controlled by a sentinel file rather than a timer: get the app
+## into the state you care about first (e.g. many boards open), then switch
+## profiling on, reproduce the slowness, and switch it off. A timed window
+## anchored to app start just profiles the boot.
+##
+##   Rscript dev/run_app_profile.R          # PROF_FLAG defaults to /tmp/opg-profile.on
+##   touch  $PROF_FLAG                      # start profiling
+##   rm     $PROF_FLAG                      # stop, flushing $PROF_FILE
+##   Rscript -e 'summaryRprof("<PROF_FILE>")'
+##
+
+PROF_FILE <- Sys.getenv("PROF_FILE", "/tmp/opg-Rprof.out")
+PROF_FLAG <- Sys.getenv("PROF_FLAG", "/tmp/opg-profile.on")
+
+setwd("components/app/R")
+source("global.R")
+source("ui.R")
+source("server.R")
+
+local({
+  running <- FALSE
+  poll <- function() {
+    on.exit(later::later(poll, delay = 1))
+    wanted <- file.exists(PROF_FLAG)
+    if (wanted && !running) {
+      running <<- TRUE
+      Rprof(PROF_FILE, interval = 0.02, line.profiling = TRUE)
+      message("[PROFILE] >>> Rprof STARTED <<<")
+    } else if (!wanted && running) {
+      Rprof(NULL)
+      running <<- FALSE
+      message("[PROFILE] >>> Rprof STOPPED, wrote ", PROF_FILE, " <<<")
+    }
+  }
+  later::later(poll, delay = 1)
+})
+
+shinyApp(
+  ui = app_ui,
+  server = app_server,
+  uiPattern = ".*",
+  options = list(
+    launch.browser = FALSE,
+    host = "0.0.0.0",
+    port = 3838
+  )
+)


### PR DESCRIPTION
Two development/testing aids, both **off by default**. Split out of the plot-editor work (#1846) since they are tooling, not fixes.

## `DEV_AUTOLOAD`

Skips the sign-in splash, loads the example dataset and opens the Dashboard, so a fresh browser session reaches a usable state with no clicking. Requires `AUTHENTICATION = none`. Never enable on a deployed instance.

Two things it has to do that are not obvious:

- `show_modal = FALSE` only suppresses the splash. `NoAuthenticationModule` flips `logged` inside `resetUSER()`, which it calls from the `showLogin` output's `renderUI` — so with the splash gone, nothing logs the user in.
- It calls the module's own `resetUSER()` rather than setting `$logged` by hand, because that also clears `MODULES_LOADED` — a **cross-session global**. Without the reset the previous session's value survives, `MODULES_TO_LOAD` comes out empty and no board UI is inserted: the Dashboard opens blank while the server log cheerfully reports *"calling modules done!"*.

Verified: fresh session reaches the Dashboard with 22 tabs present and `dataview-tab` open, no interaction.

## `dev/run_app_profile.R`

Runs the app under `Rprof`, started and stopped by a **sentinel file** rather than a timer:

```
Rscript dev/run_app_profile.R
touch $PROF_FLAG     # start
rm    $PROF_FLAG     # stop, flushes $PROF_FILE
Rscript -e 'summaryRprof("<PROF_FILE>")'
```

Sentinel rather than timer because the interesting slowness only appears once many boards are open — a window anchored to app start just profiles the boot (I tried that first; it captured 5s of idle event loop).

This is what attributed the tab-switch cost: R saturated at ~100% CPU, ~40% in plot re-rendering (`glasso` 2.46s, `heatmaply` 2.70s, `seriate` 2.16s re-running on tab return) and ~12% in Shiny's per-flush output bookkeeping (`manageHiddenOutputs`).

Note: the Makefile's `run.profvis` target points at `dev/run_app_profvis.R`, which does not exist in the repo. This does not replace it.

@ESCRI11 — low-risk, both default off, but worth a glance at the `resetUSER()` call in `server.R` since that path is normally only reached on logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)