### PR TITLE
fix(biomarker): explain why Compute is greyed out

### DIFF
--- a/components/board.biomarker/R/biomarker_server.R
+++ b/components/board.biomarker/R/biomarker_server.R
@@ -90,6 +90,24 @@ BiomarkerBoard <- function(id, pgx) {
       }
     )
 
+    ## explain why the run button above is greyed out
+    output$pdx_runbutton_msg <- shiny::renderUI({
+      shiny::req(pgx$Y, input$pdx_target)
+      shiny::req(input$pdx_target %in% colnames(pgx$Y))
+      nlevels <- length(unique(pgx$Y[selected_samples(), input$pdx_target]))
+      if (nlevels > 1) {
+        return(NULL)
+      }
+      shiny::div(
+        class = "small text-danger mt-2",
+        paste0(
+          "The sample filter leaves only one level of '", input$pdx_target,
+          "'. Biomarker selection needs at least two groups: relax the ",
+          "filter or pick another prediction target."
+        )
+      )
+    })
+
     is_computed <- reactiveVal(FALSE)
     observeEvent(
       {

--- a/components/board.biomarker/R/biomarker_server.R
+++ b/components/board.biomarker/R/biomarker_server.R
@@ -99,7 +99,8 @@ BiomarkerBoard <- function(id, pgx) {
         return(NULL)
       }
       shiny::div(
-        class = "small text-danger mt-2",
+        class = "small mt-2",
+        style = "color: #555;",
         paste0(
           "The sample filter leaves only one level of '", input$pdx_target,
           "'. Biomarker selection needs at least two groups: relax the ",

--- a/components/board.biomarker/R/biomarker_ui.R
+++ b/components/board.biomarker/R/biomarker_ui.R
@@ -53,7 +53,8 @@ BiomarkerInputs <- function(id) {
         ),
         "Click to start biomarker computation.",
         placement = "right"
-      )
+      ),
+      shiny::uiOutput(ns("pdx_runbutton_msg"))
     )
   )
 }


### PR DESCRIPTION
On **Find Biomarkers**, the Compute button is disabled when the sample filter leaves the prediction target with a single level. Nothing said so, so the button just looked broken. This renders the reason under the button.

| Filter collapses the target | Valid target |
|---|---|
| <img src="https://raw.githubusercontent.com/bigomics/omicsplayground/assets/biomark-samples/screenshots/biomark-samples/compute-blocked.png" width="192"> | <img src="https://raw.githubusercontent.com/bigomics/omicsplayground/assets/biomark-samples/screenshots/biomark-samples/compute-enabled.png" width="192"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

