### PR TITLE
feat: hide copilot reports tab outside dev mode

### DIFF
--- a/components/app_copilot/R/CopilotBoardUI.R
+++ b/components/app_copilot/R/CopilotBoardUI.R
@@ -56,9 +56,13 @@ CopilotBoardUI <- function(id) {
               "Workspace"
             )
           )),
+          # Dev-only panel. Hidden, its controls fall back to defaults in
+          # CopilotReportsServer: Summary staged, tools connected.
           bslib::navset_underline(
             bslib::nav_panel("Documents", CopilotDocsUI(ns("docs"))),
-            bslib::nav_panel("Reports", CopilotReportsUI(ns("reports"))),
+            if (isTRUE(opt$DEVMODE)) {
+              bslib::nav_panel("Reports", CopilotReportsUI(ns("reports")))
+            },
             bslib::nav_panel("Settings", CopilotChatSettings(ns("chat"))),
             bslib::nav_panel("History", CopilotHistoryUI(ns("history")))
           )

--- a/components/app_copilot/R/CopilotReportsServer.R
+++ b/components/app_copilot/R/CopilotReportsServer.R
@@ -127,6 +127,7 @@ CopilotReportsServer <- function(id, pgx) {
         if (slot %in% used) return(FALSE)
         val <- input[[.input_id(i)]]
         if (is.null(val)) {
+          # NULL outside DEVMODE: no checkboxes rendered, use defaults.
           return(slot %in% .copilot_report_default_selection(available))
         }
         isTRUE(val)
@@ -147,6 +148,7 @@ CopilotReportsServer <- function(id, pgx) {
       invisible(NULL)
     }
 
+    # NULL is the non-DEVMODE path (panel not rendered) — keep tools on.
     tools_enabled <- shiny::reactive({
       is.null(input$tools_enabled) || isTRUE(input$tools_enabled)
     })


### PR DESCRIPTION
## Summary

Hides the Reports tab in the copilot Workspace panel. Beta testers found it confusing, it exposes which precomputed reports get staged into the agent's context, which is developer detail rather than a choice a user should have to
make.

Set `DEVMODE = TRUE` in `etc/OPTIONS` to get the tab back, gated the same way as the existing Runs and Tools tabs.

Nothing else changes for users. With the panel unrendered its inputs stay NULL, so CopilotReportsServer falls through to its defaults: the Summary report is still staged and analysis tools stay connected.