### PR TITLE
feat: show locked bigomics ai models with masked labels

### DIFF
--- a/components/board.user/R/appsettings_server.R
+++ b/components/board.user/R/appsettings_server.R
@@ -54,12 +54,32 @@ AppSettingsBoard <- function(id, auth, pgx) {
       choices
     }
 
+    ## BigOmics' pinned models route through a backend (OpenRouter) to a
+    ## specific lab (DeepSeek, OpenAI, Google) that users aren't meant to see
+    ## in a locked, non-BYOK menu -- show a friendly product name instead of
+    ## the raw id. Other providers' ids (e.g. "gpt-5.4-nano") are already
+    ## user-facing, so this only rewrites the bigomics catalog.
+    bigomics_model_labels <- c(
+      "openrouter:deepseek/deepseek-v4-flash" = "Deepseek V4",
+      "openrouter:openai/gpt-5.6-terra"       = "GPT-5.6",
+      "gemini-3.1-flash-image-preview"        = "Gemini 3.1 Nano Banana"
+    )
+
+    display_menu_choices <- function(provider, choices) {
+      if (!identical(provider, "bigomics") || !length(choices)) {
+        return(choices)
+      }
+      labels <- ifelse(choices %in% names(bigomics_model_labels),
+                       bigomics_model_labels[choices], choices)
+      stats::setNames(choices, labels)
+    }
+
     update_ai_model_menus <- function(provider, live_models = NULL) {
       for (input_id in names(ai_menu_choices)) {
         choices <- provider_menu_choices(provider, input_id, live_models)
         shiny::updateSelectInput(
           session, input_id,
-          choices = choices,
+          choices = display_menu_choices(provider, choices),
           selected = if (length(choices)) choices[[1]] else character(0)
         )
       }
@@ -296,6 +316,16 @@ AppSettingsBoard <- function(id, auth, pgx) {
 
       if (base_locked) shinyjs::disable("enable_ai") else shinyjs::enable("enable_ai")
       if (provider_locked) shinyjs::disable("ai_provider") else shinyjs::enable("ai_provider")
+
+      ## BigOmics runs a fixed model per menu -- show the resolved model but
+      ## block editing (disabled select, no live "Test & load"), instead of
+      ## hiding the panel. Non-BYOK users are pinned to bigomics above, so
+      ## fall back to it here too rather than trusting a forged provider.
+      provider <- if (byok) input$ai_provider else "bigomics"
+      models_locked <- base_locked || identical(provider, "bigomics")
+      for (input_id in names(ai_menu_choices)) {
+        if (models_locked) shinyjs::disable(input_id) else shinyjs::enable(input_id)
+      }
     })
 
     ## Effective AI-enabled state = deployment licence (opt$ENABLE_AI) AND the

--- a/components/board.user/R/appsettings_ui.R
+++ b/components/board.user/R/appsettings_ui.R
@@ -124,10 +124,12 @@ AppSettingsUI <- function(id) {
             bslib::card_header("AI Models"),
             bslib::card_body(
               gap = "0.3em",
-              ## Hide the model menus for the BigOmics-managed backend — users
-              ## don't choose (or need to see) which models BigOmics runs.
+              ## Always show the model menus, even for the BigOmics-managed
+              ## backend — but they're disabled (shinyjs, see the lock
+              ## observer in appsettings_server.R) for bigomics, since users
+              ## don't choose which models BigOmics runs, only see them.
               shiny::conditionalPanel(
-                "input.enable_ai && input.ai_provider != 'bigomics'",
+                "input.enable_ai",
                 ns = ns,
                 shiny::selectInput(
                   inputId = ns("llm_reports"),

--- a/tests/testthat/test-appsettings-ai.R
+++ b/tests/testthat/test-appsettings-ai.R
@@ -28,6 +28,7 @@ ai_byok_allowed <- function(level) {
 
 ## Init-time collaborators the module touches but that are irrelevant here.
 dbg                         <- function(...) invisible(NULL)
+OmicsBoard                  <- function(...) invisible(NULL)
 user_table_resources_server <- function(...) invisible(NULL)
 get_color_theme             <- function() shiny::reactiveValues()
 load_color_theme            <- function(...) NULL
@@ -53,7 +54,7 @@ testthat::skip_if_not(
   all(.required_omicsai_exports %in% getNamespaceExports("omicsai")),
   "omicsai provider catalog API exports are required"
 )
-source(file.path(.repo_dir, "components/app/R/ai_model_policy.R"), local = TRUE)
+source(file.path(.repo_dir, "components/utils/ai_model_policy.R"), local = TRUE)
 
 make_opt <- function(locked = FALSE,
                      enable_ai = TRUE,
@@ -181,7 +182,7 @@ test_that("OPG policy can disable a provider and reorder menu defaults", {
   expect_null(make_opt(providers = "openai")$AI_MODELS$mistral)
 })
 
-test_that("BigOmics defaults point at the OpenRouter models and menus remain hidden", {
+test_that("BigOmics defaults point at the OpenRouter models and menus stay visible but locked", {
   expect_equal(opt$AI_MODELS$bigomics$reports[[1]],
                "openrouter:deepseek/deepseek-v4-flash")
   expect_equal(opt$AI_MODELS$bigomics$images[[1]],
@@ -193,9 +194,19 @@ test_that("BigOmics defaults point at the OpenRouter models and menus remain hid
 
   ui_source <- readLines(file.path(.repo_dir,
                                    "components/board.user/R/appsettings_ui.R"))
-  expect_true(any(grepl("input.ai_provider != 'bigomics'", ui_source,
-                        fixed = TRUE)))
+  ## Scope the assertion to the "AI Models" card: the "AI Provider" card
+  ## legitimately still hides the API-key/base-URL inputs and the "Test &
+  ## load models" button for bigomics via != 'bigomics' conditionalPanels.
+  models_card_start <- grep('card_header("AI Models")', ui_source, fixed = TRUE)
+  models_card <- ui_source[models_card_start:length(ui_source)]
+  expect_true(any(grepl('"input.enable_ai"', models_card, fixed = TRUE)))
+  expect_false(any(grepl("input.ai_provider != 'bigomics'", models_card,
+                         fixed = TRUE)))
   expect_true(any(grepl("ai_test_status", ui_source, fixed = TRUE)))
+
+  server_source <- readLines(file.path(.repo_dir,
+                                       "components/board.user/R/appsettings_server.R"))
+  expect_true(any(grepl("models_locked", server_source, fixed = TRUE)))
 })
 
 test_that("changing provider repopulates the four menus from that provider's catalog", {


### PR DESCRIPTION
- unhide the AI Models panel for the bigomics provider and disable its four selects (shinyjs) instead of hiding the whole card, so users can see which models bigomics runs without being able to change them
- relabel the bigomics pinned model ids to friendly product names (Deepseek V4, GPT-5.6, Gemini 3.1 Nano Banana) so the backend routing (OpenRouter) and lab ownership stay internal
- fix stale test bootstrap path and missing OmicsBoard stub in test-appsettings-ai.R that were blocking the suite from running

## Before
<img width="1841" height="990" alt="image (2)" src="https://github.com/user-attachments/assets/a886b020-6b9b-43ad-9c0c-68ffd029a499" />

## After
<img width="1799" height="558" alt="Screenshot 2026-08-27 at 15 27 28" src="https://github.com/user-attachments/assets/f67b1e26-3a4f-43bf-beab-04f78cbecf1c" />
