### PR TITLE
feat(upload): gate PGX computation behind explicit Start confirmation

### DIFF
--- a/components/board.upload/R/upload_module_computepgx.R
+++ b/components/board.upload/R/upload_module_computepgx.R
@@ -41,8 +41,8 @@ upload_module_computepgx_server <- function(
   upload_gset_methods,
   process_counter,
   reset_upload_text_input,
-  probetype,
-  recompute_pgx = NULL
+  recompute_pgx = NULL,
+  clear_upload
 ) {
   shiny::moduleServer(
     id,
@@ -381,18 +381,6 @@ upload_module_computepgx_server <- function(
               )
             )
           },
-          if (!is.null(probetype()) && probetype() == "running" && upload_datatype() != "methylomics") {
-            shiny::div(
-              style = "display: flex; justify-content: center; align-items: center;",
-              shiny::tags$h4(
-                "Probe type detection still running, please wait...",
-                style = "color: red;"
-              )
-            )
-          },
-          shiny::div(
-            shiny::uiOutput(ns("probetype_result"))
-          ),
           shiny::div(
             shiny::actionLink(ns("options"), "Computation options",
               icon = icon("cog", lib = "glyphicon")
@@ -791,19 +779,8 @@ upload_module_computepgx_server <- function(
       output$input_recap2 <- renderUI({
         tagList(
           shiny::HTML("<b>Data type:</b>", upload_datatype()),
-          shiny::HTML("<br><b>Organism:</b>", upload_organism()),
-          shiny::HTML("<br><b>Probe type:</b>", probetype())
+          shiny::HTML("<br><b>Organism:</b>", upload_organism())
         )
-      })
-
-      output$probetype_result <- shiny::renderUI({
-        p <- probetype()
-        if (is.null(p) || p == "error") {
-          shiny::div(
-            style = "display: flex; justify-content: center; align-items: center; color: red;",
-            shiny::tags$p("Probes not recognized, please check organism or your probe names.")
-          )
-        }
       })
 
       output$timeseries_checkbox <- renderUI({
@@ -929,6 +906,7 @@ upload_module_computepgx_server <- function(
       # Define a reactive value to store the process object
       PROCESS_LIST <- list()
       computedPGX <- shiny::reactiveVal(NULL)
+      dispatch_computation <- shiny::reactiveVal(FALSE)
       custom_geneset <- list(gmt = NULL, info = NULL)
       custom_fc <- NULL
       processx_error <- list(user_email = NULL, pgx_name = NULL, pgx_path = NULL, error = NULL)
@@ -1031,7 +1009,9 @@ upload_module_computepgx_server <- function(
         }
       })
 
-      shiny::observeEvent(upload_wizard(), {
+      shiny::observeEvent( upload_wizard(), {
+        dispatch_computation(FALSE) ## reset any stale dispatch signal
+
         if (!is.null(upload_wizard()) && upload_wizard() != "wizard_finished") {
           return(NULL)
         }
@@ -1046,20 +1026,102 @@ upload_module_computepgx_server <- function(
           return(NULL)
         }
 
-        ## bail out if probetype task is not finished or has error
-        p <- probetype()
-        if (is.null(p) || grepl("error", tolower(p)) || p == "") {
-          dbg("[computepgx_server:upload_wizard] ERROR probetype failed")
-          shinyalert::shinyalert("ERROR", "probetype detection failed",
-            type = "error"
+        ## -----------------------------------------------------------
+        ## Check probe type against selected organism
+        ## -----------------------------------------------------------
+        detected_probetype <- NULL
+        if (upload_datatype() != "methylomics") {
+          probes <- rownames(countsRT())
+          annot.cols <- colnames(annotRT())
+          shinyalert::shinyalert(
+            title = "Checking your data...",
+            text = "Analysing probe types. Please wait.",
+            type = "info",
+            closeOnClickOutside = FALSE,
+            showConfirmButton = FALSE
           )
-          return(NULL)
+
+          dbg("[computepgx_server:upload_wizard] checking probetype...")
+          organism <- upload_organism()
+          dbg("[computepgx_server:upload_wizard] organism = ", organism)
+          
+          detected <- playbase::check_species_probetype(
+            probes = probes,
+            datatype = upload_datatype(),
+            test_species = unique(c(organism, c("Human", "Mouse", "Rat"))),
+            annot.cols = annot.cols
+          )
+          dbg("[computepgx_server:upload_wizard] detected = ", detected)
+          
+          alt.text <- ""
+          e0 <- length(detected) == 0
+          e1 <- is.null(detected[[organism]])
+          e2 <- all(is.na(detected[[organism]]))
+          e3 <- !(organism %in% names(detected))
+          task_failed <- (e0 || e1 || e2 || e3)
+          alt.text <- ""
+          if (task_failed) {
+            dbg("[computepgx_server:upload_wizard] ERROR probetype not recognized")
+
+            detected_probetype <- NULL
+            detected_species <- setdiff(names(detected), organism)
+            alt.species <- paste(detected_species, collapse = " or ")
+            if (length(alt.species)) {
+              alt.text <- paste0("Are these perhaps <b>", alt.species, "</b>?")
+            }
+            if (upload_datatype() == "metabolomics") {
+              alt.text <- paste0("Valid probes are: <b>ChEBI (recommended), HMDB, PubChem, or KEGG</b>")
+            }
+
+            shinyalert::shinyalert(
+              title = "Probes not recognized!",
+              text = paste0(
+                "Error. Your probes do not match any probe type for <b>",
+                organism, "</b>. Please check your probe names and select ",
+                "another organism. ", alt.text
+              ),
+              type = "error",
+              timer = 0,
+              immediate = TRUE,
+              size = "s",
+              html = TRUE
+            )
+
+            ## abort
+            dbg("[computepgx_server:upload_wizard] upload aborted")
+            clear_upload()
+            
+            return(NULL)
+          }
+
+          detected_probetype <- paste(detected[[organism]], collapse = "+")
+          dbg("[computepgx_server:upload_wizard] detected probetype = ",
+            detected_probetype)
+          
+          ## wrong datatype — warn but don't block
+          if (any(grepl("PROT", detected_probetype)) &&
+            !(grepl("proteomics", upload_datatype(), ignore.case = TRUE))) {
+            shinyalert::shinyalert(
+              title = "Is this proteomics data?",
+              text = paste0(
+                "Warning. Your data seems to be <b>proteomics</b> but you have selected ",
+                "<b>", upload_datatype(), "</b> as data type."
+              ),
+              type = "warning",
+              size = "s",
+              html = TRUE
+            )
+          }
+        } else {
+          detected_probetype <- "CpG probes"
         }
-        shiny::req(!(p %in% c("error", "running", ""))) ## wait for process??
 
         ## -----------------------------------------------------------
         ## Retrieve the most recent matrices from reactive values
         ## -----------------------------------------------------------
+        dbg("[computepgx_server:upload_wizard] preparing for computing dispatch")
+        dbg("[computepgx_server:upload_wizard] 1:")
+        
         counts <- countsRT()
         countsX <- countsX()
 
@@ -1088,6 +1150,8 @@ upload_module_computepgx_server <- function(
           pgx_preprocess <- preprocess()
         }
 
+        dbg("[computepgx_server:upload_wizard] 2:")
+        
         ## -----------------------------------------------------------
         ## Set statistical methods and run parameters
         ## -----------------------------------------------------------
@@ -1109,6 +1173,8 @@ upload_module_computepgx_server <- function(
         ## at least do meta.go, infer
         extra.methods <- unique(c("meta.go", "infer", extra.methods))
 
+        dbg("[computepgx_server:upload_wizard] 3:")
+        
         ## ----------------------------------------------------------------------
         ## Start computation
         ## ----------------------------------------------------------------------
@@ -1125,7 +1191,8 @@ upload_module_computepgx_server <- function(
           batch.pars <- compute_settings$bc_method$param
         }
         ## --------------------------------
-
+        dbg("[computepgx_server:upload_wizard] 4:")
+        
         only.proteincoding <- FALSE # DEPRECATED: use exclude_genes
         excl.immuno <- ("excl.immuno" %in% flt)
         excl.xy <- ("excl.xy" %in% flt)
@@ -1144,7 +1211,8 @@ upload_module_computepgx_server <- function(
         libx.dir <- paste0(sub("/$", "", lib.dir), "x") ## set to .../libx
         pgx_save_folder <- auth$user_dir
 
-
+        dbg("[computepgx_server:upload_wizard] 5:")
+        
         ## -----------------------------------------------
         ## Collect user-defined metadata from inputs
         ## -----------------------------------------------
@@ -1165,6 +1233,8 @@ upload_module_computepgx_server <- function(
           ## If all empty, set to NULL
           if (length(user_metadata) == 0) user_metadata <- NULL
         }
+
+        dbg("[computepgx_server:upload_wizard] 6:")
 
         ## -----------------------------------------------
         ## Covariates to regress out
@@ -1192,6 +1262,8 @@ upload_module_computepgx_server <- function(
           regress_ccs = ifelse("Cell cycle scores" %in% covariates, TRUE, FALSE)
         )
 
+        dbg("[computepgx_server:upload_wizard] 7:")
+        
         ## Resolve proteomics subtype from is.olink / is.nulisa reactives
         datatype_subtype <- NULL
         if (upload_datatype() == "proteomics") {
@@ -1204,6 +1276,8 @@ upload_module_computepgx_server <- function(
           }
         }
 
+        dbg("[computepgx_server:upload_wizard] 8:")
+        
         create_ai_reports <- is.null(input$create_ai_reports) || isTRUE(input$create_ai_reports)
         create_ai_infographics <- isTRUE(input$create_ai_infographics)
         llm_model <- getUserOption(session, "llm_model")
@@ -1237,6 +1311,8 @@ upload_module_computepgx_server <- function(
           }
         }
 
+        dbg("[computepgx_server:upload_wizard] preparing params list")
+        
         ## Define create_pgx function arguments
         params <- list(
           organism = upload_organism(),
@@ -1246,7 +1322,7 @@ upload_module_computepgx_server <- function(
           preprocess = pgx_preprocess,
           azimuth_ref = azimuth_ref(),
           contrasts = contrasts,
-          probe_type = probetype(),
+          probe_type = detected_probetype,
           # ------- extra tables ---------
           annot_table = pgx_annot,
           custom.geneset = custom_geneset,
@@ -1302,6 +1378,13 @@ upload_module_computepgx_server <- function(
           sendSuccessMessageToUser = sendSuccessMessageToUser
         )
 
+        ## -----------------------------------------------------------
+        ## Show confirmation popup with 10-second countdown and cancel.
+        ## Computation starts only if not cancelled.
+        ## -----------------------------------------------------------
+
+        dbg("[computepgx_server:upload_wizard] preparing for computing dispatch")
+
         shinyalert::shinyalert(
           title = "Crunching your data!",
           text = stringr::str_squish("Your dataset will be computed in the background.
@@ -1309,8 +1392,20 @@ upload_module_computepgx_server <- function(
             When it is ready, it will appear in your dataset library. Most datasets
             take between 30 - 60 minutes to complete."),
           type = "info",
-          timer = 60000
+          immediate = TRUE,
+          timer = 0,
+          closeOnClickOutside = FALSE,
+          showCancelButton = TRUE,
+          confirmButtonText = "Start",
+          cancelButtonText = "Cancel",
+          callbackR = function(value) {
+            if (isTRUE(value)) {
+              dispatch_computation(TRUE)
+            }
+          }
         )
+
+        dbg("[computepgx_server:upload_wizard] waiting for Start")        
         bigdash.selectTab(
           session,
           selected = "load-tab"
@@ -1327,39 +1422,47 @@ upload_module_computepgx_server <- function(
         try(rm(annot_table))
         try(rm(custom_geneset))
 
-        process_counter(process_counter() + 1)
-        dbg("[compute PGX process] : starting processx nr: ", process_counter())
-        dbg("[compute PGX process] : process tmpdir = ", tmpdir)
-        dbg("[compute PGX process] : see error.log => tail -f", paste0(tmpdir, "/processx-error.log"))
+        ## Wait for dispatch signal (confirmed or timer expired) before
+        ## starting the background process.
+        shiny::observeEvent(dispatch_computation(), {
+          req(dispatch_computation())
+          dbg("[computepgx_server:upload_wizard] execute dispatch!")
+          
+          process_counter(process_counter() + 1)
+          dbg("[compute PGX process] : starting processx nr: ", process_counter())
+          dbg("[compute PGX process] : process tmpdir = ", tmpdir)
+          dbg("[compute PGX process] : see error.log => tail -f", paste0(tmpdir, "/processx-error.log"))
 
-        ## write compute transaction to log file, similar to share log
-        log.file <- file.path(ETC, "PGXCOMPUTE.log")
-        log.entry <- data.frame(date = format(Sys.time(), tz = "CET"), user = auth$email, tmpdir = tmpdir)
-        if (file.exists(log.file)) {
-          write.table(log.entry, file = log.file, col.names = FALSE, row.names = FALSE, sep = ",", append = TRUE)
-        } else {
-          write.table(log.entry, file = log.file, col.names = TRUE, row.names = FALSE, sep = ",")
-        }
+          ## write compute transaction to log file, similar to share log
+          log.file <- file.path(ETC, "PGXCOMPUTE.log")
+          log.entry <- data.frame(date = format(Sys.time(), tz = "CET"), user = auth$email, tmpdir = tmpdir)
+          if (file.exists(log.file)) {
+            write.table(log.entry, file = log.file, col.names = FALSE, row.names = FALSE, sep = ",", append = TRUE)
+          } else {
+            write.table(log.entry, file = log.file, col.names = TRUE, row.names = FALSE, sep = ",")
+          }
 
-        new.job <- list(
-          process = processx::process$new(
-            "Rscript",
-            args = c(script_path, tmpdir, OPG),
-            supervise = TRUE,
-            stderr = "|",
-            stdout = "|"
-          ),
-          number = process_counter(),
-          dataset_name = gsub("[ ]", "_", input$selected_name),
-          raw_dir = raw_dir(),
-          stderr = c(),
-          stdout = c()
-        )
-        session$sendCustomMessage("warnOnExit", TRUE)
+          new.job <- list(
+            process = processx::process$new(
+              "Rscript",
+              args = c(script_path, tmpdir, OPG),
+              supervise = TRUE,
+              stderr = "|",
+              stdout = "|"
+            ),
+            number = process_counter(),
+            dataset_name = gsub("[ ]", "_", input$selected_name),
+            raw_dir = raw_dir(),
+            stderr = c(),
+            stdout = c()
+          )
+          session$sendCustomMessage("warnOnExit", TRUE)
 
-        ## append to process list
-        PROCESS_LIST <<- c(PROCESS_LIST, list(new.job))
-      }) ## end observe input$compute
+          ## append to process list
+          PROCESS_LIST <<- c(PROCESS_LIST, list(new.job))
+        }) ## end observeEvent(dispatch_computation)
+
+      }) ## end observeEvent(upload_wizard)
 
       check_process_status <- reactive({
         if (process_counter() == 0) {

--- a/components/board.upload/R/upload_module_preview_counts.R
+++ b/components/board.upload/R/upload_module_preview_counts.R
@@ -29,9 +29,11 @@ upload_table_preview_counts_server <- function(id,
 
     GEO_alert_shown <- reactiveVal(FALSE)
 
-    table_data <- shiny::reactive({
+    table_data <- shiny::eventReactive( uploaded$counts.csv,
+    {
       shiny::req(!is.null(uploaded$counts.csv))
       dt <- uploaded$counts.csv
+
       nrow0 <- nrow(dt)
       ncol0 <- ncol(dt)
       MAXROW <- 1000

--- a/components/board.upload/R/upload_server.R
+++ b/components/board.upload/R/upload_server.R
@@ -32,39 +32,24 @@ UploadBoard <- function(id,
     show_comparison_builder <- shiny::reactiveVal(TRUE)
     selected_contrast_input <- shiny::reactiveVal(TRUE)
     reset_upload_text_input <- shiny::reactiveVal(0)
-    probetype <- shiny::reactiveVal("running")
-
     compute_settings <- shiny::reactiveValues()
 
-    # add task to detect probetype using annothub
-    checkprobes_task <- ExtendedTask$new(function(organism, datatype, probes, annot.cols) {
-      future_promise({
-        detected <- playbase::check_species_probetype(
-          probes = probes,
-          datatype = datatype,
-          test_species = unique(c(organism, c("Human", "Mouse", "Rat"))),
-          annot.cols = annot.cols
-        )
-        detected
-      })
-    })
-
-    output$navheader <- shiny::renderUI({
-      fillRow(
-        flex = c(NA, 1, NA),
-        shiny::div(
-          id = "navheader-current-section",
-          HTML("Upload data &nbsp;"),
-          shiny::actionLink(
-            ns("module_info"), "",
-            icon = shiny::icon("info-circle"),
-            style = "color: #ccc;"
-          )
-        ),
-        shiny::br(),
-        shiny::div(pgx$name, id = "navheader-current-dataset")
-      )
-    })
+    ## output$navheader <- shiny::renderUI({
+    ##   fillRow(
+    ##     flex = c(NA, 1, NA),
+    ##     shiny::div(
+    ##       id = "navheader-current-section",
+    ##       HTML("Upload data &nbsp;"),
+    ##       shiny::actionLink(
+    ##         ns("module_info"), "",
+    ##         icon = shiny::icon("info-circle"),
+    ##         style = "color: #ccc;"
+    ##       )
+    ##     ),
+    ##     shiny::br(),
+    ##     shiny::div(pgx$name, id = "navheader-current-dataset")
+    ##   )
+    ## })
 
     module_infotext <- HTML('<center><iframe width="560" height="315" src="https://www.youtube.com/embed/YTzLkio4M_4?si=eg24X_GphkzAqLGe" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe><center>')
 
@@ -270,7 +255,7 @@ UploadBoard <- function(id,
       {
         list(uploaded$counts.csv)
       },
-      {
+      {        
         ## --------------------------------------------------------
         ## Single matrix counts check
         ## --------------------------------------------------------
@@ -322,7 +307,7 @@ UploadBoard <- function(id,
           } else {
             checked_for_log(TRUE)
           }
-        }
+        }        
         return(list(res = res, olink = olink, nulisa = nulisa))
       }
     )
@@ -331,7 +316,7 @@ UploadBoard <- function(id,
       {
         list(checked_for_log(), uploaded_counts()$res)
       },
-      {
+      {        
         ## get uploaded counts
         checked <- NULL
         res <- uploaded_counts()$res
@@ -635,7 +620,7 @@ UploadBoard <- function(id,
       )
 
       wizard <- wizardR::wizard(
-        id = ns("upload_wizard"),
+        id = ns("upload_wizard_nav"),
         width = 90,
         height = 75,
         modal = TRUE,
@@ -877,25 +862,25 @@ UploadBoard <- function(id,
         }
 
         if (is.null(result_alert)) {
-          if (input$upload_wizard == "step_samples") {
+          if (input$upload_wizard_nav == "step_samples") {
             shinyalert::shinyalert(
               title = "Upload your samples!",
               text = "Please finish the current step before proceeding.",
               type = "warning"
             )
-          } else if (input$upload_wizard == "step_counts") {
+          } else if (input$upload_wizard_nav == "step_counts") {
             shinyalert::shinyalert(
               title = "Upload your data!",
               text = "Please finish the current step before proceeding.",
               type = "warning"
             )
-          } else if (input$upload_wizard == "step_comparisons") {
+          } else if (input$upload_wizard_nav == "step_comparisons") {
             shinyalert::shinyalert(
               title = "Create at least one comparison!",
               text = "Upload or build your comparisons.",
               type = "warning"
             )
-          } else if (input$upload_wizard == "step_compute") {
+          } else if (input$upload_wizard_nav == "step_compute") {
             shinyalert::shinyalert(
               title = "Start the computation!",
               text = "Please finish the current step before proceeding.",
@@ -911,41 +896,41 @@ UploadBoard <- function(id,
 
     # lock/unlock wizard for counts.csv
     observeEvent(
-      list(uploaded$counts.csv, checked_counts(), input$upload_wizard),
+      list(uploaded$counts.csv, checked_counts(), input$upload_wizard_nav),
       {
-        req(input$upload_wizard == "step_counts")
+        req(input$upload_wizard_nav == "step_counts")
         chk <- checked_counts()$status
         if (is.null(chk) || chk != "OK") {
-          wizardR::lock("upload_wizard")
+          wizardR::lock("upload_wizard_nav")
         } else if (!is.null(chk) && chk == "OK") {
-          wizardR::unlock("upload_wizard")
+          wizardR::unlock("upload_wizard_nav")
         }
       }
     )
 
     # lock/unlock wizard for samples.csv
     observeEvent(
-      list(uploaded$samples.csv, checked_samples_counts(), input$upload_wizard),
+      list(uploaded$samples.csv, checked_samples_counts(), input$upload_wizard_nav),
       {
-        req(input$upload_wizard == "step_samples")
+        req(input$upload_wizard_nav == "step_samples")
         chk <- checked_samples_counts()$status
         if (is.null(chk) || chk != "OK") {
-          wizardR::lock("upload_wizard")
+          wizardR::lock("upload_wizard_nav")
         } else if (!is.null(chk) && chk == "OK") {
-          wizardR::unlock("upload_wizard")
+          wizardR::unlock("upload_wizard_nav")
         }
       }
     )
 
     # lock wizard at Comparison step
     observeEvent(
-      list(input$upload_wizard, modified_ct()),
+      list(input$upload_wizard_nav, modified_ct()),
       {
-        req(input$upload_wizard == "step_comparisons")
+        req(input$upload_wizard_nav == "step_comparisons")
         if (is.null(modified_ct()) || ncol(modified_ct()) == 0 || is.null(checked_contrasts()) || is.null(checked_samples_counts()) || is.null(checked_counts())) {
-          wizardR::lock("upload_wizard")
+          wizardR::lock("upload_wizard_nav")
         } else {
-          wizardR::unlock("upload_wizard")
+          wizardR::unlock("upload_wizard_nav")
         }
       }
     )
@@ -953,17 +938,16 @@ UploadBoard <- function(id,
     # lock wizard it compute step
     observeEvent(
       list(
-        input$upload_wizard,
+        input$upload_wizard_nav,
         upload_name(),
         upload_datatype(),
         upload_description(),
         ## upload_organism(),
         upload_gset_methods(),
-        upload_gx_methods(),
-        probetype()
+        upload_gx_methods()
       ),
       {
-        req(input$upload_wizard == "step_compute")
+        req(input$upload_wizard_nav == "step_compute")
 
         pgx_files <- playbase::pgxinfo.read(auth$user_dir, file = "datasets-info.csv")
         if (!is.null(upload_name()) && upload_name() %in% pgx_files$dataset) {
@@ -1000,24 +984,37 @@ UploadBoard <- function(id,
           upload_name(NULL)
         }
 
-        probetype.finished <- !(probetype() %in% c("error", "running"))
-
         if (is.null(upload_name()) ||
           upload_name() == "" ||
           upload_description() == "" ||
           is.null(upload_description()) ||
           is.null(upload_gx_methods()) ||
-          is.null(upload_gset_methods()) ||
-          !probetype.finished
+          is.null(upload_gset_methods())
         ) {
-          wizardR::lock("upload_wizard")
+          wizardR::lock("upload_wizard_nav")
         } else {
-          wizardR::unlock("upload_wizard")
+          wizardR::unlock("upload_wizard_nav")
         }
       }
     )
 
-
+    clear_upload <- function() {
+      isolate({
+        lapply(names(uploaded), function(i) uploaded[[i]] <- NULL)
+        lapply(names(checklist), function(i) checklist[[i]] <- NULL)
+        upload_organism(input$selected_organism)
+        upload_name(NULL)
+        upload_description(NULL)
+        show_comparison_builder(TRUE)
+        selected_contrast_input(FALSE)
+        loaded_samples(FALSE)
+        sum_techreps(FALSE) ## new az
+        orig_sample_matrix(NULL)
+        orig_counts_matrix(NULL) ## new az
+        vars_selected(NULL)
+      })
+    }
+    
     # observe show_modal and start modal
     shiny::observeEvent(
       list(new_upload()),
@@ -1039,23 +1036,11 @@ UploadBoard <- function(id,
           return(NULL)
         }
         
-        isolate({
-          lapply(names(uploaded), function(i) uploaded[[i]] <- NULL)
-          lapply(names(checklist), function(i) checklist[[i]] <- NULL)
-          upload_organism(input$selected_organism)
-          upload_name(NULL)
-          upload_description(NULL)
-          show_comparison_builder(TRUE)
-          selected_contrast_input(FALSE)
-          loaded_samples(FALSE)
-          sum_techreps(FALSE) ## new az
-          orig_sample_matrix(NULL)
-          orig_counts_matrix(NULL) ## new az
-          vars_selected(NULL)
-        })
+        ## clear all uploaded
+        clear_upload()
         
         reset_upload_text_input(reset_upload_text_input() + 1)
-        wizardR::reset("upload_wizard")
+        wizardR::reset("upload_wizard_nav")
 
         if (input$selected_organism == "No organism") {
           shinyalert::shinyalert(
@@ -1069,8 +1054,8 @@ UploadBoard <- function(id,
         if (enable_upload) {
           MAX_DS_PROCESS <- 1
           if (process_counter() < MAX_DS_PROCESS) {
-            wizardR::lock("upload_wizard")
-            wizardR::wizard_show(ns("upload_wizard"))
+            wizardR::lock("upload_wizard_nav")
+            wizardR::wizard_show(ns("upload_wizard_nav"))
             if (!is.null(recompute_pgx())) {
               pgx <- recompute_pgx()
               upload_organism(pgx$organism)
@@ -1097,129 +1082,6 @@ UploadBoard <- function(id,
             type = "warning",
             closeOnClickOutside = FALSE
           )
-        }
-      }
-    )
-
-    ## ===============================================================================
-    ## =========================== EXTENDED TASK =====================================
-    ## ===============================================================================
-
-    ## check probetypes we have counts and every time upload_species changes
-    observeEvent(
-      {
-        ## list(uploaded$counts.csv, upload_organism())
-        list(uploaded$counts.csv)
-      },
-      {
-        shiny::req(uploaded$counts.csv, upload_organism())
-        probes <- rownames(uploaded$counts.csv)
-        annot <- uploaded$annot.csv
-        annot.cols <- colnames(uploaded$annot.csv)
-        probetype("running")
-
-        checkprobes_task$invoke(
-          organism = upload_organism(),
-          datatype = upload_datatype(),
-          probes = probes,
-          annot.cols = annot.cols
-        )
-      }
-    )
-
-    observeEvent(
-      checkprobes_task$status(),
-      {
-        dbg(
-          "[UploadServer:observeEvent:checkprobes_task] task$status = ",
-          checkprobes_task$status()
-        )
-
-        if (checkprobes_task$status() == "error") {
-          probetype("error")
-          return(NULL)
-        }
-        if (checkprobes_task$status() != "success") {
-          probetype("running")
-          return(NULL)
-        }
-
-        ## inspect ExtendedTask results
-        detected <- checkprobes_task$result()
-        dbg(
-          "[UploadServer:observeEvent:checkprobes_task] task$result: names(detected) = ",
-          names(detected)
-        )
-
-        organism <- upload_organism()
-        alt.text <- ""
-
-        # detect_probetypes return NULL if no probetype is found
-        # across a given organism if NULL, probetype matching failed
-        e0 <- length(detected) == 0
-        e1 <- is.null(detected[[organism]])
-        e2 <- all(is.na(detected[[organism]]))
-        e3 <- !(organism %in% names(detected))
-        task_failed <- (e0 || e1 || e2 || e3)
-        alt.text <- ""
-        detected_probetype <- NULL
-        if (task_failed) {
-          # handle probetype mismatch failures: assign "error" to detected_probetype
-          detected_probetype <- "error"
-          detected_species <- setdiff(names(detected), organism)
-          alt.species <- paste(detected_species, collapse = " or ")
-          if (length(alt.species)) {
-            # check if ANY organism matched the probes, if yes add a hint to the user
-            alt.text <- c(alt.text, paste0(
-              "Are these perhaps <b>",
-              alt.species, "</b>?"
-            ))
-          }
-          if (upload_datatype() == "metabolomics") {
-            # overwrite alt.text for metabolomics
-            alt.text <- c(alt.text, paste0("Valid probes are: <b>ChEBI (recommended), HMDB, PubChem, or KEGG</b>"))
-          }
-        } else {
-          # handle success: assign detected probetype to detected_probetype
-          detected_probetype <- paste(detected[[organism]], collapse = "+")
-        }
-
-        if (upload_datatype() != "methylomics") {
-          probetype(detected_probetype) ## set RV
-          info("[checkprobes_task$result] detected_probetype = ", detected_probetype)
-
-          if (!is.null(detected_probetype) && detected_probetype == "error") {
-            info("[UploadBoard] ExtendedTask result has ERROR")
-            shinyalert::shinyalert(
-              title = "Probes not recognized!",
-              text = paste0(
-                "Error. Your probes do not match any probe type for <b>",
-                organism, "</b>. Please check your probe names and select ",
-                "another organism. ", paste(alt.text, collapse = " ")
-              ),
-              type = "error",
-              size = "s",
-              html = TRUE
-            )
-          }
-
-          ## wrong datatype. just give warning. or should we change datatype?
-          if (detected_probetype != "error" &&
-            any(grepl("PROT", detected_probetype)) &&
-            !(grepl("proteomics", upload_datatype(), ignore.case = TRUE))) {
-            shinyalert::shinyalert(
-              title = "Is this proteomics data?",
-              text = paste0(
-                "Warning. Your data seems to be <b>proteomics</b> but you have selected ",
-                "<b>", upload_datatype(), "</b> as data type."
-              ),
-              type = "warning",
-              size = "s",
-              html = TRUE
-            )
-          }
-        } else {
-          probetype("CpG probes")
         }
       }
     )
@@ -1283,7 +1145,7 @@ UploadBoard <- function(id,
       show_comparison_builder = show_comparison_builder,
       selected_contrast_input = selected_contrast_input,
       upload_datatype = upload_datatype,
-      upload_wizard = shiny::reactive(input$upload_wizard),
+      upload_wizard = shiny::reactive(input$upload_wizard_nav),
       auth = auth
     )
 
@@ -1360,7 +1222,7 @@ UploadBoard <- function(id,
       height = "100%",
       compute_settings = compute_settings,
       inactivityCounter = inactivityCounter,
-      upload_wizard = reactive(input$upload_wizard),
+      upload_wizard = reactive(input$upload_wizard_nav),
       upload_name = upload_name,
       upload_description = upload_description,
       upload_datatype = upload_datatype,
@@ -1372,8 +1234,8 @@ UploadBoard <- function(id,
       upload_gset_methods = upload_gset_methods,
       process_counter = process_counter,
       reset_upload_text_input = reset_upload_text_input,
-      probetype = probetype,
-      recompute_pgx = recompute_pgx
+      recompute_pgx = recompute_pgx,
+      clear_upload = clear_upload
     )
 
     ## ------------------------------------------------


### PR DESCRIPTION
## What
Refactors the upload wizard compute step:

- **Synchronous probe-type check** — `playbase::check_species_probetype()` now runs inside the compute step behind a blocking 'Checking your data...' alert, replacing the background `ExtendedTask` and the `probetype` reactive ('running'/'error' states) that was plumbed through `UploadBoard`.
- **Mismatch handling** — on failure the alert hints at alternative organisms (or valid metabolomics probe IDs), the upload is aborted and reset via a new `clear_upload()` helper (extracted from the `new_upload` observer).
- **Compute gated behind explicit confirmation** — the 'Crunching your data!' popup now has Start/Cancel buttons instead of a 60s timer auto-start; the processx job is dispatched only after the user clicks Start (`dispatch_computation` signal).
- **Wizard id renamed** `upload_wizard` → `upload_wizard_nav` to avoid collision with the reactive passed into the compute module.
- **Preview fix** — counts preview `table_data` is now `eventReactive(uploaded$counts.csv)` so it re-renders after a fresh upload or reset.

## Out of scope (left in working tree for separate PRs)
`app/R/ui.R` (`useShinyalert(force = TRUE)`), `00SourceAll.R` group-registry sources, `etc/OPTIONS`, `VERSION`.

## Testing
- Upload example/batch data, walk the wizard to the compute step: probe-check popup → Start / Cancel
- Mismatched probes for the selected organism → error alert + upload reset
- Methylomics upload → probe check skipped
