### PR TITLE
refactor(boards): migrate boardHeader() to OmicsBoardUI()/OmicsBoard()

### DIFF
--- a/components/app_across/R/across_server.R
+++ b/components/app_across/R/across_server.R
@@ -125,17 +125,11 @@ AcrossBoard <- function(id, pgx, pgx_dir = reactive(NULL),
 
     query_result <- reactiveVal(NULL)
 
+    OmicsBoard("board", pgx, title = "Across Datasets", infotext = infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Across Datasets</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     shiny::observeEvent(input$zscore_info, {
       shiny::showModal(shiny::modalDialog(

--- a/components/app_across/R/across_ui.R
+++ b/components/app_across/R/across_ui.R
@@ -265,22 +265,25 @@ AcrossUI <- function(id) {
   )
 
   ## Board header spans the full width; the inputs (left) and content (right)
-  ## align on the same baseline below it.
-  bslib::layout_columns(
-    col_widths = 12,
-    gap = 0,
-    height = "calc(100vh - 60px)",
-    row_heights = list("auto", 1),
-    boardHeader(title = "Across Datasets", info_link = ns("info")),
-    bslib::layout_columns(
-      col_widths = c(3, 9),
-      fill = TRUE,
-      bslib::card(
-        bslib::card_body(
-          AcrossInputs(id)
-        )
-      ),
-      content
+  ## align on the same baseline below it. OmicsBoardUI() already splits
+  ## header (auto) / content (1fr) internally, so only the overall height
+  ## needs to be fixed here for the "100%" heights inside `content` to
+  ## resolve against.
+  div(
+    style = "height: calc(100vh - 60px);",
+    OmicsBoardUI(
+      id = ns("board"),
+      title = "Across Datasets",
+      bslib::layout_columns(
+        col_widths = c(3, 9),
+        fill = TRUE,
+        bslib::card(
+          bslib::card_body(
+            AcrossInputs(id)
+          )
+        ),
+        content
+      )
     )
   )
 }

--- a/components/board.admin/R/admin_server.R
+++ b/components/board.admin/R/admin_server.R
@@ -62,25 +62,16 @@ AdminPanelBoard <- function(id, auth, credentials_file = NULL) {
     ns <- session$ns ## NAMESPACE
     dbg("[AdminPanelBoard] >>> initializing AdminBoard...")
 
+    OmicsBoard(
+      "board", pgx = NULL, title = "Admin Panel",
+      infotext = "The Admin Panel provides administrative functions for managing
+          the OmicsPlayground platform. This panel is only accessible to
+          users with admin privileges."
+    )
+
     ## Check if user is admin - this is a critical security check
     is_admin <- reactive({
       isTRUE(auth$ADMIN)
-    })
-
-    ## ----------------------------------------------------------------------
-    ## More Info (pop up window)
-    ## ----------------------------------------------------------------------
-
-    shiny::observeEvent(input$board_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Admin Panel</strong>"),
-        shiny::HTML(
-          "The Admin Panel provides administrative functions for managing
-          the OmicsPlayground platform. This panel is only accessible to
-          users with admin privileges."
-        ),
-        easyClose = TRUE, size = "l"
-      ))
     })
 
     ## ================================================================================

--- a/components/board.admin/R/admin_ui.R
+++ b/components/board.admin/R/admin_ui.R
@@ -83,8 +83,9 @@ AdminPanelUI <- function(id) {
     )
   )
 
-  div(
-    boardHeader(title = "Admin Panel", info_link = ns("board_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Admin Panel",
     tabs
   )
 }

--- a/components/board.biomarker/R/biomarker_server.R
+++ b/components/board.biomarker/R/biomarker_server.R
@@ -29,6 +29,8 @@ BiomarkerBoard <- function(id, pgx) {
     and provides expression boxplots by phenotype classes for features present in
     the tree.", js = FALSE)
 
+    OmicsBoard("board", pgx, title = "Biomarker Selection", infotext = pdx_infotext)
+
     ## =========================================================================
     ## ======================== OBSERVERS ======================================
     ## =========================================================================
@@ -47,15 +49,6 @@ BiomarkerBoard <- function(id, pgx) {
     shiny::observeEvent(input$tabs1, {
       bigdash::update_tab_elements(input$tabs1, tab_elements)
     })
-
-    shiny::observeEvent(input$pdx_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Biomarker Board</strong>"),
-        shiny::HTML(pdx_infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
-
 
     shiny::observe({
       shiny::req(pgx$X)

--- a/components/board.biomarker/R/biomarker_ui.R
+++ b/components/board.biomarker/R/biomarker_ui.R
@@ -65,8 +65,9 @@ BiomarkerUI <- function(id) {
   imgH2 <- c("calc(60vh - 181px)", "70vh")
   fullH <- "calc(100vh - 200px)"
 
-  div(
-    boardHeader(title = "Biomarker Selection", info_link = ns("pdx_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Biomarker Selection",
     shiny::tabsetPanel(
       id = ns("tabs1"),
       shiny::tabPanel(
@@ -169,5 +170,5 @@ BiomarkerUI <- function(id) {
         )
       )
     ) ## tabsetpanel
-  ) ## div
+  ) ## OmicsBoardUI
 }

--- a/components/board.compare/R/compare_server.R
+++ b/components/board.compare/R/compare_server.R
@@ -16,17 +16,11 @@ CompareBoard <- function(id, pgx, pgx_dir = reactive(file.path(OPG, "data", "min
         js = FALSE
       )
 
+    OmicsBoard("board", pgx, title = "Compare Datasets", infotext = infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Compare Experiments</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     # Observe tabPanel change to update Settings visibility
     tab_elements <- list(

--- a/components/board.compare/R/compare_ui.R
+++ b/components/board.compare/R/compare_ui.R
@@ -210,8 +210,9 @@ CompareUI <- function(id) {
   )
 
 
-  div(
-    boardHeader(title = "Compare datasets", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Compare datasets",
     tabs
   )
 }

--- a/components/board.connectivity/R/connectivity_server.R
+++ b/components/board.connectivity/R/connectivity_server.R
@@ -23,17 +23,11 @@ ConnectivityBoard <- function(
       <br><br><center><iframe width='560' height='315' src='https://www.youtube.com/embed/4-2SkBNcTZk?si=m4qEXCuQJo6o-A9o&amp;start=38' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe></center>"
     )
 
+    OmicsBoard("board", pgx, title = "Connectivity Analysis", infotext = infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Connectivity Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     ## update choices upon change of data set
     shiny::observeEvent(pgx$model.parameters$contr.matrix, {

--- a/components/board.connectivity/R/connectivity_ui.R
+++ b/components/board.connectivity/R/connectivity_ui.R
@@ -199,9 +199,9 @@ ConnectivityUI <- function(id) {
     )
   )
 
-  ## returned UI object
-  div(
-    boardHeader(title = "Similar experiments", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Similar experiments",
     tabs
   )
 }

--- a/components/board.correlation/R/correlation_server.R
+++ b/components/board.correlation/R/correlation_server.R
@@ -10,7 +10,7 @@ CorrelationBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     fullH <- 800 ## full height of page
     rowH <- 340 ## full height of page
 
-    cor_infotext <- tspan("The <strong>Correlation Analysis Board</strong> provides statistical correlation analysis on gene level with visualisations. During the visual analysis, users can filter out some samples or collapse the samples by predetermined groups. The dark shaded area in the barplot estimates the partial correlation.", js = FALSE)
+    cor_infotext <- tspan("<center><iframe width='560' height='315' src='https://www.youtube.com/embed/IICgZVUSrpU?si=mBmZNx4z19MoAucQ&amp;start=156' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe></center><br><br>The <strong>Correlation Analysis Board</strong> provides statistical correlation analysis on gene level with visualisations. During the visual analysis, users can filter out some samples or collapse the samples by predetermined groups. The dark shaded area in the barplot estimates the partial correlation.", js = FALSE)
 
     COL <- RColorBrewer::brewer.pal(12, "Paired")[seq(1, 12, 2)]
     COL <- RColorBrewer::brewer.pal(9, "Set1")[c(2, 1, 3:9)]
@@ -18,17 +18,11 @@ CorrelationBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     COL2 <- RColorBrewer::brewer.pal(2, "Paired")[1:2]
     COL2 <- COL[1:2]
 
+    OmicsBoard("board", pgx, title = "Correlation analysis", infotext = cor_infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$data_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<center><iframe width='560' height='315' src='https://www.youtube.com/embed/IICgZVUSrpU?si=mBmZNx4z19MoAucQ&amp;start=156' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe><center>"),
-        shiny::HTML(cor_infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     # Observe tabPanel change to update Settings visibility
     tab_elements <- list(
@@ -43,14 +37,6 @@ CorrelationBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
     )
     shiny::observeEvent(input$tabs1, {
       bigdash::update_tab_elements(input$tabs1, tab_elements)
-    })
-
-    shiny::observeEvent(input$cor_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Correlation Analysis Board</strong>"),
-        shiny::HTML(cor_infotext),
-        easyClose = TRUE
-      ))
     })
 
     ## update filter choices upon change of data set

--- a/components/board.correlation/R/correlation_ui.R
+++ b/components/board.correlation/R/correlation_ui.R
@@ -144,8 +144,9 @@ CorrelationUI <- function(id) {
   )
 
   ## full page
-  div(
-    boardHeader(title = "Correlation analysis", info_link = ns("data_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Correlation analysis",
     tabs
   )
 }

--- a/components/board.drugconnectivity/R/drugconnectivity_server.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_server.R
@@ -21,6 +21,8 @@ DrugConnectivityBoard <- function(id, pgx) {
         This facilitates to quickly see and detect the similarities between contrasts for certain drugs.<br><br><br><br>
         <center><iframe width='560' height='315' src='https://www.youtube.com/embed/BtMQ7Y0NoIA?si=3T61_k_onEqsTMcr&amp;start=91' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe></center>")
 
+    OmicsBoard("board", pgx, title = "Drug Connectivity Analysis", infotext = infotext)
+
     ## ================================================================================
     ## ============================== OBSERVERS  ======================================
     ## ================================================================================
@@ -29,14 +31,6 @@ DrugConnectivityBoard <- function(id, pgx) {
       shiny::req(pgx$X)
       ct <- names(pgx$drugs)
       shiny::updateSelectInput(session, "method", choices = ct)
-    })
-
-    shiny::observeEvent(input$dsea_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Drug Connectivity Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "l"
-      ))
     })
 
     shiny::observe({

--- a/components/board.drugconnectivity/R/drugconnectivity_ui.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_ui.R
@@ -130,8 +130,9 @@ DrugConnectivityUI <- function(id) {
     )
   )
 
-  div(
-    boardHeader(title = "Drug Connectivity", info_link = ns("dsea_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Drug Connectivity",
     shiny::tabsetPanel(
       id = ns("tabs"),
       panel1,

--- a/components/board.enrichment/R/enrichment_server.R
+++ b/components/board.enrichment/R/enrichment_server.R
@@ -35,17 +35,11 @@ EnrichmentBoard <- function(id, pgx,
 
     GSET.DEFAULTMETHODS <- c("gsva", "camera", "fgsea", "fisher")
 
+    OmicsBoard("board", pgx, title = "Enrichment Analysis", infotext = gs_infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$gs_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Enrichment Analysis Board</strong>"),
-        shiny::HTML(gs_infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     shiny::observe({
       shiny::req(pgx$X)

--- a/components/board.enrichment/R/enrichment_ui.R
+++ b/components/board.enrichment/R/enrichment_ui.R
@@ -369,8 +369,9 @@ EnrichmentUI <- function(id) {
     )
   )
 
-  div(
-    boardHeader(title = "Geneset enrichment", info_link = ns("gs_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Geneset enrichment",
     bslib::layout_columns(
       col_widths = 12,
       height = fullH,

--- a/components/board.epigenomics/R/epigenomics_server.R
+++ b/components/board.epigenomics/R/epigenomics_server.R
@@ -5,14 +5,10 @@ EpigenomicsBoard <- function(id, pgx) {
   shiny::moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    shiny::observeEvent(input$board_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Epigenomics Board</strong>"),
-        shiny::HTML("Epigenomics visualizations and analyses for methylomics data."),
-        easyClose = TRUE,
-        size = "l"
-      ))
-    })
+    OmicsBoard(
+      "board", pgx, title = "Epigenomics",
+      infotext = "Epigenomics visualizations and analyses for methylomics data."
+    )
 
     shiny::observe({
       shiny::req(pgx$X, pgx$samples, pgx$genes)

--- a/components/board.epigenomics/R/epigenomics_ui.R
+++ b/components/board.epigenomics/R/epigenomics_ui.R
@@ -44,9 +44,10 @@ EpigenomicsInputs <- function(id) {
 EpigenomicsUI <- function(id) {
   ns <- shiny::NS(id)
 
-  div(
-    boardHeader(title = "Epigenomics", info_link = ns("board_info")),
-    tabs <- shiny::tabsetPanel(
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Epigenomics",
+    shiny::tabsetPanel(
       id = ns("tabs"),
       shiny::tabPanel(
         "Methylomics landscape",

--- a/components/board.featuremap/R/featuremap_server.R
+++ b/components/board.featuremap/R/featuremap_server.R
@@ -17,21 +17,13 @@ FeatureMapBoard <- function(id, pgx, labeltype = shiny::reactive("feature")) {
 <br><br><br><center><iframe width='560' height='315' src='https://www.youtube.com/embed/phm1joeZTO4?si=G1fJyxS1lDmxZEpo' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe><center>
 ", js = FALSE)
 
+    OmicsBoard("board", pgx, title = "Feature Map Analysis", infotext = infotext)
+
     ## ========================================================================
     ## ======================= OBSERVE FUNCTIONS ==============================
     ## ========================================================================
 
-    # Observer (1):
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Feature Map Analysis</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
-
-    # Observer (2): tabPanel change to update Settings visibility
+    # Observer (1): tabPanel change to update Settings visibility
     tab_elements <- list(
       "Gene" = list(
         enable = c("filter_genes"),

--- a/components/board.featuremap/R/featuremap_ui.R
+++ b/components/board.featuremap/R/featuremap_ui.R
@@ -85,8 +85,9 @@ FeatureMapUI <- function(id) {
   height2 <- c("40%", "70vh")
   fullH <- "calc(100vh - 181px)"
 
-  div(
-    boardHeader(title = "Cluster features", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Cluster features",
     shiny::tabsetPanel(
       id = ns("tabs"),
       shiny::tabPanel(

--- a/components/board.intersection/R/intersection_server.R
+++ b/components/board.intersection/R/intersection_server.R
@@ -23,6 +23,8 @@ IntersectionBoard <- function(
 
 ", js = FALSE)
 
+    OmicsBoard("board", pgx, title = "Intersection Analysis", infotext = infotext)
+
     ## delayed input
     input_comparisons <- shiny::reactive({
       input$comparisons
@@ -35,14 +37,6 @@ IntersectionBoard <- function(
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Intersection Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     ## update choices upon change of data set
     shiny::observe({

--- a/components/board.intersection/R/intersection_ui.R
+++ b/components/board.intersection/R/intersection_ui.R
@@ -125,9 +125,9 @@ IntersectionUI <- function(id) {
     )
   )
 
-  ## return this div
-  div(
-    boardHeader(title = "Compare signatures", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Compare signatures",
     tabs
   )
 }

--- a/components/board.mofa/R/board_deepnet_server.R
+++ b/components/board.mofa/R/board_deepnet_server.R
@@ -43,14 +43,7 @@ DeepNetBoard <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>WGCNA Analysis Board</strong>"),
-        shiny::HTML(infotext2),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Multi-Omics Supervised Auto-Encoder", infotext = infotext2)
 
 
     shiny::observeEvent(

--- a/components/board.mofa/R/board_deepnet_ui.R
+++ b/components/board.mofa/R/board_deepnet_ui.R
@@ -62,8 +62,9 @@ DeepNetUI <- function(id) {
   rowH1 <- 250 ## row 1 height
   rowH2 <- 440 ## row 2 height
 
-  shiny::div(
-    boardHeader(title = "Multi-Omics Supervised Auto-Encoder", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Multi-Omics Supervised Auto-Encoder",
     shiny::tabsetPanel(
       id = ns("tabs"),
 

--- a/components/board.mofa/R/board_lasagna_server.R
+++ b/components/board.mofa/R/board_lasagna_server.R
@@ -29,14 +29,7 @@ LasagnaBoard <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>LASAGNA Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "LASAGNA", infotext = infotext)
 
     # Observe tabPanel change to update Settings visibility
     tab_elements <- list(

--- a/components/board.mofa/R/board_lasagna_ui.R
+++ b/components/board.mofa/R/board_lasagna_ui.R
@@ -62,8 +62,9 @@ LasagnaUI <- function(id) {
   rowH1 <- 250
   rowH2 <- 440
 
-  shiny::div(
-    boardHeader(title = "LASAGNA", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "LASAGNA",
     shiny::tabsetPanel(
       id = ns("tabs"),
       shiny::tabPanel(

--- a/components/board.mofa/R/board_mgsea_server.R
+++ b/components/board.mofa/R/board_mgsea_server.R
@@ -30,14 +30,7 @@ MGseaBoard <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>WGCNA Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Multi-Omics GSEA", infotext = infotext)
 
     ## =====================================================================
     ## ===================== REACTIVES =====================================

--- a/components/board.mofa/R/board_mgsea_ui.R
+++ b/components/board.mofa/R/board_mgsea_ui.R
@@ -18,8 +18,9 @@ MGseaUI <- function(id) {
   rowH1 <- 250 ## row 1 height
   rowH2 <- 440 ## row 2 height
 
-  shiny::div(
-    boardHeader(title = "Multi-Omics GSEA", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Multi-Omics GSEA",
     shiny::tabsetPanel(
       id = ns("tabs"),
 

--- a/components/board.mofa/R/board_mofa_server.R
+++ b/components/board.mofa/R/board_mofa_server.R
@@ -30,14 +30,7 @@ MofaBoard <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>WGCNA Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Multi-Omics Factor Analysis", infotext = infotext)
 
 
     # Observe tabPanel change to update Settings visibility

--- a/components/board.mofa/R/board_mofa_ui.R
+++ b/components/board.mofa/R/board_mofa_ui.R
@@ -276,13 +276,16 @@ MofaUI <- function(id) {
   #  shiny::div(
   bslib::page_fillable(
     fillable_mobile = FALSE, # not working here...
-    boardHeader(title = "Multi-Omics Factor Analysis", info_link = ns("info")),
-    shiny::tabsetPanel(
-      id = ns("tabs"),
-      panel1,
-      panel2,
-      panel3,
-      panel4
+    OmicsBoardUI(
+      id = ns("board"),
+      title = "Multi-Omics Factor Analysis",
+      shiny::tabsetPanel(
+        id = ns("tabs"),
+        panel1,
+        panel2,
+        panel3,
+        panel4
+      )
     )
   )
 

--- a/components/board.mofa/R/board_snf_server.R
+++ b/components/board.mofa/R/board_snf_server.R
@@ -30,14 +30,7 @@ SNFBoard <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>WGCNA Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Similarity Network Fusion", infotext = infotext)
 
     ## ========================================================================
     ## ============================= REACTIVES ================================

--- a/components/board.mofa/R/board_snf_ui.R
+++ b/components/board.mofa/R/board_snf_ui.R
@@ -30,8 +30,9 @@ SNFUI <- function(id) {
   rowH1 <- 250 ## row 1 height
   rowH2 <- 440 ## row 2 height
 
-  shiny::div(
-    boardHeader(title = "Similarity Network Fusion", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Similarity Network Fusion",
     shiny::tabsetPanel(
       id = ns("tabs"),
       shiny::tabPanel(

--- a/components/board.pathway/R/pathway_server.R
+++ b/components/board.pathway/R/pathway_server.R
@@ -33,17 +33,11 @@ PathwayBoard <- function(id,
     <br><br><br><br>
     <center><iframe width='560' height='315' src='https://www.youtube.com/embed/BmPTfanUnR0?si=AB4FSqin7aqqYU_n&amp;start=100' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe></center>"), js = FALSE)
 
+    OmicsBoard("board", pgx, title = "Pathway Analysis", infotext = fa_infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$fa_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Functional Analysis Board</strong>"),
-        shiny::HTML(fa_infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     shiny::observe({
       shiny::req(pgx$X)

--- a/components/board.pathway/R/pathway_ui.R
+++ b/components/board.pathway/R/pathway_ui.R
@@ -209,8 +209,9 @@ PathwayUI <- function(id) {
     ) ## Enrichment map tabpanel
   ) ## end of tabset panel
 
-  page_ui <- div(
-    boardHeader(title = "Pathway Analysis", info_link = ns("fa_info")),
+  page_ui <- OmicsBoardUI(
+    id = ns("board"),
+    title = "Pathway Analysis",
     tabs
   )
   return(page_ui)

--- a/components/board.pcsf/R/pcsf_server.R
+++ b/components/board.pcsf/R/pcsf_server.R
@@ -13,6 +13,8 @@ PcsfBoard <- function(id, pgx) {
       "This PCSF analysis module..."
     )
 
+    OmicsBoard("board", pgx, title = "PCSF Network Analysis", infotext = as.character(pcsf_info))
+
     ## ========================================================================
     ## ============================ OBSERVERS =================================
     ## ========================================================================
@@ -28,18 +30,7 @@ PcsfBoard <- function(id, pgx) {
       bigdash::update_tab_elements(input$tabs, tab_elements)
     })
 
-    my_observers[[2]] <- observeEvent(input$pcsf_info, {
-      showModal(
-        modalDialog(
-          title = tags$strong("PCSF Network Analysis"),
-          pcsf_info,
-          easyClose = TRUE,
-          size = "xl"
-        )
-      )
-    })
-
-    my_observers[[3]] <- observe({
+    my_observers[[2]] <- observe({
       if (is.null(pgx)) {
         return(NULL)
       }

--- a/components/board.pcsf/R/pcsf_ui.R
+++ b/components/board.pcsf/R/pcsf_ui.R
@@ -43,10 +43,9 @@ pcsf_graph_info <- "Prize-collection Steiner Forest solution for the top differe
 
 PcsfUI <- function(id) {
   ns <- NS(id)
-  tagList(
-    boardHeader(
-      title = "Prize-Collecting Steiner Forest", info_link = ns("pcsf_info")
-    ),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Prize-Collecting Steiner Forest",
     shiny::tabsetPanel(
       id = ns("tabs"),
       shiny::tabPanel(

--- a/components/board.signature/R/signature_server.R
+++ b/components/board.signature/R/signature_server.R
@@ -39,17 +39,11 @@ SignatureBoard <- function(id, pgx,
     CITRICACIDCYCLE.METABOLITES <- "57288 16947 32805 30887 16810 15380 15741 18012 30797 30744 15346 15846 16908 16238 17877 17552 15996 16526 15377"
     UREACYCLE.METABOLITES <- "15729 16349 16941 16467 16199 17672 17053 18012"
 
+    OmicsBoard("board", pgx, title = "Signature Analysis", infotext = infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Signature Analysis Board</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "xl"
-      ))
-    })
 
     ## ------------------------ observe/reactive function  -----------------------------
 

--- a/components/board.signature/R/signature_ui.R
+++ b/components/board.signature/R/signature_ui.R
@@ -247,8 +247,9 @@ SignatureUI <- function(id) {
     )
   )
 
-  div(
-    boardHeader(title = "Test signatures", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Test signatures",
     bslib::layout_columns(
       col_widths = c(8, 4),
       left.panel,

--- a/components/board.singlecell/R/singlecell_server.R
+++ b/components/board.singlecell/R/singlecell_server.R
@@ -25,17 +25,11 @@ SingleCellBoard <- function(id, pgx) {
       '<center><iframe width="560" height="315" src="https://www.youtube.com/embed/BtMQ7Y0NoIA?si=pebNlzthvdZF7h5o&amp;start=35" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></center>'
     )
 
+    OmicsBoard("board", pgx, title = "Cell Profiling", infotext = infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$infotext, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Single Cell Board</strong>"),
-        shiny::HTML(infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     ## update filter choices upon change of data set
     shiny::observe({

--- a/components/board.singlecell/R/singlecell_ui.R
+++ b/components/board.singlecell/R/singlecell_ui.R
@@ -30,8 +30,9 @@ SingleCellUI <- function(id) {
   modH <- TABLE_HEIGHT_MODAL
 
   ns <- shiny::NS(id) ## namespace
-  div(
-    boardHeader(title = "Cell Profiling", info_link = ns("infotext")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Cell Profiling",
     shiny::tabsetPanel(
       id = ns("tabs"),
       shiny::tabPanel(

--- a/components/board.tcga/R/tcga_server.R
+++ b/components/board.tcga/R/tcga_server.R
@@ -21,20 +21,11 @@ TcgaBoard <- function(id, pgx) {
       "The survival probabilities are computed and tested using the Kaplan-Meier method."
     )
 
+    OmicsBoard("board", pgx, title = "TCGA", infotext = as.character(tcga_tcgasurv_info))
+
     ## ========================================================================
     ## ============================ OBSERVERS =================================
     ## ========================================================================
-
-    observeEvent(input$tcga_info, {
-      showModal(
-        modalDialog(
-          title = tags$strong("TCGA Analysis Board"),
-          tcga_tcgasurv_info,
-          easyClose = TRUE,
-          size = "l"
-        )
-      )
-    })
 
     observe({
       if (is.null(pgx)) {

--- a/components/board.tcga/R/tcga_ui.R
+++ b/components/board.tcga/R/tcga_ui.R
@@ -67,11 +67,9 @@ tcga_info <- "This analysis module computes the survival probability in (more th
 TcgaUI <- function(id) {
   ns <- NS(id)
 
-  div(
-    boardHeader(
-      title = "TCGA",
-      info_link = ns("tcga_info")
-    ),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "TCGA",
     tabsetPanel(
       id = ns("tabs1"),
       tabPanel(

--- a/components/board.timeseries/R/board_server.R
+++ b/components/board.timeseries/R/board_server.R
@@ -23,6 +23,8 @@ TimeSeriesBoard <- function(id,
        title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
        encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
+    OmicsBoard("board", pgx, title = "TimeSeries", infotext = clust_infotext)
+
     tab_elements <- list(
       "Clustering" = list(
         enable = NULL,
@@ -36,14 +38,6 @@ TimeSeriesBoard <- function(id,
 
     shiny::observeEvent(input$tabs1, {
       bigdash::update_tab_elements(input$tabs1, tab_elements)
-    })
-
-    shiny::observeEvent(input$board_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>TimeSeries Board</strong>"),
-        shiny::HTML(clust_infotext),
-        easyClose = TRUE, size = "xl"
-      ))
     })
 
     shiny::observeEvent(pgx$samples, {

--- a/components/board.timeseries/R/board_ui.R
+++ b/components/board.timeseries/R/board_ui.R
@@ -70,8 +70,9 @@ TimeSeriesUI <- function(id) {
 
   parallel_info <- HTML("<b>Time clustering</b> groups features with similar variation in time together using KNN. We can see different trends in the expression of groups of genes, or so-called gene modules. The parallel plot is interactive so you can manually order the time points.")
 
-  div(
-    boardHeader(title = "Time Series", info_link = ns("board_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Time Series",
     shiny::tabsetPanel(
       id = ns("tabs1"),
       shiny::tabPanel(

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -66,16 +66,9 @@ UploadBoard <- function(id,
       )
     })
 
-    shiny::observeEvent(input$upload_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>How to upload new data</strong>"),
-        shiny::HTML(module_infotext),
-        easyClose = TRUE,
-        size = "xl"
-      ))
-    })
-
     module_infotext <- HTML('<center><iframe width="560" height="315" src="https://www.youtube.com/embed/YTzLkio4M_4?si=eg24X_GphkzAqLGe" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe><center>')
+
+    OmicsBoard("board", pgx, title = "Upload New", infotext = as.character(module_infotext))
 
     observeEvent(auth$logged, {
       all_species <- playbase::allSpecies(col = "species_name")

--- a/components/board.upload/R/upload_ui.R
+++ b/components/board.upload/R/upload_ui.R
@@ -126,14 +126,17 @@ UploadUI <- function(id) {
   )
 
   spinner <- div(computing_spinner_ui("Computation in progress..."),
-    style="position:absolute; top:50px; right:-20px;")
-  
+    style="position:absolute; top:10px; right:20px;")
+
   ui <- div(
-    shinybusy::use_busy_bar(color="#AA0101", height="4px"),  
-    boardHeader(title = "Upload New", info_link = ns("upload_info"),
-      right = shinyjs::hidden(spinner) ),
-    uiOutput(ns("upload_wizard")),
-    body
+    shinybusy::use_busy_bar(color="#AA0101", height="4px"),
+    OmicsBoardUI(
+      id = ns("board"),
+      title = "Upload New",
+      div(style = "position: relative;", shinyjs::hidden(spinner)),
+      uiOutput(ns("upload_wizard")),
+      body
+    )
   )
   return(ui)
 }

--- a/components/board.user/R/appsettings_server.R
+++ b/components/board.user/R/appsettings_server.R
@@ -11,16 +11,11 @@ AppSettingsBoard <- function(id, auth, pgx) {
     ## module for system resources
     user_table_resources_server("resources", pgx = pgx)
 
-    shiny::observeEvent(input$board_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>User Profile</strong>"),
-        shiny::HTML(
-          "The User Settings page allows you to change overall settings
+    OmicsBoard(
+      "board", pgx, title = "Settings",
+      infotext = "The User Settings page allows you to change overall settings
                 that will alter how the app looks and functions."
-        ),
-        easyClose = TRUE, size = "l"
-      ))
-    })
+    )
 
     ## ----------------------------------------------------------------
     ## AI Features — provider, credentials and model selection

--- a/components/board.user/R/appsettings_ui.R
+++ b/components/board.user/R/appsettings_ui.R
@@ -11,9 +11,9 @@ AppSettingsUI <- function(id) {
 
   initial_is_basic <- (opt$USER_LEVEL == "BASIC")
 
-  div(
-    boardHeader(title = "Settings", info_link = ns("board_info")),
-
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Settings",
     bslib::navset_pill_list(
       id = ns("tabs1"),
       widths = c(2,10),

--- a/components/board.user/R/userprofile_server.R
+++ b/components/board.user/R/userprofile_server.R
@@ -8,17 +8,12 @@ UserProfileBoard <- function(id, auth, nav_count) {
     ns <- session$ns ## NAMESPACE
     dbg("[UserProfileBoard] >>> initializing UserBoard...")
 
-    shiny::observeEvent(input$board_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>User Profile</strong>"),
-        shiny::HTML(
-          "The User Profile page allows you to view and change your
+    OmicsBoard(
+      "board", pgx = NULL, title = "User Profile",
+      infotext = "The User Profile page allows you to view and change your
                 subscription plan and to view the latest news about application
                 development."
-        ),
-        easyClose = TRUE, size = "l"
-      ))
-    })
+    )
 
     output$plan <- renderUI({
       p(

--- a/components/board.user/R/userprofile_ui.R
+++ b/components/board.user/R/userprofile_ui.R
@@ -8,9 +8,11 @@ UserProfileUI <- function(id) {
 
   div(
     class = "row",
-    boardHeader(title = "User Profile", info_link = ns("board_info")),
-    shiny::tabsetPanel(
-      id = ns("tabs1"),
+    OmicsBoardUI(
+      id = ns("board"),
+      title = "User Profile",
+      shiny::tabsetPanel(
+        id = ns("tabs1"),
       shiny::tabPanel(
         "User profile",
         bslib::layout_columns(
@@ -35,5 +37,6 @@ UserProfileUI <- function(id) {
         )
       )
     )
+  )
   )
 }

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_server.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_server.R
@@ -28,14 +28,7 @@ ConsensusWGCNA_Board <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Multi-Omics WGCNA Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Consensus WGCNA", infotext = infotext)
 
     # Observe tabPanel change to update Settings visibility
     tab_elements <- list(

--- a/components/board.wgcna/R/consensusWGCNA/consensuswgcna_ui.R
+++ b/components/board.wgcna/R/consensusWGCNA/consensuswgcna_ui.R
@@ -47,8 +47,9 @@ ConsensusWGCNA_UI <- function(id) {
   rowH1 <- 250 ## row 1 height
   rowH2 <- 440 ## row 2 height
 
-  shiny::div(
-    boardHeader(title = "Consensus WGCNA", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Consensus WGCNA",
     shiny::tabsetPanel(
       id = ns("tabs"),
 

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
@@ -28,14 +28,7 @@ MultiWGCNA_Board <- function(id, pgx, save_pgx = NULL) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Multi-Omics WGCNA Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Multiomics WGCNA", infotext = infotext)
 
     # Observe tabPanel change to update Settings visibility
     tab_elements <- list(

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_ui.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_ui.R
@@ -76,8 +76,9 @@ MultiWGCNA_UI <- function(id) {
   rowH1 <- 250 ## row 1 height
   rowH2 <- 440 ## row 2 height
 
-  shiny::div(
-    boardHeader(title = "Multiomics WGCNA", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Multiomics WGCNA",
     shiny::tabsetPanel(
       id = ns("tabs"),
 

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_server.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_server.R
@@ -28,14 +28,7 @@ PreservationWGCNA_Board <- function(id, pgx) {
         title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>'
 
-    shiny::observeEvent(input$info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>Preservation WGCNA Board</strong>"),
-        shiny::HTML(infotext),
-        size = "xl",
-        easyClose = TRUE
-      ))
-    })
+    OmicsBoard("board", pgx, title = "Preservation WGCNA", infotext = infotext)
 
     # Observe tabPanel change to update Settings visibility
     tab_elements <- list(

--- a/components/board.wgcna/R/preservationWGCNA/preservationwgcna_ui.R
+++ b/components/board.wgcna/R/preservationWGCNA/preservationwgcna_ui.R
@@ -47,8 +47,9 @@ PreservationWGCNA_UI <- function(id) {
   rowH1 <- 250 ## row 1 height
   rowH2 <- 440 ## row 2 height
 
-  shiny::div(
-    boardHeader(title = "Preservation WGCNA", info_link = ns("info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Preservation WGCNA",
     shiny::tabsetPanel(
       id = ns("tabs"),
 

--- a/components/board.wordcloud/R/wordcloud_server.R
+++ b/components/board.wordcloud/R/wordcloud_server.R
@@ -12,17 +12,11 @@ WordCloudBoard <- function(id, pgx) {
 <center><iframe width='560' height='315' src='https://www.youtube.com/embed/BmPTfanUnR0?si=2irSbCjCBRgQf5Wd&amp;start=190' title='YouTube video player' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share' referrerpolicy='strict-origin-when-cross-origin' allowfullscreen></iframe></center>
 "), js = FALSE)
 
+    OmicsBoard("board", pgx, title = "WordCloud Analysis", infotext = wc_infotext)
+
     ## ================================================================================
     ## ======================= OBSERVE FUNCTIONS ======================================
     ## ================================================================================
-
-    shiny::observeEvent(input$wc_info, {
-      shiny::showModal(shiny::modalDialog(
-        title = shiny::HTML("<strong>WordCloud Analysis Board</strong>"),
-        shiny::HTML(wc_infotext),
-        easyClose = TRUE, size = "l"
-      ))
-    })
 
     shiny::observe({
       # shiny::req(pgx$gset.meta)

--- a/components/board.wordcloud/R/wordcloud_ui.R
+++ b/components/board.wordcloud/R/wordcloud_ui.R
@@ -94,8 +94,9 @@ WordCloudUI <- function(id) {
       )
     )
   )
-  div(
-    boardHeader(title = "Word cloud", info_link = ns("wc_info")),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Word cloud",
     tabs
   )
 }

--- a/components/modules/SummaryBoard.R
+++ b/components/modules/SummaryBoard.R
@@ -20,11 +20,9 @@ SummaryBoardInputs <- function(id) {
 SummaryBoardUI <- function(id) {
   ns <- shiny::NS(id) ## namespace
 
-  div(
-    boardHeader(
-      title = "Summary",
-      info_link = ns("summary_info")
-    ),
+  OmicsBoardUI(
+    id = ns("board"),
+    title = "Summary",
     bslib::layout_columns(
       col_widths = 12,
       height = "calc(100vh - 124px)",
@@ -63,18 +61,7 @@ SummaryBoard <- function(id, pgx) {
     ## ========================================================================
     ## ============================ OBSERVERS =================================
     ## ========================================================================
-    summary_info <- "Summary"
-
-    observeEvent(input$summary_info, {
-      showModal(
-        modalDialog(
-          title = tags$strong("Summary Board"),
-          summary_info,
-          easyClose = TRUE,
-          size = "l"
-        )
-      )
-    })
+    OmicsBoard("board", pgx, title = "Summary", infotext = "Summary")
 
     output$bullet_points <- shiny::renderUI({
       txt <- pgx$wgcna$report$bullets

--- a/components/ui/ui-boardHeader.R
+++ b/components/ui/ui-boardHeader.R
@@ -68,7 +68,7 @@ OmicsBoardUI <- function(id, title, ..., info=TRUE) {
         class = "quick-button", style="border: 0px; background-color: transparent;"),
         style="margin: 28px 5px -20px 0; padding: 0 0 0 80px;")
     ),
-    ...
+    div(...)
   )
 }
 


### PR DESCRIPTION
## Summary

- Migrates every remaining `board.*` package (21 packages, some with multiple sub-boards: `mofa`/`snf`/`mgsea`/`deepnet`/`lasagna`, `wgcna` consensus/preservation/multi, `user` appsettings/userprofile), plus `app_across` and `modules/SummaryBoard.R`, from the bare `boardHeader()` + `observeEvent(input$..._info, showModal(...))` pattern onto `OmicsBoardUI()`/`OmicsBoard()` — matching what `dataview`, `clustering`, `expression`, `wgcna` and all of `app_qsee` already use.
- This is prep work: `OmicsBoardUI` is the natural single injection point for wiring up bigdash's `bd_visibility_probe()`/`bd_is_visible()` later, so hidden boards' Plotly/iheatmapr plots can be purged app-wide the way `app_qsee` already does. That wiring is a deliberately separate follow-up, not part of this PR.
- Fixes a latent bug in `OmicsBoardUI()` itself (`components/ui/ui-boardHeader.R`): its `bslib::layout_columns(row_heights = list("auto", 1), ...)` silently assumed callers always pass exactly one object for the content row. `board.upload`'s original UI had three sibling elements instead of one; converting it as-is broke the header/content grid (a big blank gap above the visible content, no error). Wrapped `OmicsBoardUI`'s `...` in `div(...)` — a no-op for every existing single-child caller, but makes this class of bug impossible for any future board.

## Test plan

- [x] Every changed file parses (`Rscript -e "parse(...)"`) and was diff-reviewed line-by-line against the original `boardHeader()` call site to confirm only the header/info-modal block was touched.
- [x] Live-clicked through every board reachable with the bundled `example-data` (proteomics) dataset on `dev/run_app.R`: header renders (title, video-tutorial icon, current-dataset display), info modal opens with the correct text/video, no console errors.
- [x] Special cases verified individually: `board.admin`/`userprofile` (no `pgx`, pass `pgx = NULL`), `board.correlation` (iframe folded from modal title into `infotext`), `board.upload` (multi-child bug found, fixed centrally in `OmicsBoardUI`, re-verified).
- [x] WGCNA consensus/preservation/multi and the MOFA family boards need a multiomics dataset to reach in the UI — not available in this session, so those were verified via parse + diff only (identical structure to already-verified siblings in the same families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)