### PR TITLE
feat: add per-user consent for AI conversation data sharing

### DIFF
--- a/components/app_copilot/R/copilot_restore_controller.R
+++ b/components/app_copilot/R/copilot_restore_controller.R
@@ -95,21 +95,29 @@ copilot_restore_controller <- function(
   restore_status <- shiny::reactiveVal("idle")
 
   # ---- ExtendedTask ----
-  # `provider` + `credentials` are captured on the Shiny thread by start()
-  # and passed in as task args, never read from the reactive inside the
-  # worker (the future-worker gotcha). `credentials` is a plain value-capturing
-  # closure (or NULL), so it serialises into the future cleanly.
+  # `provider`, `credentials` and `data_consent` are captured on the Shiny
+  # thread by start() and passed in as task args, never read from the reactive
+  # inside the worker (the future-worker gotcha). `credentials` is a plain
+  # value-capturing closure (or NULL), so it serialises into the future
+  # cleanly.
+  #
+  # `data_consent` travels the same route as `provider` for the same reason it
+  # is not read back from the snapshot: the saved session records what the
+  # conversation was, not what the user currently permits. Passing the live
+  # setting means a session saved while the switch was on restores private
+  # once the user turns it off.
   restore_task <- shiny::ExtendedTask$new(
-    function(store, session_id, bindings, provider, credentials) {
+    function(store, session_id, bindings, provider, credentials, data_consent) {
       promises::future_promise({
         omicsagentovi::ovi_restore(
-          session_id  = session_id,
-          session_dir = store@session_dir,
-          bindings    = bindings,
-          restore_pgx = "never",
-          db_name     = basename(store@db_path),
-          provider    = provider,
-          credentials = credentials
+          session_id   = session_id,
+          session_dir  = store@session_dir,
+          bindings     = bindings,
+          restore_pgx  = "never",
+          db_name      = basename(store@db_path),
+          provider     = provider,
+          credentials  = credentials,
+          data_consent = data_consent
         )
       }, seed = TRUE)
     })
@@ -246,6 +254,16 @@ copilot_restore_controller <- function(
     ai_sel   <- .copilot_restore_provider(session)
     provider <- ai_sel$provider
     cred     <- ai_sel$credentials
+    ## Read on the Shiny thread; `session` is not available in the worker.
+    ## Scoped to the managed backend exactly as fresh-agent construction is:
+    ## on BYOK the user's own provider account governs their data policy.
+    ##
+    ## Note this asks .copilot_ai_provider, not the `provider` resolved just
+    ## above: .copilot_restore_provider has already rewritten the managed
+    ## backend to ovi's "openai" sentinel, so testing that value for
+    ## "bigomics" never matches and would silently drop every opt-in.
+    consent  <- identical(.copilot_ai_provider(session)$provider, "bigomics") &&
+      get_ai_data_consent(session)
 
     restore_inflight(session_id)
     restore_status("restoring")
@@ -288,8 +306,9 @@ copilot_restore_controller <- function(
             bindings    = bindings,
             restore_pgx = "never",
             db_name     = basename(store@db_path),
-            provider    = provider,
-            credentials = cred
+            provider     = provider,
+            credentials  = cred,
+            data_consent = consent
           ),
           error = function(e) {
             log_info("copilot.restore_sync_failed", msg = conditionMessage(e))
@@ -310,7 +329,8 @@ copilot_restore_controller <- function(
 
     tryCatch(
       {
-        restore_task$invoke(store, session_id, bindings, provider, cred)
+        restore_task$invoke(store, session_id, bindings, provider, cred,
+                            consent)
       },
       error = function(e) {
         log_info("copilot.restore_invoke_failed",

--- a/components/app_copilot/R/copilot_run_controller.R
+++ b/components/app_copilot/R/copilot_run_controller.R
@@ -67,7 +67,13 @@
 .copilot_agent_build_args <- function(session, tier) {
   sel <- .copilot_ai_provider(session)
   if (identical(sel$provider, "bigomics")) {
-    return(list(tier = tier))
+    ## Data-sharing consent travels with the managed backend only. omicsai
+    ## already defaults every OpenRouter call to no-training + zero-retention,
+    ## so passing FALSE is a restatement of the default and passing TRUE is the
+    ## user's recorded opt-in. On BYOK the user's own provider account governs,
+    ## so we deliberately send nothing and leave `data_consent` NULL there.
+    return(list(tier = tier,
+                data_consent = get_ai_data_consent(session)))
   }
   menu_key   <- if (identical(tier, "copilot-deep")) "llm_copilot_deep"
                 else "llm_copilot_balanced"

--- a/components/board.user/R/appsettings_server.R
+++ b/components/board.user/R/appsettings_server.R
@@ -222,7 +222,26 @@ AppSettingsBoard <- function(id, auth, pgx) {
     ## set routing preferences on their behalf. Coerce accordingly rather than
     ## trusting the client, matching how the provider write-observer above
     ## treats forged input.
+    ##
+    ## The base lock is read in three places (here, the greying observer, and
+    ## the login seed), so it lives in one reactive rather than being
+    ## recomputed per site and drifting.
+    ai_base_locked <- shiny::reactive({
+      (isTRUE(opt$AI_PROVIDER_LOCKED) && !isTRUE(auth$ADMIN)) ||
+        !isTRUE(opt$ENABLE_AI)
+    })
+
     shiny::observeEvent(input$ai_share_data, {
+      ## A locked deployment never records consent. Note the early return
+      ## *before* save_ai_consent(): the user's stored preference is left on
+      ## disk untouched. A deployment-level lock is not the user withdrawing
+      ## their consent, and it should not erase an answer they gave before the
+      ## lock was applied or would give again after it lifts. The in-session
+      ## option is what governs routing, and that is forced off.
+      if (isTRUE(ai_base_locked())) {
+        setUserOption(session, "ai_share_data", FALSE)
+        return()
+      }
       provider <- if (ai_byok_allowed(auth$level)) input$ai_provider else "bigomics"
       consent <- isTRUE(input$ai_share_data) && identical(provider, "bigomics")
       setUserOption(session, "ai_share_data", consent)
@@ -319,8 +338,7 @@ AppSettingsBoard <- function(id, auth, pgx) {
     shiny::observe({
       ## Base lock: deployment pins AI config for non-admins, or the deployment
       ## is unlicensed. Governs the "Enable AI" switch.
-      base_locked <- (isTRUE(opt$AI_PROVIDER_LOCKED) && !isTRUE(auth$ADMIN)) ||
-        !isTRUE(opt$ENABLE_AI)
+      base_locked <- ai_base_locked()
 
       ## Non-enterprise (non-BYOK) users may not change the provider: pin it to
       ## bigomics and grey it too. This mirrors the authoritative write-observer
@@ -338,9 +356,20 @@ AppSettingsBoard <- function(id, auth, pgx) {
 
       ## The consent switch follows the base lock, not the provider lock: on a
       ## deployment that pins AI config (or is unlicensed) nobody but an admin
-      ## changes AI behaviour, and a greyed switch that still reads FALSE is
-      ## the safe resting state.
-      if (base_locked) shinyjs::disable("ai_share_data") else shinyjs::enable("ai_share_data")
+      ## changes AI behaviour.
+      ##
+      ## Greying it is not enough, and that distinction matters here more than
+      ## for the other controls: a disabled switch keeps whatever value it
+      ## already had, so a user who had opted in would stay opted in behind a
+      ## control they can no longer reach. Force the value off as well, so the
+      ## visibly-off switch and the routing decision agree.
+      if (base_locked) {
+        shinyjs::disable("ai_share_data")
+        setUserOption(session, "ai_share_data", FALSE)
+        bslib::update_switch("ai_share_data", value = FALSE, session = session)
+      } else {
+        shinyjs::enable("ai_share_data")
+      }
 
       ## BigOmics runs a fixed model per menu -- show the resolved model but
       ## block editing (disabled select, no live "Test & load"), instead of
@@ -373,7 +402,7 @@ AppSettingsBoard <- function(id, auth, pgx) {
       if (!isTRUE(auth$logged)) {
         return()
       }
-      consent <- load_ai_consent(auth$user_dir)
+      consent <- load_ai_consent(auth$user_dir) && !isTRUE(ai_base_locked())
       setUserOption(session, "ai_share_data", consent)
       bslib::update_switch("ai_share_data", value = consent, session = session)
     })

--- a/components/board.user/R/appsettings_server.R
+++ b/components/board.user/R/appsettings_server.R
@@ -210,6 +210,25 @@ AppSettingsBoard <- function(id, auth, pgx) {
       }
     )
 
+    ## AI data-sharing consent. Unlike every other AI setting here this one is
+    ## written to disk (user_dir/ai_consent.json), because a consent that
+    ## silently reverts to its default on the next login is not a consent.
+    ## The session copy is what the Copilot reads at Agent-build time; the file
+    ## is what seeds it on login.
+    ##
+    ## The switch only exists for the BigOmics-managed backend (see the
+    ## conditionalPanel in appsettings_ui.R): on a BYOK key the user's own
+    ## provider account governs their data policy and we have no standing to
+    ## set routing preferences on their behalf. Coerce accordingly rather than
+    ## trusting the client, matching how the provider write-observer above
+    ## treats forged input.
+    shiny::observeEvent(input$ai_share_data, {
+      provider <- if (ai_byok_allowed(auth$level)) input$ai_provider else "bigomics"
+      consent <- isTRUE(input$ai_share_data) && identical(provider, "bigomics")
+      setUserOption(session, "ai_share_data", consent)
+      save_ai_consent(auth$user_dir, consent)
+    }, ignoreInit = TRUE)
+
     ## Repopulate the four model menus with the selected provider's catalog.
     shiny::observeEvent(input$ai_provider, {
       provider <- input$ai_provider
@@ -317,6 +336,12 @@ AppSettingsBoard <- function(id, auth, pgx) {
       if (base_locked) shinyjs::disable("enable_ai") else shinyjs::enable("enable_ai")
       if (provider_locked) shinyjs::disable("ai_provider") else shinyjs::enable("ai_provider")
 
+      ## The consent switch follows the base lock, not the provider lock: on a
+      ## deployment that pins AI config (or is unlicensed) nobody but an admin
+      ## changes AI behaviour, and a greyed switch that still reads FALSE is
+      ## the safe resting state.
+      if (base_locked) shinyjs::disable("ai_share_data") else shinyjs::enable("ai_share_data")
+
       ## BigOmics runs a fixed model per menu -- show the resolved model but
       ## block editing (disabled select, no live "Test & load"), instead of
       ## hiding the panel. Non-BYOK users are pinned to bigomics above, so
@@ -339,6 +364,19 @@ AppSettingsBoard <- function(id, auth, pgx) {
       setUserOption(session, "ai_enabled", ai_on)
     })
 
+
+    ## Seed the consent switch from the user's persisted record on login.
+    ## Fails closed: load_ai_consent() returns FALSE for a missing, corrupt or
+    ## stale-version file, so the user is asked again rather than silently
+    ## treated as having opted in.
+    shiny::observeEvent(auth$logged, {
+      if (!isTRUE(auth$logged)) {
+        return()
+      }
+      consent <- load_ai_consent(auth$user_dir)
+      setUserOption(session, "ai_share_data", consent)
+      bslib::update_switch("ai_share_data", value = consent, session = session)
+    })
 
     ## ----------------------------------------------------------------
     ## Plot Colors theme handling
@@ -382,6 +420,12 @@ AppSettingsBoard <- function(id, auth, pgx) {
       setUserOption(session, "ai_credentials", NULL)
       setUserOption(session, "ai_provider", "bigomics")
       shiny::updateSelectInput(session, "ai_provider", selected = "bigomics")
+      ## Consent is per user, so drop the session copy too — otherwise the next
+      ## login in this Shiny process would inherit the previous user's opt-in
+      ## before their own record loads. The file is untouched: this is a
+      ## session reset, not a withdrawal.
+      setUserOption(session, "ai_share_data", FALSE)
+      bslib::update_switch("ai_share_data", value = FALSE, session = session)
     }, ignoreInit = TRUE)
 
     ## Map UI input IDs to theme keys

--- a/components/board.user/R/appsettings_ui.R
+++ b/components/board.user/R/appsettings_ui.R
@@ -129,18 +129,21 @@ AppSettingsUI <- function(id) {
               shiny::tags$hr(class = "my-2"),
               bslib::input_switch(
                 ns("ai_share_data"),
-                "Use my conversation data to improve OmicsPlayground's AI",
+                ## Names the party that actually does the training. BigOmics
+                ## trains no models; what the switch changes is which upstream
+                ## providers the prompt may be routed to.
+                "Allow model providers to train on my Copilot conversations",
                 value = FALSE
               ),
               shiny::tags$small(
                 class = "text-muted",
                 paste(
-                  "When off, your Copilot prompts are sent to the model",
-                  "provider under a no-training, zero-retention policy.",
-                  "Turning this on allows the model provider to retain and",
-                  "train on those conversations. Your chat history is stored",
-                  "in your own workspace either way, and usage accounting",
-                  "records token counts only — never message content."
+                  "Off by default: prompts go to providers under a",
+                  "no-training, zero-retention policy. Turning this on lets",
+                  "them keep and train on your conversations. Your chat",
+                  "history is stored in your own workspace either way, and",
+                  "usage accounting records token counts only — never",
+                  "message content."
                 )
               )
             )

--- a/components/board.user/R/appsettings_ui.R
+++ b/components/board.user/R/appsettings_ui.R
@@ -116,6 +116,33 @@ AppSettingsUI <- function(id) {
                 ),
                 shiny::uiOutput(ns("ai_test_status"))
               )
+            ),
+
+            ## Data-sharing consent. BigOmics-managed backend only: on a BYOK
+            ## key the user's own provider account governs their data policy,
+            ## and it would be misleading to imply we control it. Off by
+            ## default; persisted per user (see components/modules/AiConsent.R)
+            ## because a consent that resets every login is not a consent.
+            shiny::conditionalPanel(
+              condition = "input.ai_provider == 'bigomics'",
+              ns = ns,
+              shiny::tags$hr(class = "my-2"),
+              bslib::input_switch(
+                ns("ai_share_data"),
+                "Use my conversation data to improve OmicsPlayground's AI",
+                value = FALSE
+              ),
+              shiny::tags$small(
+                class = "text-muted",
+                paste(
+                  "When off, your Copilot prompts are sent to the model",
+                  "provider under a no-training, zero-retention policy.",
+                  "Turning this on allows the model provider to retain and",
+                  "train on those conversations. Your chat history is stored",
+                  "in your own workspace either way, and usage accounting",
+                  "records token counts only — never message content."
+                )
+              )
             )
           )
         ),

--- a/components/modules/AiConsent.R
+++ b/components/modules/AiConsent.R
@@ -1,0 +1,99 @@
+##
+## This file is part of the Omics Playground project.
+## Copyright (c) 2018-2026 BigOmics Analytics SA. All rights reserved.
+##
+
+## AI data-sharing consent — per-user, persisted to disk.
+##
+## Every other AI setting (provider, credentials, the four model menus) lives
+## only in `session$userData` and resets on logout. That is fine for a
+## preference; it is not fine for a consent. A consent that silently reverts to
+## its default on the next login is not a consent, so this one field gets real
+## per-user persistence, modelled on the plot colour theme
+## (components/ui/ui-ColorDefaults.R): a small JSON file in the user's dir,
+## written on change and read back on login.
+##
+## Default is FALSE — opt-in, not opt-out. A user who never opens Settings has
+## not consented, and their calls go out under omicsai's private routing
+## defaults (see omicsai::omicsai_privacy_extra).
+##
+## Scope note: the switch governs *conversation* data, i.e. Copilot chats. AI
+## reports, infographics and card summaries are not conversations and always
+## run under the private default; they never read this flag. AI usage telemetry
+## (components/modules/AiTelemetry.R) records token counts and cost only, never
+## prompt or completion text, and is operational data that runs regardless.
+
+AI_CONSENT_FILE <- "ai_consent.json"
+
+## Bump when the consent wording changes materially enough that a previously
+## recorded opt-in should no longer be considered informed. `load_ai_consent()`
+## treats a stored record with an older version as "no consent", which
+## re-prompts the user by returning the switch to its default position.
+AI_CONSENT_VERSION <- 1L
+
+#' Persist the AI data-sharing consent for a user
+#'
+#' @param user_dir The user's personal directory (`auth$user_dir`). A NULL or
+#'   non-existent directory is a no-op — anonymous/no-auth deployments have no
+#'   place to write, and their consent stays session-scoped.
+#' @param consent Logical scalar; coerced with `isTRUE()`.
+#' @return invisible path written, or invisible NULL.
+save_ai_consent <- function(user_dir, consent) {
+  if (is.null(user_dir) || !nzchar(user_dir) || !dir.exists(user_dir)) {
+    return(invisible(NULL))
+  }
+  path <- file.path(user_dir, AI_CONSENT_FILE)
+  record <- list(
+    share_data   = isTRUE(consent),
+    version      = AI_CONSENT_VERSION,
+    consented_at = as.numeric(Sys.time())
+  )
+  tryCatch(
+    {
+      jsonlite::write_json(record, path, auto_unbox = TRUE, pretty = TRUE)
+      invisible(path)
+    },
+    error = function(e) {
+      warning("[save_ai_consent] could not write ", path, ": ",
+              conditionMessage(e), call. = FALSE)
+      invisible(NULL)
+    }
+  )
+}
+
+#' Read the persisted AI data-sharing consent for a user
+#'
+#' Fails closed: a missing file, an unreadable file, or a record written under
+#' an older `AI_CONSENT_VERSION` all read as FALSE.
+#'
+#' @param user_dir The user's personal directory (`auth$user_dir`).
+#' @return Logical scalar.
+load_ai_consent <- function(user_dir) {
+  if (is.null(user_dir) || !nzchar(user_dir)) {
+    return(FALSE)
+  }
+  path <- file.path(user_dir, AI_CONSENT_FILE)
+  if (!file.exists(path)) {
+    return(FALSE)
+  }
+  record <- tryCatch(
+    jsonlite::read_json(path, simplifyVector = TRUE),
+    error = function(e) NULL
+  )
+  if (is.null(record) || !isTRUE(record$share_data)) {
+    return(FALSE)
+  }
+  ## Stale consent wording — treat as not given so the user is asked again.
+  isTRUE(as.integer(record$version %||% 0L) >= AI_CONSENT_VERSION)
+}
+
+#' Read the current session's AI data-sharing consent
+#'
+#' The session copy is authoritative at runtime; the JSON file is what seeds it
+#' at login (see the `auth$logged` observer in appsettings_server.R).
+#'
+#' @param parent_session Parent Shiny session.
+#' @return Logical scalar; FALSE when unset.
+get_ai_data_consent <- function(parent_session) {
+  isTRUE(getUserOption(parent_session, "ai_share_data"))
+}

--- a/tests/testthat/test-ai-consent.R
+++ b/tests/testthat/test-ai-consent.R
@@ -1,0 +1,102 @@
+## test-ai-consent.R
+##
+## Unit tests for the per-user AI data-sharing consent store
+## (components/modules/AiConsent.R). The consent is the one AI setting that
+## outlives a session, so these focus on the fail-closed reads: a missing,
+## corrupt, or stale-version record must never read as an opt-in.
+
+.modules_dir <- if (dir.exists("components/modules")) {
+  "components/modules"
+} else {
+  "../../components/modules"
+}
+
+if (!exists("%||%")) `%||%` <- function(a, b) if (is.null(a)) b else a
+
+## getUserOption double, matching Shiny's session$userData semantics.
+getUserOption <- function(session, var, value) session$userData[[var]]
+make_fake_session <- function(opts = list()) {
+  ud <- new.env(parent = emptyenv())
+  for (k in names(opts)) ud[[k]] <- opts[[k]]
+  list(userData = ud)
+}
+
+source(file.path(.modules_dir, "AiConsent.R"), local = TRUE)
+
+# ---------------------------------------------------------------------------
+# Round trip
+# ---------------------------------------------------------------------------
+test_that("consent round-trips through the user dir", {
+  dir <- withr::local_tempdir()
+
+  expect_false(load_ai_consent(dir))          # nothing written yet
+
+  save_ai_consent(dir, TRUE)
+  expect_true(file.exists(file.path(dir, AI_CONSENT_FILE)))
+  expect_true(load_ai_consent(dir))
+
+  save_ai_consent(dir, FALSE)
+  expect_false(load_ai_consent(dir))
+})
+
+test_that("save records the version and a timestamp alongside the decision", {
+  dir <- withr::local_tempdir()
+  save_ai_consent(dir, TRUE)
+  rec <- jsonlite::read_json(file.path(dir, AI_CONSENT_FILE), simplifyVector = TRUE)
+  expect_true(rec$share_data)
+  expect_equal(rec$version, AI_CONSENT_VERSION)
+  expect_true(is.numeric(rec$consented_at) && rec$consented_at > 0)
+})
+
+# ---------------------------------------------------------------------------
+# Fail-closed reads
+# ---------------------------------------------------------------------------
+test_that("load fails closed on missing, NULL and non-existent dirs", {
+  expect_false(load_ai_consent(NULL))
+  expect_false(load_ai_consent(""))
+  expect_false(load_ai_consent(file.path(tempdir(), "no-such-user-dir")))
+})
+
+test_that("a corrupt record reads as no consent", {
+  dir <- withr::local_tempdir()
+  writeLines("{not json at all", file.path(dir, AI_CONSENT_FILE))
+  expect_false(load_ai_consent(dir))
+})
+
+test_that("a record from an older consent version reads as no consent", {
+  ## The wording changed materially, so a previously recorded opt-in is no
+  ## longer informed — the user must be asked again.
+  dir <- withr::local_tempdir()
+  jsonlite::write_json(
+    list(share_data = TRUE, version = AI_CONSENT_VERSION - 1L, consented_at = 1),
+    file.path(dir, AI_CONSENT_FILE), auto_unbox = TRUE
+  )
+  expect_false(load_ai_consent(dir))
+})
+
+test_that("a record with no version field reads as no consent", {
+  dir <- withr::local_tempdir()
+  jsonlite::write_json(list(share_data = TRUE), file.path(dir, AI_CONSENT_FILE),
+                       auto_unbox = TRUE)
+  expect_false(load_ai_consent(dir))
+})
+
+# ---------------------------------------------------------------------------
+# Writes to an unwritable / absent dir are a no-op, not an error
+# ---------------------------------------------------------------------------
+test_that("saving to a non-existent user dir is a silent no-op", {
+  ## No-auth deployments have no user_dir; the consent simply stays
+  ## session-scoped rather than blowing up the settings observer.
+  expect_silent(save_ai_consent(NULL, TRUE))
+  expect_silent(save_ai_consent(file.path(tempdir(), "nope"), TRUE))
+})
+
+# ---------------------------------------------------------------------------
+# Session accessor
+# ---------------------------------------------------------------------------
+test_that("get_ai_data_consent reads the session copy and defaults to FALSE", {
+  expect_false(get_ai_data_consent(make_fake_session()))
+  expect_false(get_ai_data_consent(make_fake_session(list(ai_share_data = NULL))))
+  expect_false(get_ai_data_consent(make_fake_session(list(ai_share_data = NA))))
+  expect_true(get_ai_data_consent(make_fake_session(list(ai_share_data = TRUE))))
+})

--- a/tests/testthat/test-appsettings-ai.R
+++ b/tests/testthat/test-appsettings-ai.R
@@ -666,3 +666,72 @@ test_that("an unlicensed deployment greys the consent switch", {
     }
   )
 })
+
+# ===========================================================================
+# Deployment lock vs consent. Greying the switch is not enough: a disabled
+# control keeps whatever value it had, so a user who opted in before the lock
+# would stay opted in behind a switch they can no longer reach.
+# ===========================================================================
+
+test_that("a locked deployment forces the session consent off", {
+  dir <- withr::local_tempdir()
+  save_ai_consent(dir, TRUE)
+  opt <<- make_opt(locked = TRUE)
+  on.exit(opt <<- make_opt(), add = TRUE)
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+    }
+  )
+})
+
+test_that("an admin is unaffected by AI_PROVIDER_LOCKED", {
+  ## The lock exists to stop non-admins changing AI behaviour on a pinned
+  ## deployment; the admin who set it keeps their own switch.
+  dir <- withr::local_tempdir()
+  save_ai_consent(dir, TRUE)
+  opt <<- make_opt(locked = TRUE)
+  on.exit(opt <<- make_opt(), add = TRUE)
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(admin = TRUE, dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      expect_true(isTRUE(session$userData[["ai_share_data"]]))
+    }
+  )
+})
+
+test_that("an unlicensed deployment forces the session consent off", {
+  dir <- withr::local_tempdir()
+  save_ai_consent(dir, TRUE)
+  opt <<- make_opt(enable_ai = FALSE)
+  on.exit(opt <<- make_opt(), add = TRUE)
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+    }
+  )
+})
+
+test_that("a lock does not erase the user's stored consent", {
+  ## A deployment-level lock is not the user withdrawing. When it lifts, the
+  ## answer they gave must still be there.
+  dir <- withr::local_tempdir()
+  save_ai_consent(dir, TRUE)
+  opt <<- make_opt(locked = TRUE)
+  on.exit(opt <<- make_opt(), add = TRUE)
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      session$setInputs(ai_provider = "bigomics", ai_share_data = TRUE)
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+    }
+  )
+  expect_true(load_ai_consent(dir))
+})

--- a/tests/testthat/test-appsettings-ai.R
+++ b/tests/testthat/test-appsettings-ai.R
@@ -55,6 +55,10 @@ testthat::skip_if_not(
   "omicsai provider catalog API exports are required"
 )
 source(file.path(.repo_dir, "components/utils/ai_model_policy.R"), local = TRUE)
+## Sourced for real (not stubbed like the colour theme): the consent store is
+## the one AI setting that touches disk, and the settings observers are exactly
+## where that persistence is wired, so the tests below exercise it end to end.
+source(file.path(.repo_dir, "components/modules/AiConsent.R"), local = TRUE)
 
 make_opt <- function(locked = FALSE,
                      enable_ai = TRUE,
@@ -531,6 +535,134 @@ test_that("logging out clears the stored credential and resets the provider", {
 
       expect_null(session$userData[["ai_credentials"]])
       expect_equal(session$userData[["ai_provider"]], "bigomics")
+    }
+  )
+})
+
+# ===========================================================================
+# AI data-sharing consent
+#
+# The one AI setting that outlives the session. These cover the three things
+# that make it a consent rather than a preference: it defaults off, it is
+# written to and re-read from the user's dir, and it never survives into a
+# different user's session.
+# ===========================================================================
+
+## Per-test user dir so a consent file written by one test cannot be read by
+## the next (make_auth() shares tempdir()).
+make_consent_auth <- function(admin = FALSE, dir = withr::local_tempdir(.local_envir = parent.frame())) {
+  shiny::reactiveValues(logged = TRUE, ADMIN = admin, user_dir = dir)
+}
+
+test_that("consent defaults to off and is not written before the user touches it", {
+  dir <- withr::local_tempdir()
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+      expect_false(file.exists(file.path(dir, AI_CONSENT_FILE)))
+    }
+  )
+})
+
+test_that("opting in stores the consent in the session and on disk", {
+  dir <- withr::local_tempdir()
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      ## Let the login seed settle first: in the real lifecycle the user can
+      ## only reach the switch after the session has loaded their record.
+      session$flushReact()
+      session$setInputs(ai_provider = "bigomics", ai_share_data = TRUE)
+      session$flushReact()
+      expect_true(isTRUE(session$userData[["ai_share_data"]]))
+      expect_true(load_ai_consent(dir))
+    }
+  )
+})
+
+test_that("withdrawing consent overwrites the stored record", {
+  dir <- withr::local_tempdir()
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      session$setInputs(ai_provider = "bigomics", ai_share_data = TRUE)
+      session$flushReact()
+      expect_true(load_ai_consent(dir))
+
+      session$setInputs(ai_share_data = FALSE)
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+      expect_false(load_ai_consent(dir))
+    }
+  )
+})
+
+test_that("a persisted consent is restored on login", {
+  dir <- withr::local_tempdir()
+  save_ai_consent(dir, TRUE)
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      expect_true(isTRUE(session$userData[["ai_share_data"]]))
+    }
+  )
+})
+
+test_that("consent is refused for a BYOK provider even if the client sends TRUE", {
+  ## On a user's own key their provider account governs; a forged input must
+  ## not record a consent we would then act on.
+  dir <- withr::local_tempdir()
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      session$setInputs(ai_provider = "openai", ai_api_key = "sk-x",
+                        ai_share_data = TRUE)
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+      expect_false(load_ai_consent(dir))
+    }
+  )
+})
+
+test_that("logging out drops the session consent but leaves the record intact", {
+  ## The next login in this Shiny process must not inherit the previous user's
+  ## opt-in; logging out is not a withdrawal, so the file stays.
+  dir <- withr::local_tempdir()
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(dir = dir),
+                pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      session$setInputs(ai_provider = "bigomics", ai_share_data = TRUE)
+      session$flushReact()
+      expect_true(isTRUE(session$userData[["ai_share_data"]]))
+
+      auth$logged <- FALSE
+      session$flushReact()
+      expect_false(isTRUE(session$userData[["ai_share_data"]]))
+      expect_true(load_ai_consent(dir))
+    }
+  )
+})
+
+test_that("an unlicensed deployment greys the consent switch", {
+  opt <<- make_opt(enable_ai = FALSE)
+  on.exit(opt <<- make_opt(), add = TRUE)
+  toggled <- list(disabled = character(0), enabled = character(0))
+  testthat::local_mocked_bindings(
+    disable = function(id, ...) toggled$disabled <<- c(toggled$disabled, id),
+    enable  = function(id, ...) toggled$enabled  <<- c(toggled$enabled, id),
+    .package = "shinyjs"
+  )
+  shiny::testServer(AppSettingsBoard,
+    args = list(id = "s", auth = make_consent_auth(), pgx = shiny::reactiveValues()), {
+      session$flushReact()
+      expect_true("ai_share_data" %in% toggled$disabled)
+      expect_false("ai_share_data" %in% toggled$enabled)
     }
   )
 })

