### PR TITLE
fix(home): make "Show my library" quick action work

### DIFF
--- a/components/app_launcher/R/launcher_server.R
+++ b/components/app_launcher/R/launcher_server.R
@@ -157,6 +157,11 @@ launcher_server <- function(id, parent, load_example = NULL,
       bslib::nav_select("app-sidebar", "Upload", session = parent)
     })
 
+    ## Quick action: go to the dataset Library
+    observeEvent(input$show_library, {
+      bslib::nav_select("app-sidebar", "Library", session = parent)
+    })
+
     ## Quick action: go to the Obi panel
     observeEvent(input$chat_with_obi, {
       if(check_pgx_loaded()) {


### PR DESCRIPTION
The Home tile had no `observeEvent` in `launcher_server.R`, so clicking it did nothing. Added the missing handler pointing at the `Library` nav panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
