### PR TITLE
fix(admin): make Data Management table fill full page height

### DIFF
--- a/components/board.admin/R/admin_table_credentials.R
+++ b/components/board.admin/R/admin_table_credentials.R
@@ -133,6 +133,8 @@ admin_table_credentials_server <- function(id, auth, credentials_file = NULL) {
           escape = 1,
           editable = FALSE,
           selection = list(mode = "single", target = "row"),
+          extensions = c("Scroller"),
+          plugins = "scrollResize",
           callback = DT::JS(sprintf(
             "table.on('change', 'select.admin-select', function() {
                var row = parseInt($(this).data('row'));
@@ -145,6 +147,7 @@ admin_table_credentials_server <- function(id, auth, credentials_file = NULL) {
             dom = "lfrtip",
             scrollX = TRUE,
             scrollY = "45vh",
+            scrollResize = TRUE,
             deferRender = TRUE,
             pageLength = 20
           )

--- a/components/board.admin/R/admin_table_datamanager.R
+++ b/components/board.admin/R/admin_table_datamanager.R
@@ -307,10 +307,13 @@ admin_table_datamanager_server <- function(id, auth) {
           class = "compact hover",
           rownames = FALSE,
           selection = list(mode = "multiple", target = "row"),
+          extensions = c("Scroller"),
+          plugins = "scrollResize",
           options = list(
             dom = "tip",
             scrollX = TRUE,
             scrollY = "45vh",
+            scrollResize = TRUE,
             deferRender = TRUE,
             pageLength = 50,
             order = list(list(0, "asc"), list(1, "asc"))

--- a/components/board.admin/R/admin_ui.R
+++ b/components/board.admin/R/admin_ui.R
@@ -30,7 +30,8 @@ AdminPanelUI <- function(id) {
   ns <- shiny::NS(id) ## namespace
 
   fullH <- "100%"
-
+  fullH <- "calc(100vh - 60px)"
+  
   ## Both choosers list every board of the full sidebar menu, labelled with its
   ## group so "Samples" and "Features" are not ambiguous.
   menu_tree <- opg_menu_tree()
@@ -45,7 +46,7 @@ AdminPanelUI <- function(id) {
     bslib::nav_panel(
       "Overview",
       bslib::layout_columns(
-        col_widths = 12,
+        col_widths = c(6,6),
         height = fullH,
         row_heights = list(1),
         admin_table_users_ui(
@@ -61,16 +62,19 @@ AdminPanelUI <- function(id) {
     bslib::nav_panel(
       "User Management",
       bslib::layout_columns(
-        col_widths = 12,
+        col_widths = c(6,6),
         height = fullH,
-        row_heights = list("auto", 1),
-        bs_alert("Manage user credentials. Click on a cell to edit it. Use the buttons below to add or remove users, and save changes when done."),
-        admin_table_credentials_ui(
-          id = ns("credentials"),
-          title = "User Credentials",
-          info.text = "Editable table of user credentials from the CREDENTIALS file.",
-          caption = "Edit user credentials and save changes.",
-          height = c("100%", TABLE_HEIGHT_MODAL)
+        row_heights = list(1),
+        shiny::div(
+          bs_alert("Manage user credentials. Click on a cell to edit it. Use the buttons below to add or remove users, and save changes when done."),
+          br(),
+          admin_table_credentials_ui(
+            id = ns("credentials"),
+            title = "User Credentials",
+            info.text = "Editable table of user credentials from the CREDENTIALS file.",
+            caption = "Edit user credentials and save changes.",
+            height = c("100%", TABLE_HEIGHT_MODAL)
+          )
         )
       )
     ),

--- a/components/board.admin/R/admin_ui.R
+++ b/components/board.admin/R/admin_ui.R
@@ -65,9 +65,11 @@ AdminPanelUI <- function(id) {
         col_widths = c(6,6),
         height = fullH,
         row_heights = list(1),
-        shiny::div(
+        bslib::layout_columns(
+          col_widths = 12,
+          height = "100%",
+          row_heights = list("auto",1),
           bs_alert("Manage user credentials. Click on a cell to edit it. Use the buttons below to add or remove users, and save changes when done."),
-          br(),
           admin_table_credentials_ui(
             id = ns("credentials"),
             title = "User Credentials",


### PR DESCRIPTION
## Summary
- Data Management table in the Admin panel only filled ~60% of the page height with a double scrollbar, because its DT table was missing the `scrollResize` wiring (Scroller extension + plugin + option) that every other admin table already uses, so its `scrollY = "45vh"` never adapted to the card's actual size.
- Applied the same fix to the Credentials table (same underlying bug) and adjusted the Admin panel layout (`admin_ui.R`) so both tables' cards correctly fill the available viewport height.

## Test plan
- [ ] Open Admin Panel > Data Management as an admin user, confirm the table fills the full page height with no double scrollbar
- [ ] Open Admin Panel > User Management (Credentials), confirm same fix applies
- [ ] Resize the browser window and confirm the table height adapts responsively

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFPyigzjnVGTQo21DoZ7FF