--- a/tests/testthat/test-copilot-provider-args.R
+++ b/tests/testthat/test-copilot-provider-args.R
@@ -25,6 +25,7 @@ make_fake_session <- function(opts = list()) {
 }
 getUserOption <- function(session, var, value) session$userData[[var]]
 get_ai_credentials <- function(session) getUserOption(session, "ai_credentials")
+get_ai_data_consent <- function(session) isTRUE(getUserOption(session, "ai_share_data"))
 
 source(file.path(.board_dir, "copilot_run_controller.R"), local = TRUE)
 
@@ -50,15 +51,41 @@ test_that(".copilot_ai_provider surfaces a BYOK provider + credential closure", 
 # ---------------------------------------------------------------------------
 # .copilot_agent_build_args — BigOmics path (regression-critical)
 # ---------------------------------------------------------------------------
-test_that("BigOmics build args are byte-for-byte the tier path (no creds/model)", {
-  s <- make_fake_session()  # provider defaults to bigomics
+test_that("BigOmics build args are the tier path plus consent (no creds/model)", {
+  s <- make_fake_session()  # provider defaults to bigomics, consent unset
   for (tier in c("copilot-default", "copilot-deep")) {
     args <- .copilot_agent_build_args(s, tier)
-    expect_identical(args, list(tier = tier))
+    expect_identical(args, list(tier = tier, data_consent = FALSE))
     expect_false("credentials" %in% names(args))
     expect_false("model" %in% names(args))
     expect_false("provider" %in% names(args))
   }
+})
+
+test_that("BigOmics consent defaults to FALSE and only TRUE on an explicit opt-in", {
+  ## Unset, NULL and NA must all read as "no consent" — anything short of a
+  ## recorded TRUE is a user who has not agreed.
+  for (stored in list(NULL, NA, FALSE, "yes")) {
+    s <- make_fake_session(list(ai_share_data = stored))
+    expect_false(.copilot_agent_build_args(s, "copilot-default")$data_consent)
+  }
+  s <- make_fake_session(list(ai_share_data = TRUE))
+  expect_true(.copilot_agent_build_args(s, "copilot-default")$data_consent)
+})
+
+test_that("BYOK build args carry no consent flag at all", {
+  ## On a user's own key their provider account governs data policy; sending a
+  ## routing preference on their behalf would be both wrong and misleading.
+  cred <- local({ k <- "sk-anthropic"; function() k })
+  s <- make_fake_session(list(
+    ai_provider          = "anthropic",
+    ai_credentials       = cred,
+    ai_share_data        = TRUE,
+    llm_copilot_deep     = "claude-sonnet-4-6",
+    llm_copilot_balanced = "claude-haiku-4-5"
+  ))
+  expect_false("data_consent" %in% names(.copilot_agent_build_args(s, "copilot-deep")))
+  expect_false("data_consent" %in% names(.copilot_agent_build_args(s, "copilot-default")))
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test-copilot-restore-controller.R
+++ b/tests/testthat/test-copilot-restore-controller.R
@@ -46,6 +46,14 @@ if (!exists("get_ai_credentials")) {
   get_ai_credentials <- function(session) session$userData[["ai_credentials"]]
 }
 if (!exists("copilot_system_prompt")) copilot_system_prompt <- function() ""
+# Mirrors components/modules/AiConsent.R, which is not on the search path when
+# the copilot sources are loaded standalone. Reads the same session copy the
+# real one does, so the consent tests below can steer it via session$userData.
+if (!exists("get_ai_data_consent")) {
+  get_ai_data_consent <- function(session) {
+    isTRUE(getUserOption(session, "ai_share_data"))
+  }
+}
 
 source(file.path(.board_dir, "copilot_options.R"),  local = TRUE)
 source(file.path(.board_dir, "copilot_messages.R"), local = TRUE)
@@ -553,9 +561,10 @@ test_that("non-NULL local_pgx triggers the sync fast path: restore completes ins
 
   local_mocked_bindings(
     ovi_restore = function(session_id, session_dir, bindings, restore_pgx,
-                           db_name, provider, credentials) {
-      captured$provider    <- provider
-      captured$credentials <- credentials
+                           db_name, provider, credentials, data_consent) {
+      captured$provider     <- provider
+      captured$credentials  <- credentials
+      captured$data_consent <- data_consent
       restored_agent
     },
     agent_set_pgx = function(agent, pgx, ...) agent,
@@ -613,6 +622,34 @@ test_that("BYOK restore passes the user's real provider + credential closure", {
   expect_equal(captured$provider, "anthropic")
   expect_identical(captured$credentials, key_fn)
   expect_equal(captured$credentials(), "USER-KEY")
+})
+
+# ===========================================================================
+# Data-sharing consent — restore must carry the user's *live* setting, not
+# whatever the snapshot was saved under. A consent that a restore reinstates
+# is a consent the user cannot withdraw.
+# ===========================================================================
+
+test_that("restore passes the live consent, not the snapshot's", {
+  captured <- .run_restore_capturing_provider(list(ai_share_data = TRUE))
+  expect_true(captured$data_consent)
+})
+
+test_that("restore defaults to no consent when the user has not opted in", {
+  captured <- .run_restore_capturing_provider(list())
+  expect_false(captured$data_consent)
+})
+
+test_that("a BYOK restore never claims consent", {
+  ## The switch only governs the BigOmics-managed backend; on a user's own
+  ## key their provider account decides, and we have no standing to route on
+  ## their behalf. Even a stored TRUE must not travel with a BYOK restore.
+  captured <- .run_restore_capturing_provider(list(
+    ai_provider    = "anthropic",
+    ai_credentials = function() "USER-KEY",
+    ai_share_data  = TRUE
+  ))
+  expect_false(captured$data_consent)
 })
 
 # ===========================================================================

--- a/tests/testthat/test-copilot-run-controller.R
+++ b/tests/testthat/test-copilot-run-controller.R
@@ -27,6 +27,7 @@ if (!exists("%||%")) `%||%` <- function(a, b) if (is.null(a)) b else a
 # components/app/ but not loaded during standalone test runs.
 if (!exists("getUserOption"))    getUserOption    <- function(session, var, ...) NULL
 if (!exists("get_ai_credentials")) get_ai_credentials <- function(session) NULL
+if (!exists("get_ai_data_consent")) get_ai_data_consent <- function(session) FALSE
 if (!exists("copilot_system_prompt")) copilot_system_prompt <- function() ""
 
 source(file.path(.board_dir, "copilot_options.R"),        local = TRUE)


### PR DESCRIPTION
## Why

Maine Health B-tester (Calvin) suggested to add "training policy option". This adds the control and wires it to something
that actually enforces it on the wire.

## What

Settings → AI Features → AI Provider gains one switch, **off by default**:

```
appsettings_ui.R      switch inside conditionalPanel(provider == 'bigomics')
appsettings_server.R  write → setUserOption + save_ai_consent
                      login → load_ai_consent → seed switch
                      logout → drop session copy, keep the file
                      lock  → greyed with base_locked
AiConsent.R (new)     user_dir/ai_consent.json + get_ai_data_consent()
copilot_run_controller.R  .copilot_agent_build_args() → data_consent
                      → omicsagentovi::Agent(data_consent=)
                      → omicsai → api_args$provider
```

## What the switch does and does not cover

| | Behaviour |
|---|---|
| Prompts to the model provider | Governed by the switch |
| Chat history in your workspace | Stored either way (the history panel needs it) |
| AI usage telemetry | Token counts and cost only, never message content — runs regardless |

<img width="480" height="207" alt="Screenshot 2026-09-02 at 10 48 18" src="https://github.com/user-attachments/assets/b9ec36c5-3dd9-4f20-96a9-82fbcbd964e1" />


## Tests

`test-ai-consent.R` (new, 19) · `test-appsettings-ai.R` (99, +7) ·
`test-copilot-provider-args.R` (31, +2) · `test-copilot-run-controller.R` (45).

Pre-existing and untouched: `test-copilot-{bindings,evidence-server,plot-render,save-controller}.R`
error at load — they source `components/board.copilot/R/…`, a path renamed to
`app_copilot`.

## Depends on

- [bigomics/omicsai PR6:`omicsai_privacy_extra()` and the deny-by-default routing](https://github.com/bigomics/omicsai/pull/6)
- [omicsagentovi PR5: `Agent(data_consent=)`](https://github.com/bigomics/omicsagentovi/pull/5)
