### PR TITLE
chore: bump stale copyright years to 2026

### DIFF
--- a/components/app/R/server.R
+++ b/components/app/R/server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app/R/ui.R
+++ b/components/app/R/ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 app_ui <- function(x) {

--- a/components/app_across/R/across_plot_barplot.R
+++ b/components/app_across/R/across_plot_barplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' @export

--- a/components/app_across/R/across_plot_boxplot.R
+++ b/components/app_across/R/across_plot_boxplot.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' @export

--- a/components/app_across/R/across_server.R
+++ b/components/app_across/R/across_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 AcrossBoard <- function(id, pgx, pgx_dir = reactive(NULL),

--- a/components/app_across/R/across_table_data.R
+++ b/components/app_across/R/across_table_data.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' @export

--- a/components/app_across/R/across_ui.R
+++ b/components/app_across/R/across_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 AcrossInputs <- function(id) {

--- a/components/app_launcher/R/launcher_server.R
+++ b/components/app_launcher/R/launcher_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app_launcher/R/launcher_ui.R
+++ b/components/app_launcher/R/launcher_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Launcher page for dashboards, apps and tools.

--- a/components/app_launcher/test/launcher_ui_classic.R
+++ b/components/app_launcher/test/launcher_ui_classic.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Original pre-redesign "classic" 3-card layout (backup reference).

--- a/components/app_launcher/test/launcher_ui_claude.R
+++ b/components/app_launcher/test/launcher_ui_claude.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Pre-redesign version saved as launcher_ui_classic() in launcher_ui_classic.R —

--- a/components/app_launcher/test/launcher_ui_ds.R
+++ b/components/app_launcher/test/launcher_ui_ds.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Tablet-friendly app launcher UI — inspired by mobile home screens but

--- a/components/app_opg/R/opg_ui.R
+++ b/components/app_opg/R/opg_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 #' Full sidebar menu: module group -> named vector of boards (id = title).

--- a/components/app_prism/R/prism_server.R
+++ b/components/app_prism/R/prism_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app_prism/R/prism_ui.R
+++ b/components/app_prism/R/prism_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 prism_ui <- function(id) {

--- a/components/app_qsee/shiny/qsee_batchcorrect_server.R
+++ b/components/app_qsee/shiny/qsee_batchcorrect_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 qsee_bsee_server <- function(id, rX, rY, purge = NULL) {

--- a/components/app_qsee/shiny/qsee_batchcorrect_ui.R
+++ b/components/app_qsee/shiny/qsee_batchcorrect_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 ## Was: board.upload/upload_module_batchcorrect.R

--- a/components/app_qsee/shiny/qsee_server.R
+++ b/components/app_qsee/shiny/qsee_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 qsee_server <- function(id, pgx=NULL, matx="counts", parent=NULL, purge=NULL, lazy=TRUE) {

--- a/components/app_studio/R/aireport_server.R
+++ b/components/app_studio/R/aireport_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 if(0) {

--- a/components/app_studio/R/studio_server.R
+++ b/components/app_studio/R/studio_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app_studio/R/studio_ui.R
+++ b/components/app_studio/R/studio_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/app_studio/R/visreport_server.R
+++ b/components/app_studio/R/visreport_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2024 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 VisReportSettings <- function(id, output_format=NULL, type="dataset") {

--- a/components/board.dataview/R/dataview_html_settings.R
+++ b/components/board.dataview/R/dataview_html_settings.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.drugconnectivity/R/drugconnectivity_server.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DrugConnectivityBoard <- function(id, pgx) {

--- a/components/board.drugconnectivity/R/drugconnectivity_ui.R
+++ b/components/board.drugconnectivity/R/drugconnectivity_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 DrugConnectivityInputs <- function(id) {

--- a/components/board.mofa/R/board_mofa_server.R
+++ b/components/board.mofa/R/board_mofa_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/board.mofa/R/board_mofa_ui.R
+++ b/components/board.mofa/R/board_mofa_ui.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MofaInputs <- function(id) {

--- a/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
+++ b/components/board.wgcna/R/multiwgcna/board_multiwgcna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 MultiWGCNA_Board <- function(id, pgx, save_pgx = NULL) {

--- a/components/board.wgcna/R/wgcna_html_module_summary.R
+++ b/components/board.wgcna/R/wgcna_html_module_summary.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2025 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 wgcna_html_module_summary_ui <- function(

--- a/components/board.wgcna/R/wgcna_server.R
+++ b/components/board.wgcna/R/wgcna_server.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 

--- a/components/modules/SummaryBoard.R
+++ b/components/modules/SummaryBoard.R
@@ -1,6 +1,6 @@
 ##
 ## This file is part of the Omics Playground project.
-## Copyright (c) 2018-2023 BigOmics Analytics SA. All rights reserved.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
 ##
 
 SummaryBoardInputs <- function(id) {

--- a/components/ui/ui-credits.R
+++ b/components/ui/ui-credits.R
@@ -45,7 +45,7 @@ creditsCarousel <- function() {
         class = "col-md-12 text-center",
         shiny::tags$b("Created with love by"), br(),
         "BigOmics Analytics from Ticino, the sunny side of Switzerland.",
-        br(), "© 2000-2025 BigOmics Analytics, Inc.", br(),
+        br(), "© 2000-2026 BigOmics Analytics, Inc.", br(),
         shiny::a("www.bigomics.ch", href = "https://www.bigomics.ch")
       )
     )


### PR DESCRIPTION
Bumps the last stale copyright years in first-party sources to 2026.

- 31 file headers still read `Copyright (c) 2018-2023/2024/2025` → `2018-2026`
- `components/ui/ui-credits.R` footer read `© 2000-2025` → `© 2000-2026`

The rest of the repo (432 headers, plus `ui-startupModal.R`) was already 2026.

Untouched: third-party headers in `docs/*.html` and `components/assets/`, and literature citation years in info panels (Melville 2024, Konopka 2023, …) — those are facts, not stale.

Verified: diff is 32 lines, one year change each; `©` still valid UTF-8 (`c2 a9`); no mode changes, no trailing-newline changes, no stray files; all 32 `.R` files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)