### PR TITLE
fix(copilot): PNG download of plots produced no file

### DIFF
--- a/components/app_copilot/R/CopilotEvidenceServer.R
+++ b/components/app_copilot/R/CopilotEvidenceServer.R
@@ -155,16 +155,41 @@ CopilotEvidenceServer <- function(id, local_pgx = NULL) {
     # ---- Download handler ----
     # Format choice depends on artifact kind:
     #   ggplot    -> PNG (only; ggsave at width x height inches, 288 dpi = 4x)
-    #   plotly    -> HTML (saveWidget) or PNG (plotlyExport: kaleido -> webshot2)
-    #   iheatmapr -> HTML (saveWidget) or PNG (iheatmapr::save_iheatmap, webshot)
-    # plotlyExport is defined in bigdash R/plot-module.R and is reused
-    # here so we don't fork the kaleido/webshot fallback chain.
+    #   plotly    -> HTML (saveWidget) or PNG (plotlyExport, else .widget_png)
+    #   iheatmapr -> HTML (saveWidget) or PNG (.widget_png)
+    # bigdash::plotlyExport (R/plot-module.R) is tried first because kaleido
+    # renders faster and sharper than a browser screenshot when it is there.
     .default_fmt <- function(kind) {
       switch(kind, ggplot = "png", plotly = "html", iheatmapr = "html", "html")
     }
     .clamp_dim <- function(x, default) {
       x <- suppressWarnings(as.numeric(x))
       if (length(x) != 1L || is.na(x) || x <= 0) default else x
+    }
+
+    # Screenshot an htmlwidget to PNG via headless Chrome. Needed because
+    #   - bigdash::plotlyExport() only tries kaleido (its webshot2 branch is
+    #     dead code behind `export.ok <- TRUE`), so PNG silently writes no file
+    #     when the Python plotly/kaleido venv from dev/install_extra.R is absent;
+    #   - iheatmapr::save_iheatmap() is S4-dispatched on "Iheatmap", but
+    #     omicsplots::pgx.plot_heatmap already hands us the converted
+    #     "iheatmapr" htmlwidget, so it never matches.
+    # selfcontained = FALSE avoids the pandoc dependency; webshot2 reads the
+    # temp file over file:// so the sibling libdir resolves fine.
+    # `zoom` multiplies the output pixels, matching the 4x upscale the ggplot
+    # and kaleido branches apply — without it an 8x6in request lands at 640x480.
+    .widget_png <- function(widget, file, width, height, zoom = 1) {
+      # plotly.js renders the modebar into the page, so a screenshot picks it
+      # up; hide it for the export only. Class covers iheatmapr too (also
+      # plotly.js under the hood) and leaves no gap — the bar is an overlay.
+      widget <- htmlwidgets::prependContent(
+        widget,
+        htmltools::tags$style(".modebar, .modebar-container { display: none !important; }")
+      )
+      tmp <- tempfile(fileext = ".html")
+      on.exit(unlink(c(tmp, sub("\\.html$", "_files", tmp)), recursive = TRUE), add = TRUE)
+      htmlwidgets::saveWidget(widget, tmp, selfcontained = FALSE)
+      webshot2::webshot(tmp, file, vwidth = width, vheight = height, zoom = zoom, delay = 1)
     }
 
     output$dl_format_ui <- shiny::renderUI({
@@ -226,7 +251,15 @@ CopilotEvidenceServer <- function(id, local_pgx = NULL) {
               p <- rec$plot
               p$width  <- png_w
               p$height <- png_h
-              plotlyExport(p, file, width = p$width, height = p$height, scale = resx)
+              ok <- isTRUE(tryCatch(
+                plotlyExport(p, file, width = p$width, height = p$height, scale = resx),
+                error = function(e) FALSE
+              ))
+              # plotlyExport's success flag is just file.exists(), so a kaleido
+              # crash mid-write would pass it with a truncated file.
+              if (!ok || !isTRUE(file.size(file) > 0)) {
+                .widget_png(p, file, png_w, png_h, resx)
+              }
             } else {
               # Mirror PlotModule's HTML path (bigdash R/plot-module.R):
               # plain saveWidget, no dimension manipulation.
@@ -236,8 +269,7 @@ CopilotEvidenceServer <- function(id, local_pgx = NULL) {
             p <- rec$plot
             if (methods::is(p, "Iheatmap")) p <- iheatmapr::to_widget(p)
             if (identical(fmt, "png")) {
-              # Mirror PlotModule's iheatmapr PNG path (bigdash R/plot-module.R).
-              iheatmapr::save_iheatmap(p, vwidth = png_w, vheight = png_h, file)
+              .widget_png(p, file, png_w, png_h, resx)
             } else {
               htmlwidgets::saveWidget(p, file, selfcontained = TRUE)
             }

--- a/components/app_copilot/R/CopilotEvidenceServer.R
+++ b/components/app_copilot/R/CopilotEvidenceServer.R
@@ -157,8 +157,6 @@ CopilotEvidenceServer <- function(id, local_pgx = NULL) {
     #   ggplot    -> PNG (only; ggsave at width x height inches, 288 dpi = 4x)
     #   plotly    -> HTML (saveWidget) or PNG (plotlyExport, else .widget_png)
     #   iheatmapr -> HTML (saveWidget) or PNG (.widget_png)
-    # bigdash::plotlyExport (R/plot-module.R) is tried first because kaleido
-    # renders faster and sharper than a browser screenshot when it is there.
     .default_fmt <- function(kind) {
       switch(kind, ggplot = "png", plotly = "html", iheatmapr = "html", "html")
     }
@@ -167,21 +165,11 @@ CopilotEvidenceServer <- function(id, local_pgx = NULL) {
       if (length(x) != 1L || is.na(x) || x <= 0) default else x
     }
 
-    # Screenshot an htmlwidget to PNG via headless Chrome. Needed because
-    #   - bigdash::plotlyExport() only tries kaleido (its webshot2 branch is
-    #     dead code behind `export.ok <- TRUE`), so PNG silently writes no file
-    #     when the Python plotly/kaleido venv from dev/install_extra.R is absent;
-    #   - iheatmapr::save_iheatmap() is S4-dispatched on "Iheatmap", but
-    #     omicsplots::pgx.plot_heatmap already hands us the converted
-    #     "iheatmapr" htmlwidget, so it never matches.
-    # selfcontained = FALSE avoids the pandoc dependency; webshot2 reads the
-    # temp file over file:// so the sibling libdir resolves fine.
-    # `zoom` multiplies the output pixels, matching the 4x upscale the ggplot
-    # and kaleido branches apply — without it an 8x6in request lands at 640x480.
+    # PNG fallback for htmlwidgets: kaleido may be absent and
+    # save_iheatmap() never dispatches on the converted widget. `zoom` gives
+    # the same 4x upscale as the ggplot/kaleido branches.
     .widget_png <- function(widget, file, width, height, zoom = 1) {
-      # plotly.js renders the modebar into the page, so a screenshot picks it
-      # up; hide it for the export only. Class covers iheatmapr too (also
-      # plotly.js under the hood) and leaves no gap — the bar is an overlay.
+      # hide the plotly.js modebar, it shows up in the screenshot
       widget <- htmlwidgets::prependContent(
         widget,
         htmltools::tags$style(".modebar, .modebar-container { display: none !important; }")
@@ -255,8 +243,7 @@ CopilotEvidenceServer <- function(id, local_pgx = NULL) {
                 plotlyExport(p, file, width = p$width, height = p$height, scale = resx),
                 error = function(e) FALSE
               ))
-              # plotlyExport's success flag is just file.exists(), so a kaleido
-              # crash mid-write would pass it with a truncated file.
+              # plotlyExport returns file.exists(), so also check it is not empty
               if (!ok || !isTRUE(file.size(file) > 0)) {
                 .widget_png(p, file, png_w, png_h, resx)
               }

--- a/tests/testthat/test-copilot-evidence-server.R
+++ b/tests/testthat/test-copilot-evidence-server.R
@@ -9,12 +9,15 @@
 ## public reactive exposed by the module. output$evidence_ggplot (renderImage)
 ## IS accessible via testServer since it uses a proper render function.
 
-.board_dir <- if (dir.exists("components/board.copilot/R")) {
-  "components/board.copilot/R"
+.board_dir <- if (dir.exists("components/app_copilot/R")) {
+  "components/app_copilot/R"
 } else {
-  "../../components/board.copilot/R"
+  "../../components/app_copilot/R"
 }
 
+# `%||%` lives in components/utils/utils.R, which is not loaded by
+# shinytest2::load_app_env(); source it so the module's own `%||%` calls resolve.
+source(file.path(dirname(dirname(.board_dir)), "utils", "utils.R"), local = TRUE)
 source(file.path(.board_dir, "copilot_options.R"),  local = TRUE)
 source(file.path(.board_dir, "copilot_messages.R"), local = TRUE)
 source(file.path(.board_dir, "copilot_logger.R"),   local = TRUE)
@@ -251,5 +254,60 @@ test_that("public active() reactive returns the same value as active_artifact()"
     from_api    <- shiny::isolate(session$returned$active())
     from_direct <- shiny::isolate(active_artifact())
     expect_identical(from_api, from_direct)
+  })
+})
+
+# ===========================================================================
+# PNG download
+# ===========================================================================
+# Regression guard for the two broken PNG paths (see .widget_png in
+# CopilotEvidenceServer.R): plotly fell through bigdash::plotlyExport writing
+# no file when kaleido is absent, and iheatmapr hit an S4 dispatch failure
+# because the record already holds a converted htmlwidget.
+
+is_png <- function(path) {
+  identical(as.integer(readBin(path, "raw", 4L)), c(137L, 80L, 78L, 71L))
+}
+
+# Width from the PNG IHDR chunk: 8-byte signature + 4 length + 4 "IHDR",
+# then a big-endian uint32. Guards the 4x upscale in .widget_png -- without
+# `zoom` the screenshot comes back at CSS pixels (1/4 the width).
+png_width <- function(path) {
+  con <- file(path, "rb"); on.exit(close(con))
+  readBin(con, "raw", 16L)
+  readBin(con, "integer", 1L, size = 4L, endian = "big")
+}
+
+test_that("plotly PNG download writes a real PNG even without kaleido", {
+  skip_if_not_installed("webshot2")
+  skip_if(is.null(chromote::find_chrome()))
+  shiny::testServer(CopilotEvidenceServer, {
+    session$returned$append_artifact(make_plotly_record())
+    session$setInputs(dl_format = "png", dl_width = 6, dl_height = 4)
+
+    path <- output$evidence_download
+    expect_true(file.exists(path))
+    expect_true(is_png(path))
+    expect_equal(png_width(path), 6 * 80 * 4)
+  })
+})
+
+test_that("iheatmapr PNG download works on an already-converted widget", {
+  skip_if_not_installed("webshot2")
+  skip_if_not_installed("iheatmapr")
+  skip_if(is.null(chromote::find_chrome()))
+  shiny::testServer(CopilotEvidenceServer, {
+    widget <- iheatmapr::to_widget(iheatmapr::main_heatmap(matrix(rnorm(50), 10, 5)))
+    session$returned$append_artifact(list(
+      kind = "iheatmapr", plot = widget, prerendered_path = NULL,
+      plot_type = "heatmap", args = list(), artifact = NULL,
+      label = "heatmap", timestamp = Sys.time()
+    ))
+    session$setInputs(dl_format = "png", dl_width = 6, dl_height = 4)
+
+    path <- output$evidence_download
+    expect_true(file.exists(path))
+    expect_true(is_png(path))
+    expect_equal(png_width(path), 6 * 80 * 4)
   })
 })


### PR DESCRIPTION
## Description

Downloading a Copilot plot as PNG did nothing. The browser reported a failed download, no error appeared anywhere in the UI, and it affected every plot kind except ggplot — which is most of them, since Copilot plots come from omicsplots and are mostly plotly.

Two separate causes:

- **plotly** went through `bigdash::plotlyExport`, which only really tries kaleido — its own webshot2 fallback is dead code sitting behind a hardcoded `export.ok <- TRUE`. Without the Python venv that `dev/install_extra.R` builds, it writes no file at all, and Shiny 404s the download.
- **iheatmapr** called `iheatmapr::save_iheatmap`, which is S4-dispatched on `"Iheatmap"`. But `omicsplots::pgx.plot_heatmap` already hands back the converted `"iheatmapr"` htmlwidget, so dispatch could never match. Broken in every environment, kaleido or not.

Both now fall back to one small `.widget_png` helper — save the widget to a temp HTML, screenshot it with `webshot2` — at the same 4x upscale the ggplot and kaleido branches use, with the plotly.js modebar hidden so it doesn't end up in the image. kaleido is still tried first for plotly when it's available, since it renders faster and sharper than a browser screenshot.

Also: the test file's `.board_dir` still pointed at `components/board.copilot/R`, which no longer exists, so the whole file errored at source time and its 30 assertions never ran. Repointed at `app_copilot`; they pass.

## Related Issue

None.

## Example

Ask Copilot for a volcano plot or a heatmap, then download icon → Format → PNG.

Tests drive the real `downloadHandler` through `shiny::testServer` and assert the returned file is a PNG at the requested resolution:

```
Rscript -e 'testthat::test_dir("tests/testthat", filter="copilot-evidence-server")'
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 36 ]
```

Reverting either branch of the fix turns those red.

## Not in this PR

Same kaleido root cause breaks PNG, PDF **and** SVG download for every `plotlib="plotly"` board plot (178 call sites) via `bigdash::plotModule`. The real fix is deleting that `export.ok <- TRUE` line in bigdash so its existing fallback runs. Two smaller ones also found while looking: `plotlib = "baseplot"` in `components/modules/UsersMapModule.R:104` isn't a value bigdash knows (should be `"base"`), and the ggplot PDF path calls `sysfonts::font_add_google("lato")` unguarded — a bigdash *Suggests* that no DESCRIPTION or `docker/packages.list` installs, and which needs network access at download time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpqvooB4N7Ztpv8Q8sjcnt