### PR TITLE
WIP: perf: load one board per click instead of the whole module group

### DIFF
--- a/components/app/R/opg_server.R
+++ b/components/app/R/opg_server.R
@@ -205,6 +205,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
             info("[SERVER:UI:1] calling Expression module")
             info("[SERVER:UI:1] calling DiffExprBoard module")
             bigdash.showMenuElement(session, "Expression")
+            ## preload expression board
             ExpressionBoard("diffexpr",
               pgx = PGX, labeltype = labeltype
             ) ->> env$diffexpr
@@ -220,6 +221,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
             info("[SERVER:UI:1] calling GeneSets module")
             info("[SERVER:UI:1] calling EnrichmentBoard module")
             bigdash.showMenuElement(session, "GeneSets")
+            ## preload enrichment board
             EnrichmentBoard("enrich",
               pgx = PGX,
               selected_gxmethods = env$diffexpr$selected_gxmethods

--- a/components/app/R/opg_server.R
+++ b/components/app/R/opg_server.R
@@ -82,6 +82,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "Clustering")
         loaded$clustering <- 0
+        reset_group_tabs(MODULE.clustering)
       }
       if (x == "Expression") {
         lapply(names(MODULE.expression$module_menu()), function(x) {
@@ -89,6 +90,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "Expression")
         loaded$expression <- 0
+        reset_group_tabs(MODULE.expression)
       }
       if (x == "GeneSets") {
         lapply(names(MODULE.enrichment$module_menu()), function(x) {
@@ -96,6 +98,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "GeneSets")
         loaded$enrichment <- 0
+        reset_group_tabs(MODULE.enrichment)
       }
       if (x == "Compare") {
         lapply(names(MODULE.compare$module_menu()), function(x) {
@@ -103,6 +106,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "Compare")
         loaded$compare <- 0
+        reset_group_tabs(MODULE.compare)
       }
       if (x == "SystemsBio") {
         lapply(names(MODULE.systems$module_menu()), function(x) {
@@ -110,6 +114,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "SystemsBio")
         loaded$systems <- 0
+        reset_group_tabs(MODULE.systems)
       }
       if (x == "MultiOmics") {
         lapply(names(MODULE.multiomics$module_menu()), function(x) {
@@ -117,6 +122,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "MultiOmics")
         loaded$multiomics <- 0
+        reset_group_tabs(MODULE.multiomics)
       }
       if (x == "WGCNA") {
         lapply(names(MODULE.wgcna$module_menu()), function(x) {
@@ -124,6 +130,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "WGCNA")
         loaded$wgcna <- 0
+        reset_group_tabs(MODULE.wgcna)
       }
       if (x == "Epigenomics") {
         lapply(names(MODULE.epigenomics$module_menu()), function(x) {
@@ -131,6 +138,7 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
         })
         bigdash.hideMenuElement(session, "Epigenomics")
         loaded$epigenomics <- 0
+        reset_group_tabs(MODULE.epigenomics)
       }
     })
 
@@ -314,7 +322,18 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
     
   })
 
-  insertBigTabUI2 <- function(ui, menu) {
+  ## `only`: insert just this tab's UI instead of the whole group's. Building a
+  ## group's UI is the larger half of opening it -- measured 3.9-6.0s of a
+  ## 5.7-9.3s first click, against 1.8-3.3s for starting its servers -- and
+  ## most of it is for boards the user has not asked for.
+  insertBigTabUI2 <- function(ui, menu, only = NULL) {
+    if (!is.null(only)) {
+      keep <- vapply(ui, function(x) identical(x[[1]], only), logical(1))
+      ui <- ui[keep]
+      if (!length(ui)) {
+        return(invisible(NULL))
+      }
+    }
     for (i in 1:length(ui)) {
       for (j in 2:length(ui[[i]])) {
         shiny::insertUI(
@@ -350,82 +369,83 @@ opg_server <- function(input, output, session, PGX, env, auth, reload_pgxdir) {
     epigenomics = 0
   )
 
+  ## ---------------------------------------------------------------
+  ## Per-board loading
+  ## ---------------------------------------------------------------
+  ##
+  ## A board group used to be materialised whole: clicking one tab built and
+  ## started every board in its group. Open Differential Expression and you
+  ## also paid for Correlation, Biomarker and TimeSeries.
+  ##
+  ## load_board() does one board. Both halves have to move together -- a board
+  ## server whose UI is not in the DOM loses the updateSelectInput() calls it
+  ## makes while initialising -- so the UI is inserted first, then that board's
+  ## server is started, then the tab is latched.
+  ##
+  ## Which boards a group can load this way is given by its `module_servers`,
+  ## a list of server functions keyed by tab name. A group without one is left
+  ## to the eager path.
+  loaded_tabs <- new.env(parent = emptyenv())
+
+  load_board <- function(tab, mod, run_server) {
+    if (is.null(tab) || isTRUE(loaded_tabs[[tab]])) {
+      return(invisible(FALSE))
+    }
+    fn <- mod$module_servers[[tab]]
+    if (is.null(fn)) {
+      return(invisible(FALSE))
+    }
+    ## Latch before running: a board that errors must not re-insert its UI on
+    ## every later click.
+    loaded_tabs[[tab]] <- TRUE
+    info("[SERVER:UI:2] loading board ", tab)
+    insertBigTabUI2(mod$module_ui2(), mod$module_menu(), only = tab)
+    run_server(fn)
+    tab_control()
+    invisible(TRUE)
+  }
+
+  ## Called wherever a group is torn down (datatype change), so its boards load
+  ## again next time they are opened.
+  reset_group_tabs <- function(mod) {
+    for (tab in names(mod$module_servers)) {
+      if (!is.null(loaded_tabs[[tab]])) rm(list = tab, envir = loaded_tabs)
+    }
+  }
+
   observeEvent(input$nav, {
     dbg("[SERVER] input$nav =", input$nav)
 
-    if (input$nav %in% c("clustersamples-tab", "clusterfeatures-tab") &&
-      loaded$clustering == 0) {
-      info("[SERVER:UI:2] reacted: calling Clustering module")
-      mod <- MODULE.clustering
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX, labeltype = labeltype)
-      loaded$clustering <- 1
-      tab_control()
+    ## Phase 1 (at dataset load) inserts the tab shells; before that there is
+    ## nothing for insertUI() to target. Acting earlier would mark the board
+    ## loaded while its UI silently went nowhere, and it would never appear --
+    ## reachable by clicking a sidebar item while the dashboard is still
+    ## initialising.
+    shiny::req(PGX$name)
+
+    if (input$nav %in% names(MODULE.clustering$module_servers)) {
+      load_board(input$nav, MODULE.clustering, function(f) f(PGX, labeltype = labeltype))
     }
-    if (input$nav %in% c("diffexpr-tab", "corr-tab", "bio-tab", "timeseries-tab") &&
-      loaded$expression == 0) {
-      info("[SERVER:UI:2] reacted: calling Expression module")
-      mod <- MODULE.expression
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX, labeltype = labeltype)
-      loaded$expression <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.expression$module_servers)) {
+      load_board(input$nav, MODULE.expression, function(f) f(PGX, labeltype = labeltype))
     }
-    if (input$nav %in% c("enrich-tab", "sig-tab", "pathway-tab", "wordcloud-tab") &&
-      loaded$enrichment == 0) {
-      info("[SERVER:UI:2] reacted: calling Enrichment module")
-      mod <- MODULE.enrichment
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX, labeltype = labeltype, env = env)
-      loaded$enrichment <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.enrichment$module_servers)) {
+      load_board(input$nav, MODULE.enrichment, function(f) f(PGX, labeltype = labeltype, env = env))
     }
-    if (input$nav %in% c("isect-tab", "comp-tab", "cmap-tab") && loaded$compare == 0) {
-      info("[SERVER:UI] reacted: calling Compare module")
-      mod <- MODULE.compare
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX, labeltype = labeltype, auth = auth, env = env, reload_pgxdir = reload_pgxdir)
-      loaded$compare <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.compare$module_servers)) {
+      load_board(input$nav, MODULE.compare, function(f) f(PGX, labeltype = labeltype, auth = auth, env = env, reload_pgxdir = reload_pgxdir))
     }
-    if (input$nav %in% c("drug-tab", "tcga-tab", "cell-tab", "pcsf-tab") &&
-      loaded$systems == 0) {
-      info("[SERVER:UI:2] reacted: calling Systems module")
-      mod <- MODULE.systems
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX)
-      loaded$systems <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.systems$module_servers)) {
+      load_board(input$nav, MODULE.systems, function(f) f(PGX))
     }
-    if (input$nav %in% c(
-      "mofa-tab", "mgsea-tab", "snf-tab", "lasagna-tab",
-      "deepnet-tab"
-    ) && loaded$multiomics == 0) {
-      info("[SERVER:UI:2] reacted: calling Multi-Omics module")
-      mod <- MODULE.multiomics
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX)
-      loaded$multiomics <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.multiomics$module_servers)) {
+      load_board(input$nav, MODULE.multiomics, function(f) f(PGX))
     }
