### PR TITLE
fix: restore markdown rendering after inline tool markers

### DIFF
--- a/components/app_copilot/R/CopilotChatServer.R
+++ b/components/app_copilot/R/CopilotChatServer.R
@@ -350,10 +350,15 @@ CopilotChatServer <- function(
         )
       })
 
+      # The trailing blank line is load-bearing. A `<details>` block is a
+      # CommonMark type-6 HTML block, which runs until a blank line — without
+      # one, everything the model streams next is passed through as raw HTML,
+      # so an answer opening with "### Main findings" renders as literal text
+      # rather than a heading. A single "\n" is not enough; it takes two.
       marker <- paste0(
         '<details><summary>\U0001F527 ', req$name %||% "tool", '</summary>',
         '<pre>', args_text, '</pre>',
-        '</details>'
+        '</details>\n\n'
       )
       tryCatch(
         shinychat::chat_append_message(

--- a/tests/testthat/test-copilot-chat-server.R
+++ b/tests/testthat/test-copilot-chat-server.R
@@ -282,6 +282,10 @@ test_that("on_tool_request appends a collapsible <details> marker", {
       expect_match(captured_content, "<details>")
       expect_match(captured_content, "show_plot")
       expect_match(captured_content, "pca")
+      # Must end in a blank line: `<details>` is a CommonMark type-6 HTML
+      # block that runs until one, so without it an answer opening with
+      # "### Main findings" renders as literal text instead of a heading.
+      expect_match(captured_content, "</details>\n\n$")
     }
   )
 })


### PR DESCRIPTION
## Summary

A user reported that the copilot was mixing what looked like its own thinking into the answer text. The trace turned out to be DeepSeek's native tool-call syntax (`<｜DSML｜tool_calls>`) arriving on the content channel while OpenRouter parsed the same call separately, machine markup rather than reasoning, but it read to the user as exposed internals. Reproduced on roughly 1 in 3 tool-using turns on the Balanced tier; Deep (gpt-5.6-terra) never showed it.

Chasing that surfaced a second presentation bug in the same chat surface: answers opening with a heading rendered `### Main findings` as literal text.

## Depends

This PR depends on https://github.com/bigomics/omicsagentovi/pull/4, where most of the work happened.
