### PR TITLE
docker: explicit playbase/playdata/bigdash branch pins, fail-fast on missing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,16 +65,29 @@ COPY dev/*.R dev/description* dev/
 RUN Rscript dev/requirements.R
 
 #------------------------------------------------------------
-# Install fresh playbase (from same BRANCH)
+# Install fresh playbase.
+# If PLAYBASE_BRANCH is set, install exactly that branch and FAIL if it does
+# not exist (no silent fallback). Otherwise check playbase@{BRANCH} and fall
+# back to main when the sibling branch is missing.
 #------------------------------------------------------------
-# check if playbase@{$BRANCH} exists, if it does, install.. otherwise install main
-RUN echo "Checking playbase branch ${BRANCH}"
-RUN BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l) && \
+ARG PLAYBASE_BRANCH=
+RUN if [ -n "$PLAYBASE_BRANCH" ]; then \
+    echo "Installing playbase@${PLAYBASE_BRANCH} (explicit)"; \
+    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${PLAYBASE_BRANCH} | wc -l); \
+    if [ $BRANCH_EXISTS -ne 1 ]; then \
+        echo "ERROR: playbase branch '${PLAYBASE_BRANCH}' does not exist" >&2; exit 1; \
+    fi; \
+    R -e "remotes::install_github('bigomics/playbase@${PLAYBASE_BRANCH}',dependencies=FALSE)"; \
+else \
+    echo "Checking playbase branch ${BRANCH}"; \
+    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l) && \
     if [ $BRANCH_EXISTS -eq 1 ]; then \
         R -e "remotes::install_github('bigomics/playbase@${BRANCH}',dependencies=FALSE)"; \
     else \
+        echo "WARNING: no playbase@${BRANCH}, falling back to playbase@main"; \
         R -e "remotes::install_github('bigomics/playbase@main',dependencies=FALSE)"; \
-    fi
+    fi; \
+fi
 
 # after install non-detected missing packages
 #RUN R -e "remotes::install_version('Matrix', version = '1.6.1.1')"

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -128,21 +128,34 @@ RUN --mount=type=secret,id=GITHUB_PAT \
     fi
 
 #------------------------------------------------------------
-# Install fresh playbase (from same BRANCH)
+# Install fresh playbase.
+# If PLAYBASE_BRANCH is set, install exactly that branch and FAIL if it does
+# not exist (no silent fallback). Otherwise check playbase@{BRANCH} and fall
+# back to main when the sibling branch is missing.
 #------------------------------------------------------------
-# check if playbase@{$BRANCH} exists, if it does, install.. otherwise install main
 # TODO: temporary solution, this should go out once we rebuild base image
 RUN R -e "install.packages('ggiraph')"
 RUN R -e "BiocManager::install('TileDBArray')"
 
 ARG update_playbase=true
+ARG PLAYBASE_BRANCH=
 RUN if [ $update_playbase = true ]; then \
-    echo "Checking playbase branch ${BRANCH}"; \
-    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l); \
-    if [ $BRANCH_EXISTS -eq 1 ]; then \
-       R -e "remotes::install_github('bigomics/playbase@${BRANCH}',dependencies=FALSE)"; \
+    if [ -n "$PLAYBASE_BRANCH" ]; then \
+        echo "Installing playbase@${PLAYBASE_BRANCH} (explicit)"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${PLAYBASE_BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -ne 1 ]; then \
+            echo "ERROR: playbase branch '${PLAYBASE_BRANCH}' does not exist" >&2; exit 1; \
+        fi; \
+        R -e "remotes::install_github('bigomics/playbase@${PLAYBASE_BRANCH}',dependencies=FALSE)"; \
     else \
-       R -e "remotes::install_github('bigomics/playbase@main',dependencies=FALSE)"; \
+        echo "Checking playbase branch ${BRANCH}"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playbase.git ${BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -eq 1 ]; then \
+           R -e "remotes::install_github('bigomics/playbase@${BRANCH}',dependencies=FALSE)"; \
+        else \
+           echo "WARNING: no playbase@${BRANCH}, falling back to playbase@main"; \
+           R -e "remotes::install_github('bigomics/playbase@main',dependencies=FALSE)"; \
+        fi \
     fi \
 fi
 
@@ -158,32 +171,52 @@ RUN R -e "if (!require('playbase')) { quit(status=1) }"
 #RUN R -e "remotes::install_github('the-y-company/bsutils',dependencies=FALSE)"
 
 #------------------------------------------------------------
-# Install fresh playdata (from same BRANCH)
+# Install fresh playdata (PLAYDATA_BRANCH, or same BRANCH with main fallback)
 #------------------------------------------------------------
-# check if playbase@{$BRANCH} exists, if it does, install.. otherwise install main
 ARG update_playdata=false
+ARG PLAYDATA_BRANCH=
 RUN if [ $update_playdata = true ]; then \
-    echo "Checking playdata branch ${BRANCH}"; \
-    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playdata.git ${BRANCH} | wc -l); \
-    if [ $BRANCH_EXISTS -eq 1 ]; then \
-        R -e "remotes::install_github('bigomics/playdata@${BRANCH}',dependencies=FALSE)"; \
+    if [ -n "$PLAYDATA_BRANCH" ]; then \
+        echo "Installing playdata@${PLAYDATA_BRANCH} (explicit)"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playdata.git ${PLAYDATA_BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -ne 1 ]; then \
+            echo "ERROR: playdata branch '${PLAYDATA_BRANCH}' does not exist" >&2; exit 1; \
+        fi; \
+        R -e "remotes::install_github('bigomics/playdata@${PLAYDATA_BRANCH}',dependencies=FALSE)"; \
     else \
-        R -e "remotes::install_github('bigomics/playdata@main',dependencies=FALSE)"; \
+        echo "Checking playdata branch ${BRANCH}"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/playdata.git ${BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -eq 1 ]; then \
+            R -e "remotes::install_github('bigomics/playdata@${BRANCH}',dependencies=FALSE)"; \
+        else \
+            echo "WARNING: no playdata@${BRANCH}, falling back to playdata@main"; \
+            R -e "remotes::install_github('bigomics/playdata@main',dependencies=FALSE)"; \
+        fi \
     fi \
 fi
 
 #------------------------------------------------------------
-# Install fresh bigdash (from same BRANCH)
+# Install fresh bigdash (BIGDASH_BRANCH, or same BRANCH with master fallback)
 #------------------------------------------------------------
-# check if bigdash@{$BRANCH} exists, if it does, install.. otherwise install main
 ARG update_bigdash=false
+ARG BIGDASH_BRANCH=
 RUN if [ $update_bigdash = true ]; then \
-    echo "Checking bigdash branch ${BRANCH}"; \
-    BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/bigdash.git ${BRANCH} | wc -l); \
-    if [ $BRANCH_EXISTS -eq 1 ]; then \
-       R -e "remotes::install_github('bigomics/bigdash@${BRANCH}',dependencies=FALSE)"; \
+    if [ -n "$BIGDASH_BRANCH" ]; then \
+        echo "Installing bigdash@${BIGDASH_BRANCH} (explicit)"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/bigdash.git ${BIGDASH_BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -ne 1 ]; then \
+            echo "ERROR: bigdash branch '${BIGDASH_BRANCH}' does not exist" >&2; exit 1; \
+        fi; \
+        R -e "remotes::install_github('bigomics/bigdash@${BIGDASH_BRANCH}',dependencies=FALSE)"; \
     else \
-       R -e "remotes::install_github('bigomics/bigdash@master',dependencies=FALSE)"; \
+        echo "Checking bigdash branch ${BRANCH}"; \
+        BRANCH_EXISTS=$(git ls-remote --heads https://github.com/bigomics/bigdash.git ${BRANCH} | wc -l); \
+        if [ $BRANCH_EXISTS -eq 1 ]; then \
+           R -e "remotes::install_github('bigomics/bigdash@${BRANCH}',dependencies=FALSE)"; \
+        else \
+           echo "WARNING: no bigdash@${BRANCH}, falling back to bigdash@master"; \
+           R -e "remotes::install_github('bigomics/bigdash@master',dependencies=FALSE)"; \
+        fi \
     fi \
 fi
 

--- a/docker/build-shibuya-trixie.sh
+++ b/docker/build-shibuya-trixie.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Build bigomics/omicsplayground:trixie-edgy on shibuya, from scratch.
+#
+# Not run by CI. This is the host-specific orchestration script used on the
+# shibuya VM (tokyo's Proxmox VM 101) to hand-build the trixie image locally,
+# because bigomics/omicsplayground:trixie-edgy is not published to Docker Hub.
+# See shiny-deploy/12-shinyproxy-docker-service-swarm/tokyo/AGENTS.md gotcha 6
+# on that deploy for the full context.
+#
+# Expects $HOME/trixie-build/{playbase,omicsplayground} to be checkouts of
+# those two repos (this script does not clone them) and $HOME/trixie-build/.pat
+# to contain a GITHUB_PAT.
+#
+# Built here, not on the Proxmox host: enabling docker there sets iptables
+# FORWARD DROP and makes every VM unreachable, which would take down this very
+# deploy. Building here also means the image lands directly in the daemon
+# ShinyProxy uses, with no transfer.
+#
+# REQUIREMENT: host CPU must expose AVX/AVX2. PPM ships tiledb as a binary built
+# for a modern ISA, and TileDBArray dyn.loads it during install -- without AVX
+# that is an instant SIGILL, which fails TileDBArray -> playbase (an Import) ->
+# the whole build.
+#   grep -w avx2 /proc/cpuinfo   # must print something
+set -euo pipefail
+
+ROOT=$HOME/trixie-build
+BRANCH=edgy                     # opg code branch cloned INSIDE the image
+PB_BRANCH=edgy                  # playbase branch. Explicit: Dockerfile.{,update}
+                                 # install exactly this (fail-fast if missing)
+                                 # instead of the same-name check with silent
+                                 # fallback to playbase@main. Decouples the two
+                                 # repos -- no same-named playbase alias needed.
+SQUASH=$HOME/.local/bin/docker-squash
+export DOCKER_BUILDKIT=1
+
+GITHUB_PAT=$(cat "$ROOT/.pat"); export GITHUB_PAT
+test -n "$GITHUB_PAT"
+
+step(){ echo; echo "=================== $* ($(date -Is)) ==================="; echo; }
+
+#---------------------------------------------------------------------
+# playbase base.
+# NOT `make docker`: its docker.squash guard is always-true and always exits 1,
+# and docker.pkg pipes to tee without pipefail so a failed build returns 0.
+#---------------------------------------------------------------------
+cd "$ROOT/playbase"
+cp dev/rspm.R dev/Rprofile          # gitignored; without it everything builds from source
+grep -q '2026-07-15' dev/Rprofile   # PPM pin must be present or lattice drifts to 0.23-1
+
+step "1/5  playbase OS layer"
+if docker image inspect playbase-os >/dev/null 2>&1; then echo "reusing playbase-os"; else
+  docker build --no-cache -f dev/Dockerfile.os -t playbase-os . 2>&1 | tee "$ROOT/os.log"
+fi
+
+step "2/5  playbase R base layer"
+if docker image inspect playbase-rbase >/dev/null 2>&1; then echo "reusing playbase-rbase"; else
+  docker build -f dev/Dockerfile.rbase -t playbase-rbase . 2>&1 | tee "$ROOT/rbase.log"
+fi
+
+step "3/5  playbase package layer + squash"
+if docker image inspect bigomics/playbase:trixie >/dev/null 2>&1; then
+  echo "reusing bigomics/playbase:trixie"
+else
+  umask 077; printf 'GITHUB_PAT=%s\n' "$GITHUB_PAT" > dev/Renviron
+  docker build -f dev/Dockerfile -t playbase-pkg . 2>&1 | tee "$ROOT/pkg.log"
+  rm -f dev/Renviron
+  docker image inspect playbase-pkg >/dev/null
+  # Squash for PAT hygiene, not size: the token is baked into an intermediate
+  # layer and this docker group has two members (xavier, kwee).
+  $SQUASH playbase-pkg -t bigomics/playbase:trixie
+  docker image inspect bigomics/playbase:trixie >/dev/null
+  docker rmi playbase-pkg
+fi
+
+#---------------------------------------------------------------------
+# Plain `docker build` for the opg stages. On an earlier build host (docker
+# 26.1.5) `quarto install tinytex` died under AppArmor with a deno SIGILL-style
+# panic, which forced a privileged buildx builder plus a local registry to feed
+# it the base image. Docker 29.7.1 does NOT reproduce that -- verified by
+# running the exact quarto+tinytex install under default confinement -- so the
+# registry and the container driver are both dropped. That also avoids pushing
+# the squashed 20.5GB single-layer image, whose one ~10GB blob timed out.
+#---------------------------------------------------------------------
+step "4/5  omicsplayground stage 1 (docker/Dockerfile)"
+cd "$ROOT/omicsplayground"
+docker build --no-cache --progress plain \
+  --build-arg BRANCH=$BRANCH \
+  --build-arg PLAYBASE_BRANCH=$PB_BRANCH \
+  --build-arg BASE_IMAGE=bigomics/playbase:trixie \
+  -f docker/Dockerfile \
+  -t bigomics/omicsplayground:trixie-edgy-base . 2>&1 | tee "$ROOT/stage1.log"
+docker image inspect bigomics/omicsplayground:trixie-edgy-base >/dev/null
+
+step "5/5  omicsplayground stage 2 (docker/Dockerfile.update)"
+docker build --progress plain \
+  --build-arg BRANCH=$BRANCH \
+  --build-arg PLAYBASE_BRANCH=$PB_BRANCH \
+  --build-arg BASE_IMAGE=bigomics/omicsplayground:trixie-edgy-base \
+  --build-arg CACHEBUST_CODE="$(date +%s)" \
+  --secret id=GITHUB_PAT,env=GITHUB_PAT \
+  -f docker/Dockerfile.update \
+  -t bigomics/omicsplayground:trixie-edgy . 2>&1 | tee "$ROOT/stage2.log"
+docker image inspect bigomics/omicsplayground:trixie-edgy >/dev/null
+
+#---------------------------------------------------------------------
+step "SMOKE TEST"
+#---------------------------------------------------------------------
+docker run --rm --entrypoint sh bigomics/omicsplayground:trixie-edgy \
+  -c '. /etc/os-release; echo "$PRETTY_NAME"; quarto --version'
+# Asserts the packages LOAD, not just that they are installed: an earlier run
+# passed an installed-only check while methylumi/lumi/wateRmelon were unloadable
+# because lattice had been upgraded out from under them. tiledb/TileDBArray are
+# the AVX canaries.
+docker run --rm --entrypoint Rscript bigomics/omicsplayground:trixie-edgy -e '
+  cat(R.version.string, "| BioC", as.character(BiocManager::version()), "\n")
+  cat("lattice", as.character(packageVersion("lattice")),
+      "| exports parallel:", "parallel" %in% getNamespaceExports("lattice"), "\n")
+  need <- c("collapse","isotree","WGCNAplus","omicsai","playbase","tiledb",
+            "TileDBArray","PCSF","visNetwork","wateRmelon","methylumi","lumi")
+  bad <- character(0)
+  for (x in need) {
+    r <- tryCatch({ suppressMessages(loadNamespace(x)); "LOADS" },
+                  error = function(e) paste("FAILS:", conditionMessage(e)))
+    cat(sprintf("%-12s %s\n", x, r)); if (r != "LOADS") bad <- c(bad, x)
+  }
+  cat("playbase", as.character(packageVersion("playbase")), "\n")
+  if (length(bad)) { cat("FAILED TO LOAD:", paste(bad, collapse=" "), "\n"); quit(status=1) }'
+
+rm -f "$ROOT/.pat"
+step "BUILD COMPLETE"


### PR DESCRIPTION
## Summary
- `docker/Dockerfile` and `docker/Dockerfile.update` picked the playbase/playdata/bigdash branch by matching the omicsplayground `BRANCH` name, silently falling back to `main`/`master` when no sibling branch existed. For a branch cut from `edgy` that needs `playbase@edgy`, this meant either pushing a same-named alias branch in playbase, or the build silently landing on `playbase@main` — a runtime break, not a build-time one (this bit the `app-launcher` image on shibuya).
- Add `PLAYBASE_BRANCH` / `PLAYDATA_BRANCH` / `BIGDASH_BRANCH` build args. When set, that exact branch is installed and a missing branch is a **hard build failure**. When unset, the existing same-name-with-fallback behavior is unchanged (now logs a `WARNING` on fallback instead of being silent). No change to default build behavior/CI.
- Add `docker/build-shibuya-trixie.sh` — the host-specific script used on the shibuya deploy VM to hand-build `bigomics/omicsplayground:trixie-edgy` locally (that image isn't published to Docker Hub). It previously only existed on the VM; committing it here so it's versioned and picks up the new `PLAYBASE_BRANCH` arg.

Targets `feat/debian-trixie` (not `master`) since it builds on top of that branch's `ARG BASE_IMAGE` changes to the same two Dockerfiles.

## Test plan
- [x] `bash -n` syntax check on the extracted shell logic of all three modified RUN blocks (playbase/playdata/bigdash) in both Dockerfiles
- [x] Functional test of the playbase decision logic with stubbed `git`/`R`, covering all four paths: explicit branch missing (exit 1 + ERROR), explicit branch present (installs it), no explicit branch + sibling missing (WARNING + main fallback), no explicit branch + sibling present (installs BRANCH)
- [ ] Full `docker build` of `docker/Dockerfile.update` with `--build-arg PLAYBASE_BRANCH=edgy` end-to-end (not run locally — 26GB image, needs shibuya's AVX-capable host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSP9eeWVwmPAjFeq7erYi1