-    if (input$nav %in% c(
-      "wgcna-tab", "mwgcna-tab", "consensus-tab",
-      "preservation-tab"
-    ) && loaded$wgcna == 0) {
-      info("[SERVER:UI:2] reacted: calling WGCNA module")
-      mod <- MODULE.wgcna
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX, save_pgx = env$save_pgx)
-      loaded$wgcna <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.wgcna$module_servers)) {
+      load_board(input$nav, MODULE.wgcna, function(f) f(PGX, save_pgx = env$save_pgx))
     }
-    if (input$nav %in% c("ideograms-tab") && loaded$epigenomics == 0) {
-      info("[SERVER:UI:2] reacted: calling Epigenomics module")
-      mod <- MODULE.epigenomics
-      insertBigTabUI2(mod$module_ui2(), mod$module_menu())
-      mod$module_server(PGX)
-      loaded$epigenomics <- 1
-      tab_control()
+    if (input$nav %in% names(MODULE.epigenomics$module_servers)) {
+      load_board(input$nav, MODULE.epigenomics, function(f) f(PGX))
     }
   })
 

--- a/components/board.clustering/R/__init.R
+++ b/components/board.clustering/R/__init.R
@@ -9,6 +9,14 @@ MODULE.clustering <- list(
       clusterfeatures = "Features"
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    "clustersamples-tab" = function(PGX, labeltype = NULL)
+      ClusteringBoard("clustersamples", pgx = PGX, labeltype = labeltype),
+    "clusterfeatures-tab" = function(PGX, labeltype = NULL)
+      FeatureMapBoard("clusterfeatures", pgx = PGX, labeltype = labeltype)
+  ),
   module_server = function(PGX, labeltype = NULL) {
     info("[SERVER] calling ClusteringBoard module")
     ClusteringBoard("clustersamples",

--- a/components/board.compare/R/__init.R
+++ b/components/board.compare/R/__init.R
@@ -46,6 +46,16 @@ MODULE.compare <- list(
       )
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    "isect-tab" = function(PGX, labeltype = NULL, auth = NULL, env = NULL, reload_pgxdir = NULL)
+      IntersectionBoard("isect", pgx = PGX, selected_gxmethods = env$diffexpr$selected_gxmethods, selected_gsetmethods = env$enrich$selected_gsetmethods),
+    "comp-tab" = function(PGX, labeltype = NULL, auth = NULL, env = NULL, reload_pgxdir = NULL)
+      CompareBoard("comp", pgx = PGX, pgx_dir = reactive(auth$user_dir), labeltype = labeltype),
+    "cmap-tab" = function(PGX, labeltype = NULL, auth = NULL, env = NULL, reload_pgxdir = NULL)
+      ConnectivityBoard("cmap", pgx = PGX, auth = auth, reload_pgxdir = reload_pgxdir)
+  ),
   module_server = function(PGX, labeltype = NULL, auth = NULL, env = NULL, reload_pgxdir = NULL) {
     IntersectionBoard("isect",
       pgx = PGX,

--- a/components/board.drugconnectivity/R/__init.R
+++ b/components/board.drugconnectivity/R/__init.R
@@ -56,6 +56,18 @@ MODULE.systems <- list(
       )
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    "drug-tab" = function(PGX)
+      DrugConnectivityBoard("drug", pgx = PGX),
+    "tcga-tab" = function(PGX)
+      TcgaBoard("tcga", pgx = PGX),
+    "cell-tab" = function(PGX)
+      SingleCellBoard("cell", pgx = PGX),
+    "pcsf-tab" = function(PGX)
+      PcsfBoard("pcsf", pgx = PGX)
+  ),
   module_server = function(PGX) {
     DrugConnectivityBoard("drug",
       pgx = PGX

--- a/components/board.enrichment/R/__init.R
+++ b/components/board.enrichment/R/__init.R
@@ -10,6 +10,18 @@ MODULE.enrichment <- list(
       wordcloud = "Word cloud"
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    ## Started eagerly at dataset load (see opg_server.R); UI only here.
+    "enrich-tab" = function(...) invisible(NULL),
+    "sig-tab" = function(PGX, labeltype = NULL, env = NULL)
+      SignatureBoard("sig", pgx = PGX, selected_gxmethods = env$diffexpr$selected_gxmethods),
+    "pathway-tab" = function(PGX, labeltype = NULL, env = NULL)
+      PathwayBoard("pathway", pgx = PGX, selected_gsetmethods = env$enrich$selected_gsetmethods),
+    "wordcloud-tab" = function(PGX, labeltype = NULL, env = NULL)
+      WordCloudBoard("wordcloud", pgx = PGX)
+  ),
   module_server = function(PGX, labeltype = NULL, env = NULL) {
     info("[SERVER] calling SignatureBoard module")
     SignatureBoard("sig",

--- a/components/board.epigenomics/R/__init.R
+++ b/components/board.epigenomics/R/__init.R
@@ -24,6 +24,12 @@ MODULE.epigenomics <- list(
       )
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    "ideograms-tab" = function(PGX)
+      EpigenomicsBoard("epigenomics", pgx = PGX)
+  ),
   module_server = function(PGX) {
     EpigenomicsBoard("epigenomics", pgx = PGX)
   },

--- a/components/board.expression/R/__init.R
+++ b/components/board.expression/R/__init.R
@@ -11,6 +11,20 @@ MODULE.expression <- list(
       bio = "Find biomarkers"
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    ## Started eagerly at dataset load (see opg_server.R), so only its UI is
+    ## still to be inserted -- but it must be registered, or load_board()
+    ## would skip the tab and the board would never appear.
+    "diffexpr-tab" = function(...) invisible(NULL),
+    "corr-tab" = function(PGX, labeltype = NULL)
+      CorrelationBoard("corr", pgx = PGX, labeltype = labeltype),
+    "bio-tab" = function(PGX, labeltype = NULL)
+      BiomarkerBoard("bio", pgx = PGX),
+    "timeseries-tab" = function(PGX, labeltype = NULL)
+      TimeSeriesBoard("timeseries", pgx = PGX, labeltype = labeltype)
+  ),
   module_server = function(PGX, labeltype = NULL) {
     info("[SERVER] calling CorrelationBoard module")
     CorrelationBoard("corr",

--- a/components/board.mofa/R/__init.R
+++ b/components/board.mofa/R/__init.R
@@ -29,6 +29,20 @@ MODULE.multiomics <- list(
       list("deepnet-tab", DeepNetUI("deepnet"))
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    "mofa-tab" = function(PGX)
+      MofaBoard("mofa", pgx = PGX),
+    "mgsea-tab" = function(PGX)
+      MGseaBoard("mgsea", pgx = PGX),
+    "snf-tab" = function(PGX)
+      SNFBoard("snf", pgx = PGX),
+    "lasagna-tab" = function(PGX)
+      LasagnaBoard("lasagna", pgx = PGX),
+    "deepnet-tab" = function(PGX)
+      DeepNetBoard("deepnet", pgx = PGX)
+  ),
   module_server = function(PGX) {
     info("[SERVER] calling MofaBoard module")
     MofaBoard("mofa", pgx = PGX)

--- a/components/board.wgcna/R/__init.R
+++ b/components/board.wgcna/R/__init.R
@@ -56,6 +56,18 @@ MODULE.wgcna <- list(
       )
     )
   },
+  ## Per-board servers, keyed by tab, so opg_server can start just the board
+  ## that was opened. module_server() above stays for the eager path.
+  module_servers = list(
+    "wgcna-tab" = function(PGX, save_pgx = NULL)
+      WgcnaBoard("wgcna", pgx = PGX, save_pgx = save_pgx),
+    "consensus-tab" = function(PGX, save_pgx = NULL)
+      ConsensusWGCNA_Board(id = "consensus", pgx = PGX),
+    "preservation-tab" = function(PGX, save_pgx = NULL)
+      PreservationWGCNA_Board(id = "preservation", pgx = PGX),
+    "mwgcna-tab" = function(PGX, save_pgx = NULL)
+      MultiWGCNA_Board("mwgcna", pgx = PGX, save_pgx = save_pgx)
+  ),
   module_server = function(PGX, save_pgx = NULL) {
     WgcnaBoard("wgcna",
       pgx = PGX,


### PR DESCRIPTION
## Why

Clicking a tab materialised its **entire module group**. Open Differential Expression and you also built and started Correlation, Biomarker and TimeSeries.

Measured first-click cost per group, instrumenting the two halves separately:

| group | total | UI insertion | server start |
|---|---|---|---|
| isect | 9.3s | **6.0s** | 3.3s |
| clustersamples | 6.6s | **4.8s** | 1.8s |
| drug | 5.7s | **3.9s** | 1.8s |

65–73% of it was building UI for boards the user had not asked for.

## What

`load_board()` loads one board. Both halves have to move together — a board server whose UI is not in the DOM loses the `updateSelectInput()` calls it makes while initialising — so the UI is inserted first, then that board's server starts, then the tab is latched (latched *before* running, so a board that errors does not re-insert its UI on every later click).

- `insertBigTabUI2()` gains `only =`, to insert a single tab's UI.
- Each group gains **`module_servers`**, its per-board servers keyed by tab name. `module_server()` is untouched, so the eager path still works.
- The 8 hand-written `if (input$nav %in% c("a-tab","b-tab",...) && loaded$x == 0)` blocks become `if (input$nav %in% names(MODULE.x$module_servers))`, so the tab list has one source of truth.
- `reset_group_tabs()` clears a group's latches wherever it is torn down on a datatype change.

**`diffexpr` and `enrich` are registered as UI-only** (`function(...) invisible(NULL)`). Their servers already start eagerly at dataset load — `env$diffexpr` is read by Enrichment and Compare, so it cannot wait for a click — but without an entry `load_board()` would skip the tab and their UI would never be inserted.

## Guard

The nav observer now waits for `PGX$name`. Clicking a sidebar item while the dashboard is still initialising would otherwise latch a board as loaded while its `insertUI()` found no target, and the board would never appear. I hit exactly that while testing.

## Verification

In the running app, clicking **only** `isect-tab`:

| | before click | after |
|---|---|---|
| `isect-tab` | 2 nodes | **2460** |
| `comp-tab` | 2 | **2** |
| `cmap-tab` | 2 | **2** |
| bound outputs | 180 | 198 |

Previously that single click built all three. Also verified every group's `module_servers` names match its `module_menu()` — that check caught the two missing entries above before they became silent no-loads.

## Relation to bigdash

This is the same mechanism as `bigTabsLazy()` in bigdash PR #37, done here in opg's own nav observer because #37 is not merged and installing it would drop the settings-scoping work. When #37 lands, this can be swapped for it — the per-tab registry maps onto it directly, and `preload = TRUE` is the equivalent of the UI-only entries.

@ESCRI11 — the part worth a careful look is the UI-only registration for `diffexpr`/`enrich`. It works, but it encodes "this board's server is started elsewhere" as a no-op function, which is easy to misread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)