### PR TITLE
perf(js): stop the popover handler walking the page on every open

### DIFF
--- a/components/app/R/www/temp.js
+++ b/components/app/R/www/temp.js
@@ -193,9 +193,16 @@ Shiny.addCustomMessageHandler('redirect_nonce', function(message) {
 var hrefUpdatedStatus = {};  // Object to track href update status for each popover
 
 document.addEventListener('shown.bs.popover', function(event) {
-	// Get the popover container (Bootstrap 5 attaches the popover to the body by default)
-	var popover = document.body.querySelector('.popover');
-  
+	// The popover that was just shown, found through the trigger's own
+	// aria-describedby (Bootstrap points it at the tip while that tip is open).
+	// document.body.querySelector('.popover') walked the whole page instead --
+	// every board and every node inside every drawn SVG -- to reach a popover
+	// Bootstrap appends at the end of <body>, and returned the wrong one
+	// whenever more than one was open.
+	var trigger = event.target;
+	var popoverId = trigger && trigger.getAttribute && trigger.getAttribute('aria-describedby');
+	var popover = popoverId ? document.getElementById(popoverId) : null;
+
 	if (!popover) {
 	  console.log("Popover not found.");
 	  return;
@@ -244,4 +251,10 @@ document.addEventListener('shown.bs.popover', function(event) {
   
 	// Start observing the target node for configured mutations
 	observer.observe(targetNode, config);
+
+	// Dropped when the popover closes. Without this every single show left a
+	// live observer behind, for the whole session.
+	trigger.addEventListener('hidden.bs.popover', function () {
+	  observer.disconnect();
+	}, { once: true });
   });


### PR DESCRIPTION
## Why

Companion to the bigdash JS perf PR. Same root cause: `display:none` stops a
subtree being painted, but not being *walked*, and a drawn Plotly SVG is 5-15k
nodes. **The improvement holds with `ENABLE_PLOTLY_PURGE = FALSE`** — this is
independent of visibility gating and purging.

## What changed

`components/app/R/www/temp.js`, the `shown.bs.popover` handler, which runs every
time a plot card's download popover opens.

It found its popover with `document.body.querySelector('.popover')`. That walks
the page in document order — every board, every node inside every drawn SVG — to
reach something Bootstrap appends at the *end* of `<body>`. Two further defects
rode along: it returned the first popover in the DOM rather than the one just
shown (wrong target whenever two were open), and it left a `MutationObserver`
behind on every single show, never disconnected.

Now: the tip is resolved through the trigger's own `aria-describedby` (Bootstrap
points it at the open tip) and `getElementById` — O(1), no walk, always the right
popover — and the observer is disconnected on `hidden.bs.popover`.

## Verification

The `aria-describedby` mechanism was confirmed in a browser against this
Bootstrap/bslib stack. The handler itself has **not** been exercised in the app:
worth checking at review that a plot's download button still starts disabled and
becomes clickable once its href arrives (console would show `"Popover not found."`
if the lookup missed).

## Scope

One commit, one file. Companion PR: bigomics/bigdash#43, which carries the same treatment for the
popover helpers, the purge scan and the activity tracker.
