### PR TITLE
fix: stop hiding phenotype-confounded columns in batch dropdown

### DIFF
--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -1019,8 +1019,10 @@ upload_module_normalization_server <- function(
             return(NULL)
           }
           pars <- playbase::get_model_parameters(X, samples, pheno = NULL, contrasts = contrasts)
-          all.pars <- setdiff(colnames(samples), pars$pheno.pars)
-          all.pars <- union(all.pars, pars$batch.pars)
+          safe.pars <- setdiff(colnames(samples), pars$pheno.pars)
+          safe.pars <- union(safe.pars, pars$batch.pars)
+          confounded.pars <- intersect(colnames(samples), pars$pheno.pars)
+          all.pars <- c(safe.pars, confounded.pars)
           names(all.pars) <- ifelse(all.pars %in% pars$batch.pars,
             paste(all.pars, "*"), all.pars
           )

--- a/components/board.upload/R/upload_module_normalization.R
+++ b/components/board.upload/R/upload_module_normalization.R
@@ -1021,7 +1021,7 @@ upload_module_normalization_server <- function(
           pars <- playbase::get_model_parameters(X, samples, pheno = NULL, contrasts = contrasts)
           safe.pars <- setdiff(colnames(samples), pars$pheno.pars)
           safe.pars <- union(safe.pars, pars$batch.pars)
-          confounded.pars <- intersect(colnames(samples), pars$pheno.pars)
+          confounded.pars <- setdiff(intersect(colnames(samples), pars$pheno.pars), safe.pars)
           all.pars <- c(safe.pars, confounded.pars)
           names(all.pars) <- ifelse(all.pars %in% pars$batch.pars,
             paste(all.pars, "*"), all.pars


### PR DESCRIPTION
## Context

Reanalyzing Mekata K, et al., "Molecular endotypes in sepsis: integration of multicohort transcriptomics based on RNA sequencing." *Journal of Intensive Care* 2025;13:30. DOI: 10.1186/s40560-025-00802-1, PMC12123803. The dataset merges four cohorts with sharply uneven phenotype distributions:

| Cohort    | Groups                                         |
| --------- | ---------------------------------------------- |
| GSE63042  | sepsis: 106, sirs: 23                          |
| GSE131411 | control: 10, sepsis: 63, cardiogenic_shock: 33 |
| GSE185263 | sepsis: 348, control: 44                       |
| GSE222393 | sepsis: 58 (only)                              |

Cohort and phenotype are strongly confounded here. This is exactly the case where a user needs cohort as the batch-correction variable. However, the variable is not shown in the drop down menu.

## Bug

`components/board.upload/R/upload_module_normalization.R`, the `selectizeInput` around line 1318, pulls its choices from `getBatchParams()` (lines 1009-1030), which calls `playbase::get_model_parameters()`. That function F-tests every `samples.csv` column against the contrast/phenotype and splits columns into `pheno.pars` (looks like the outcome) and `batch.pars` (looks like a real batch, `p.pheno > 0.05`). Columns landing in `pheno.pars` get dropped from the dropdown via `setdiff()`, with only a `grep("batch", colname)` name match as a rescue. "cohort" doesn't match that pattern, so it disappears from the list entirely. No way to select it, even deliberately.

## Fix

Stop dropping confounded columns, reorder instead. `getBatchParams()` now returns all `samples.csv` columns: autodetected `batch.pars` and other safe columns first, phenotype-confounded columns appended at the end. Explicit selections already pass through `pgx-compute.R` (lines 602-606) unmodified, so picking a confounded column now works end to end. This change only affects what's visible in the dropdown, not the compute path.

This is an opinionated fix, so please let me know if you have any better idea.
